### PR TITLE
[feat] DM - 관련 엔티티 및 리포지토리 추가

### DIFF
--- a/mopl-core/src/main/java/com/mopl/domain/conversation/entity/Conversation.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/entity/Conversation.java
@@ -1,0 +1,19 @@
+package com.mopl.domain.conversation.entity;
+
+import com.mopl.global.entity.BaseCreatedEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "conversations")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Conversation extends BaseCreatedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+}

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/entity/DirectMessage.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/entity/DirectMessage.java
@@ -1,0 +1,30 @@
+package com.mopl.domain.conversation.entity;
+
+import com.mopl.domain.user.entity.User;
+import com.mopl.global.entity.BaseCreatedEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "direct_messages")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DirectMessage extends BaseCreatedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "conversation_id")
+    private Conversation conversation;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "author_id")
+    private User author;
+
+    @Column(nullable = false)
+    private String content;
+}

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/entity/ReadStatus.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/entity/ReadStatus.java
@@ -1,0 +1,31 @@
+package com.mopl.domain.conversation.entity;
+
+import com.mopl.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "read_status")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReadStatus {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "conversation_id")
+    private Conversation conversation;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "last_message_id")
+    private DirectMessage lastReadMessage;
+
+}

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ConversationRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ConversationRepository.java
@@ -1,0 +1,8 @@
+package com.mopl.domain.conversation.repository;
+
+import com.mopl.domain.conversation.entity.Conversation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ConversationRepository extends JpaRepository<Conversation, Long> {
+
+}

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/repository/DirectMessageRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/repository/DirectMessageRepository.java
@@ -1,0 +1,7 @@
+package com.mopl.domain.conversation.repository;
+
+import com.mopl.domain.conversation.entity.DirectMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DirectMessageRepository extends JpaRepository<DirectMessage, Long> {
+}

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ReadStatusRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ReadStatusRepository.java
@@ -1,0 +1,7 @@
+package com.mopl.domain.conversation.repository;
+
+import com.mopl.domain.conversation.entity.ReadStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReadStatusRepository extends JpaRepository<ReadStatus, Long> {
+}

--- a/mopl-core/src/main/resources/db/schema.sql
+++ b/mopl-core/src/main/resources/db/schema.sql
@@ -97,8 +97,9 @@ CREATE TABLE read_status
     id              BIGINT NOT NULL AUTO_INCREMENT,
     conversation_id BIGINT NOT NULL,
     user_id         BIGINT NOT NULL,
-    last_message_id BIGINT NOT NULL,
-    PRIMARY KEY (id)
+    last_message_id BIGINT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_read_status_conversation_user (conversation_id, user_id)
 );
 
 CREATE TABLE direct_messages


### PR DESCRIPTION
## 연관 이슈
close #24 

## 🔄 변경 사항
- read_status 테이블 변경 
  - `(conversation_id, user_id)` 유니크 키 추가
  - `last_message_id`를 `nullable`로 변경
- DM 도메인 엔티티 및 리포지토리 구현

## 🧩 작업 사항
- `Conversation` 엔티티, JpaRepository 생성
- `DirectMessage` 엔티티, JpaRepository 생성
- `ReadStatus` 엔티티, JpaRepository 생성
- schema.sql의 read_status 테이블 수정

## 📸 스크린샷
.