### PR TITLE
[fix] macOS(ARM64) 환경의 Netty DNS 리졸버 오류 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,9 +48,15 @@ subprojects {
 		// lombok
 		compileOnly 'org.projectlombok:lombok'
 		annotationProcessor 'org.projectlombok:lombok'
+
 		//테스트에서 lombok 사용
 		testCompileOnly 'org.projectlombok:lombok'
 		testAnnotationProcessor 'org.projectlombok:lombok'
+
+		// 맥북 라이브러리 의존성
+		if (System.getProperty("os.name").toLowerCase().contains("mac")) {
+			runtimeOnly "io.netty:netty-resolver-dns-native-macos::osx-aarch_64"
+		}
 	}
 
 	tasks.named('test') {


### PR DESCRIPTION
- 루트 build.gradle에 macOS용 netty-resolver-dns-native-macos 의존성 추가
- mopl-api 모듈의 개발 환경(application-dev.yml) 설정 업데이트

🔄 변경 사항
(예: 도서 리뷰 API의 응답 형식 수정)
-

🧩 작업 사항
[ ] 기능 구현
[ ] 테스트 코드 추가
[ ] 리팩토링
[ ] 문서 업데이트

📸 스크린샷
(변경된 UI나 로그 결과가 있다면 첨부)

closes #10 