### PR TITLE
[FEAT] Playlists - Entity, Repository 생성 및 구현

### DIFF
--- a/mopl-core/src/main/java/com/mopl/domain/playlist/entity/Playlist.java
+++ b/mopl-core/src/main/java/com/mopl/domain/playlist/entity/Playlist.java
@@ -1,0 +1,52 @@
+package com.mopl.domain.playlist.entity;
+
+import com.mopl.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "playlists")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Playlist extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Column(nullable = false, length = 255)
+    private String description;
+
+    @Column(name = "subscriber_count")
+    private Long subscriberCount;
+
+    public Playlist(Long userId, String title, String description) {
+        this.userId = userId;
+        this.title = title;
+        this.description = description;
+        this.subscriberCount = 0L;
+    }
+
+    public void update(String title, String description) {
+        this.title = title;
+        this.description = description;
+    }
+
+    public void increaseSubscriberCount() {
+        if (subscriberCount == null) subscriberCount = 0L;
+        subscriberCount++;
+    }
+
+    public void decreaseSubscriberCount() {
+        if (subscriberCount == null) subscriberCount = 0L;
+        if (subscriberCount > 0) subscriberCount--;
+    }
+}

--- a/mopl-core/src/main/java/com/mopl/domain/playlist/entity/Playlist.java
+++ b/mopl-core/src/main/java/com/mopl/domain/playlist/entity/Playlist.java
@@ -25,8 +25,8 @@ public class Playlist extends BaseTimeEntity {
     @Column(nullable = false, length = 255)
     private String description;
 
-    @Column(name = "subscriber_count")
-    private Long subscriberCount;
+    @Column(name = "subscriber_count", nullable = false)
+    private long subscriberCount;
 
     public Playlist(Long userId, String title, String description) {
         this.userId = userId;
@@ -41,12 +41,12 @@ public class Playlist extends BaseTimeEntity {
     }
 
     public void increaseSubscriberCount() {
-        if (subscriberCount == null) subscriberCount = 0L;
-        subscriberCount++;
+        this.subscriberCount++;
     }
 
     public void decreaseSubscriberCount() {
-        if (subscriberCount == null) subscriberCount = 0L;
-        if (subscriberCount > 0) subscriberCount--;
+        if (this.subscriberCount > 0L) {
+            this.subscriberCount--;
+        }
     }
 }

--- a/mopl-core/src/main/java/com/mopl/domain/playlist/entity/PlaylistContent.java
+++ b/mopl-core/src/main/java/com/mopl/domain/playlist/entity/PlaylistContent.java
@@ -1,0 +1,28 @@
+package com.mopl.domain.playlist.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "playlist_contents")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class PlaylistContent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "playlist_id", nullable = false)
+    private Long playlistId;
+
+    @Column(name = "content_id", nullable = false)
+    private Long contentId;
+
+    public PlaylistContent(Long playlistId, Long contentId) {
+        this.playlistId = playlistId;
+        this.contentId = contentId;
+    }
+}

--- a/mopl-core/src/main/java/com/mopl/domain/playlist/entity/PlaylistSubscribe.java
+++ b/mopl-core/src/main/java/com/mopl/domain/playlist/entity/PlaylistSubscribe.java
@@ -1,0 +1,28 @@
+package com.mopl.domain.playlist.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "playlist_subscribes")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class PlaylistSubscribe {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "playlist_id", nullable = false)
+    private Long playlistId;
+
+    public PlaylistSubscribe(Long userId, Long playlistId) {
+        this.userId = userId;
+        this.playlistId = playlistId;
+    }
+}

--- a/mopl-core/src/main/java/com/mopl/domain/playlist/repository/PlaylistContentRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/playlist/repository/PlaylistContentRepository.java
@@ -1,0 +1,23 @@
+package com.mopl.domain.playlist.repository;
+
+import com.mopl.domain.playlist.entity.PlaylistContent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface PlaylistContentRepository extends JpaRepository<PlaylistContent, Long> {
+
+    List<PlaylistContent> findAllByPlaylistId(Long playlistId);
+
+    List<PlaylistContent> findAllByPlaylistIdIn(Collection<Long> playlistIds);
+
+    boolean existsByPlaylistIdAndContentId(Long playlistId, Long contentId);
+
+    Optional<PlaylistContent> findByPlaylistIdAndContentId(Long playlistId, Long contentId);
+
+    void deleteByPlaylistIdAndContentId(Long playlistId, Long contentId);
+
+    void deleteAllByPlaylistId(Long playlistId);
+}

--- a/mopl-core/src/main/java/com/mopl/domain/playlist/repository/PlaylistRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/playlist/repository/PlaylistRepository.java
@@ -1,0 +1,13 @@
+package com.mopl.domain.playlist.repository;
+
+import com.mopl.domain.playlist.entity.Playlist;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
+
+    boolean existsByIdAndUserId(Long id, Long userId);
+
+    Optional<Playlist> findByIdAndUserId(Long id, Long userId);
+}

--- a/mopl-core/src/main/java/com/mopl/domain/playlist/repository/PlaylistSubscribeRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/playlist/repository/PlaylistSubscribeRepository.java
@@ -1,0 +1,23 @@
+package com.mopl.domain.playlist.repository;
+
+import com.mopl.domain.playlist.entity.PlaylistSubscribe;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface PlaylistSubscribeRepository extends JpaRepository<PlaylistSubscribe, Long> {
+
+    boolean existsByUserIdAndPlaylistId(Long userId, Long playlistId);
+
+    Optional<PlaylistSubscribe> findByUserIdAndPlaylistId(Long userId, Long playlistId);
+
+    void deleteByUserIdAndPlaylistId(Long userId, Long playlistId);
+
+    List<PlaylistSubscribe> findAllByUserId(Long userId);
+
+    List<PlaylistSubscribe> findAllByUserIdAndPlaylistIdIn(Long userId, Collection<Long> playlistIds);
+
+    long countByPlaylistId(Long playlistId);
+}

--- a/mopl-core/src/main/resources/db/schema.sql
+++ b/mopl-core/src/main/resources/db/schema.sql
@@ -62,8 +62,9 @@ CREATE TABLE playlists
     user_id          BIGINT       NOT NULL,
     title            VARCHAR(255) NOT NULL,
     description      VARCHAR(255) NOT NULL,
-    subscriber_count INT          NULL DEFAULT 0,
+    subscriber_count BIGINT       NOT NULL DEFAULT 0,
     updated_at       DATETIME     NOT NULL,
+    created_at       DATETIME     NOT NULL,
     PRIMARY KEY (id)
 );
 


### PR DESCRIPTION
## 연관 이슈
close #32 

## 🔄 변경 사항
- 타입변경 int -> bigint  integer -> long
- 최신순 정렬이 존재하기에 created_at 추가
<img width="498" height="148" alt="image" src="https://github.com/user-attachments/assets/db118f16-2732-423a-aef4-b9df5b2a7bbd" />

<img width="766" height="411" alt="image" src="https://github.com/user-attachments/assets/7b9657a8-f80c-4ba8-817e-d569fcdf001d" />

## 🧩 작업 사항
- 기능 구현: 플레이리스트 도메인 엔티티/레포지토리 구현(Playlist, PlaylistSubscribe, PlaylistContent)
- 스키마 반영: ERD 및 DDL 기준으로 컬럼/타입 정합성 맞춤
- 리팩토링: subscriberCount를 long으로 통일하여 null 케이스 제거 및 카운트 증감 로직 정리
