### PR TITLE
[feat] 글로벌 예외처리와 사용자 도메인 전용 예외처리 구현

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/user/exception/UserErrorCode.java
+++ b/mopl-api/src/main/java/com/mopl/domain/user/exception/UserErrorCode.java
@@ -1,0 +1,18 @@
+package com.mopl.domain.user.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum UserErrorCode {
+
+    USER_NOT_EXIST("U001", "존재하지 않는 사용자 입니다.", HttpStatus.NOT_FOUND),
+    PASSWORD_NOT_CORRECT("U002", "비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED)
+    ;
+
+    private final String errorCode;
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/mopl-api/src/main/java/com/mopl/domain/user/exception/UserException.java
+++ b/mopl-api/src/main/java/com/mopl/domain/user/exception/UserException.java
@@ -1,0 +1,14 @@
+package com.mopl.domain.user.exception;
+
+import lombok.Getter;
+
+@Getter
+public class UserException extends RuntimeException {
+
+    private final UserErrorCode errorCode;
+
+    public UserException(UserErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/mopl-api/src/main/java/com/mopl/domain/user/exception/UserExceptionHandler.java
+++ b/mopl-api/src/main/java/com/mopl/domain/user/exception/UserExceptionHandler.java
@@ -1,0 +1,29 @@
+package com.mopl.domain.user.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.net.URI;
+
+@Slf4j
+@RestControllerAdvice
+public class UserExceptionHandler {
+    @ExceptionHandler(UserException.class)
+    public ResponseEntity<ProblemDetail> handleAuthException(UserException e) {
+
+        UserErrorCode errorCode = e.getErrorCode();
+        log.error("AuthException 발생: {}", e.getMessage(), e);
+
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(errorCode.getHttpStatus(), e.getMessage());
+        pd.setTitle(errorCode.name());
+        pd.setProperty("code", errorCode.getErrorCode());
+        pd.setType(URI.create("https://mopl.com/problems/" + errorCode.name().toLowerCase()));
+        pd.setDetail(e.getMessage());
+        pd.setStatus(errorCode.getHttpStatus().value());
+
+        return new ResponseEntity<>(pd, errorCode.getHttpStatus());
+    }
+}

--- a/mopl-api/src/main/java/com/mopl/global/exception/GlobalExceptionHandler.java
+++ b/mopl-api/src/main/java/com/mopl/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,43 @@
+package com.mopl.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.net.URI;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ProblemDetail> handleException(Exception e) {
+        log.error("예상치 못한 오류 발생: {}", e.getMessage(), e);
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+
+        pd.setTitle("Internal Server Error");
+        pd.setType(URI.create("https://mopl.com/problems/internal-server-error"));
+        pd.setDetail(e.getMessage());
+        pd.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
+
+        return new ResponseEntity<>(pd, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(MoplException.class)
+    public ResponseEntity<ProblemDetail> handleMynMyException(MoplException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        log.error("MoplException 발생: {} - {}", errorCode.getStatus(), e.getMessage(), e);
+
+        ProblemDetail pd = ProblemDetail.forStatusAndDetail(HttpStatusCode.valueOf(errorCode.getStatus()), e.getMessage());
+        pd.setTitle(errorCode.name());
+        pd.setType(URI.create("https://mopl.com/problems/" + errorCode.name().toLowerCase()));
+        pd.setDetail(e.getMessage());
+        pd.setStatus(errorCode.getStatus());
+
+        return new ResponseEntity<>(pd, HttpStatusCode.valueOf(errorCode.getStatus()));
+    }
+}

--- a/mopl-core/src/main/java/com/mopl/global/exception/ErrorCode.java
+++ b/mopl-core/src/main/java/com/mopl/global/exception/ErrorCode.java
@@ -1,0 +1,39 @@
+package com.mopl.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    // 공통 서버 오류
+    INTERNAL_SERVER_ERROR("서버 내부 오류가 발생했습니다.", 500),
+    INVALID_REQUEST("잘못된 요청입니다.", 400),
+
+    // 리소스 관련
+    NOT_FOUND("요청한 리소스를 찾을 수 없습니다.", 404),
+    METHOD_NOT_ALLOWED("허용되지 않은 HTTP 메서드입니다.", 405),
+
+    // 데이터 및 비즈니스 로직 관련
+    INVALID_INPUT_VALUE("입력 값이 유효하지 않습니다.", 400),
+    DATA_INTEGRITY_VIOLATION("데이터 무결성 제약 조건이 위반되었습니다.", 400),
+    DUPLICATE_RESOURCE("이미 존재하는 리소스입니다.", 409),
+
+    // 외부 API 및 시스템
+    EXTERNAL_API_ERROR("외부 API 호출 중 오류가 발생했습니다.", 502),
+
+    // 인증
+    UNAUTHORIZED("인증되지 않은 사용자입니다.", 401),
+    INVALID_TOKEN("유효하지 않은 토큰입니다.", 401),
+    EXPIRED_TOKEN("만료된 토큰입니다.", 401),
+    TOKEN_NOT_FOUND("토큰을 찾을 수 없습니다.", 401),
+
+    // 인가
+    FORBIDDEN("접근 권한이 없습니다.", 403),
+    INSUFFICIENT_PERMISSIONS("해당 리소스에 대한 권한이 부족합니다.", 403)
+    ;
+
+    private final String message;
+    private final int status;
+}

--- a/mopl-core/src/main/java/com/mopl/global/exception/MoplException.java
+++ b/mopl-core/src/main/java/com/mopl/global/exception/MoplException.java
@@ -1,0 +1,14 @@
+package com.mopl.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class MoplException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public MoplException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}


### PR DESCRIPTION
closes #3 


## 사용 예시
글로벌 예외 처리
``` java
public void validateToken(String token) {
        if (isExpired(token)) {
            // 공통 에러 코드인 EXPIRED_TOKEN 사용
            throw new MoplException(ErrorCode.EXPIRED_TOKEN);
        }
    }
```

도메인 예외처리
``` java
return userRepository.findById(userId)
            .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_EXIST));
```

## 응답형태
글로벌 예외
``` json
{
  "type": "https://mopl.com/problems/forbidden",
  "title": "FORBIDDEN",
  "status": 403,
  "detail": "접근 권한이 없습니다.",
  "instance": "/api/v1/admin/dashboard"
}
```

도메인 예외
``` json
{
  "type": "https://mopl.com/problems/password_not_correct",
  "title": "PASSWORD_NOT_CORRECT",
  "status": 401,
  "detail": "비밀번호가 일치하지 않습니다.",
  "instance": "/api/v1/auth/login",
  "code": "U002"
}
```