### PR TITLE
[feat] Review 도메인 엔티티 및 리포지토리 생성

### DIFF
--- a/mopl-core/src/main/java/com/mopl/domain/review/entity/Review.java
+++ b/mopl-core/src/main/java/com/mopl/domain/review/entity/Review.java
@@ -1,0 +1,56 @@
+package com.mopl.domain.review.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "reviews")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Review {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name="user_id", nullable=false)
+    private Long userId;
+
+    @Column(name="content_id", nullable=false)
+    private Long contentId;
+
+    @Column(name="texts", nullable=false, length=255)
+    private String text;
+
+    @Column(nullable=false)
+    private double rating;
+
+    @Column(name="created_at", nullable=false, updatable=false)
+    private LocalDateTime createdAt;
+
+    @Column(name="updated_at", nullable=false)
+    private LocalDateTime updatedAt;
+
+    public Review(Long userId, Long contentId, String text, double rating) {
+        this.userId = userId;
+        this.contentId = contentId;
+        this.text = text;
+        this.rating = rating;
+    }
+
+    @PrePersist
+    private void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    private void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/mopl-core/src/main/java/com/mopl/domain/review/entity/Review.java
+++ b/mopl-core/src/main/java/com/mopl/domain/review/entity/Review.java
@@ -1,56 +1,37 @@
 package com.mopl.domain.review.entity;
 
+import com.mopl.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Entity
 @Table(name = "reviews")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Review {
+public class Review extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name="user_id", nullable=false)
+    @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    @Column(name="content_id", nullable=false)
+    @Column(name = "content_id", nullable = false)
     private Long contentId;
 
-    @Column(name="texts", nullable=false, length=255)
+    @Column(name = "texts", nullable = false, length = 255)
     private String text;
 
-    @Column(nullable=false)
+    @Column(nullable = false)
     private double rating;
-
-    @Column(name="created_at", nullable=false, updatable=false)
-    private LocalDateTime createdAt;
-
-    @Column(name="updated_at", nullable=false)
-    private LocalDateTime updatedAt;
 
     public Review(Long userId, Long contentId, String text, double rating) {
         this.userId = userId;
         this.contentId = contentId;
         this.text = text;
         this.rating = rating;
-    }
-
-    @PrePersist
-    private void prePersist() {
-        LocalDateTime now = LocalDateTime.now();
-        this.createdAt = now;
-        this.updatedAt = now;
-    }
-
-    @PreUpdate
-    private void preUpdate() {
-        this.updatedAt = LocalDateTime.now();
     }
 }

--- a/mopl-core/src/main/java/com/mopl/domain/review/repository/ReviewRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,9 @@
+package com.mopl.domain.review.repository;
+
+import com.mopl.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    long countByContentId(Long contentId);
+}


### PR DESCRIPTION
## 연관 이슈
closes #23  

## 🧩 작업 사항

- Reviews 엔티티 생성
- ERD 컬럼명 texts를 엔티티 필드 text로 매핑 처리 (@Column(name="texts"))
    - 코드/DTO에서는 보통 text(리뷰 내용 1개)로 표현하는게 맞다고 판단해서
       DB 컬럼명은 변경 안 하고도 @Column(name="texts")로 필드명만 통일하고
       의미에 맞을 수 있게 단수인 text로 조치했습니다
- 생성/수정 시간 자동 세팅 로직 추가 (@PrePersist, @PreUpdate)
- ReviewRepository 생성

## 리뷰
리뷰 내용 반영 완료
PrePersist,PreUpdate를 전부 제거하고 BaseTimeEntity 상속 받게 수정
