### PR TITLE
[FEAT] Review - Service 구현(CRUD)

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/review/controller/ReviewController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/review/controller/ReviewController.java
@@ -1,0 +1,134 @@
+package com.mopl.domain.review.controller;
+
+import com.mopl.domain.review.dto.request.ReviewCreateRequest;
+import com.mopl.domain.review.dto.request.ReviewUpdateRequest;
+import com.mopl.domain.review.dto.response.ReviewDto;
+import com.mopl.domain.review.service.ReviewService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "리뷰 관리", description = "리뷰 관련 API")
+@RestController
+@Validated
+@RequiredArgsConstructor
+@RequestMapping("/api/reviews")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    // 아직 커서 페이지네이션 미구현이라 contentId 기준 단순 조회만
+    @Operation(
+            summary = "리뷰 목록 조회",
+            description = "리뷰 목록을 조회합니다. "
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증 오류"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping
+    public ResponseEntity<List<ReviewDto>> findAll(
+            @RequestParam Long contentId,
+
+            @RequestParam(required = false)
+            String cursor,
+
+            @RequestParam(required = false)
+            String idAfter,
+
+            @RequestParam(required = false, defaultValue = "20")
+            @Min(1) @Max(100)
+            Integer limit,
+
+            @Parameter(
+                    description = "정렬 기준",
+                    schema = @Schema(allowableValues = {"createdAt", "rating"})
+            )
+            @RequestParam(required = false, defaultValue = "createdAt")
+            String sortBy,
+
+            @Parameter(
+                    description = "정렬 방향",
+                    schema = @Schema(allowableValues = {"ASCENDING", "DESCENDING"})
+            )
+            @RequestParam(required = false, defaultValue = "DESCENDING")
+            String sortDirection
+    ) {
+        // TODO 커서 페이지네이션 구현 시 cursor/idAfter/limit/sortBy/sortDirection 사용
+        return ResponseEntity.ok(reviewService.findAllByContentId(contentId));
+    }
+
+    @Operation(
+            summary = "리뷰 생성",
+            description = "생성한 리뷰는 API 요청자 본인의 리뷰로 생성됩니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "201", description = "성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증 오류"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping
+    public ResponseEntity<ReviewDto> create(
+            @RequestHeader(value = "X-User-Id", required = false) Long requesterId,
+            @Valid @RequestBody ReviewCreateRequest request
+    ) {
+        ReviewDto response = reviewService.create(requesterId, request);
+        return ResponseEntity.status(201).body(response);
+    }
+
+    @Operation(
+            summary = "리뷰 수정",
+            description = "리뷰를 수정합니다. (리뷰 작성자만 수정할 수 있습니다.)"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증 오류"),
+            @ApiResponse(responseCode = "403", description = "권한 오류"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PatchMapping("/{reviewId}")
+    public ResponseEntity<ReviewDto> update(
+            @RequestHeader(value = "X-User-Id", required = false) Long requesterId,
+            @PathVariable Long reviewId,
+            @Valid @RequestBody ReviewUpdateRequest request
+    ) {
+        return ResponseEntity.ok(reviewService.update(requesterId, reviewId, request));
+    }
+
+    @Operation(
+            summary = "리뷰 삭제",
+            description = "리뷰 작성자만 삭제할 수 있습니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증 오류"),
+            @ApiResponse(responseCode = "403", description = "권한 오류"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @DeleteMapping("/{reviewId}")
+    public ResponseEntity<Void> delete(
+            @RequestHeader(value = "X-User-Id", required = false) Long requesterId,
+            @PathVariable Long reviewId
+    ) {
+        reviewService.delete(requesterId, reviewId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/mopl-api/src/main/java/com/mopl/domain/review/dto/request/ReviewCreateRequest.java
+++ b/mopl-api/src/main/java/com/mopl/domain/review/dto/request/ReviewCreateRequest.java
@@ -1,8 +1,16 @@
 package com.mopl.domain.review.dto.request;
 
+import jakarta.validation.constraints.*;
+
 public record ReviewCreateRequest(
-        Long contentId,
+        @NotNull Long contentId,
+
+        @NotBlank
+        @Size(max = 255)
         String text,
+
+        @DecimalMin("0.0")
+        @DecimalMax("5.0")
         double rating
 ) {
 }

--- a/mopl-api/src/main/java/com/mopl/domain/review/dto/request/ReviewCreateRequest.java
+++ b/mopl-api/src/main/java/com/mopl/domain/review/dto/request/ReviewCreateRequest.java
@@ -3,14 +3,16 @@ package com.mopl.domain.review.dto.request;
 import jakarta.validation.constraints.*;
 
 public record ReviewCreateRequest(
-        @NotNull Long contentId,
+        @NotNull
+        Long contentId,
 
         @NotBlank
         @Size(max = 255)
         String text,
 
+        @NotNull
         @DecimalMin("0.0")
         @DecimalMax("5.0")
-        double rating
+        Double rating
 ) {
 }

--- a/mopl-api/src/main/java/com/mopl/domain/review/dto/request/ReviewUpdateRequest.java
+++ b/mopl-api/src/main/java/com/mopl/domain/review/dto/request/ReviewUpdateRequest.java
@@ -1,7 +1,15 @@
 package com.mopl.domain.review.dto.request;
 
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Size;
+
 public record ReviewUpdateRequest(
+        @Size(max = 255)
         String text,
+
+        @DecimalMin("0.0")
+        @DecimalMax("5.0")
         Double rating
 ) {
 }

--- a/mopl-api/src/main/java/com/mopl/domain/review/service/ReviewService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/review/service/ReviewService.java
@@ -1,6 +1,7 @@
 package com.mopl.domain.review.service;
 
 import com.mopl.domain.review.dto.request.ReviewCreateRequest;
+import com.mopl.domain.review.dto.request.ReviewUpdateRequest;
 import com.mopl.domain.review.dto.response.ReviewAuthorDto;
 import com.mopl.domain.review.dto.response.ReviewDto;
 import com.mopl.domain.review.entity.Review;
@@ -10,6 +11,8 @@ import com.mopl.global.exception.MoplException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -37,6 +40,43 @@ public class ReviewService {
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new MoplException(ErrorCode.NOT_FOUND));
         return toDto(review);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ReviewDto> findAllByContentId(Long contentId) {
+        return reviewRepository.findAllByContentIdOrderByCreatedAtDesc(contentId)
+                .stream()
+                .map(this::toDto)
+                .toList();
+    }
+
+    @Transactional
+    public ReviewDto update(Long requesterId, Long reviewId, ReviewUpdateRequest request) {
+        validateAuthenticated(requesterId);
+
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new MoplException(ErrorCode.NOT_FOUND));
+
+        if (!review.isAuthor(requesterId)) {
+            throw new MoplException(ErrorCode.FORBIDDEN);
+        }
+
+        review.update(request.text(), request.rating());
+        return toDto(review);
+    }
+
+    @Transactional
+    public void delete(Long requesterId, Long reviewId) {
+        validateAuthenticated(requesterId);
+
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new MoplException(ErrorCode.NOT_FOUND));
+
+        if (!review.isAuthor(requesterId)) {
+            throw new MoplException(ErrorCode.FORBIDDEN);
+        }
+
+        reviewRepository.delete(review);
     }
 
     private void validateAuthenticated(Long requesterId) {

--- a/mopl-api/src/main/java/com/mopl/domain/review/service/ReviewService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/review/service/ReviewService.java
@@ -1,0 +1,60 @@
+package com.mopl.domain.review.service;
+
+import com.mopl.domain.review.dto.request.ReviewCreateRequest;
+import com.mopl.domain.review.dto.response.ReviewAuthorDto;
+import com.mopl.domain.review.dto.response.ReviewDto;
+import com.mopl.domain.review.entity.Review;
+import com.mopl.domain.review.repository.ReviewRepository;
+import com.mopl.global.exception.ErrorCode;
+import com.mopl.global.exception.MoplException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+
+    @Transactional
+    public ReviewDto create(Long requesterId, ReviewCreateRequest request) {
+        validateAuthenticated(requesterId);
+
+        Review review = new Review(
+                requesterId,
+                request.contentId(),
+                request.text(),
+                request.rating()
+        );
+
+        Review saved = reviewRepository.save(review);
+        return toDto(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public ReviewDto find(Long reviewId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new MoplException(ErrorCode.NOT_FOUND));
+        return toDto(review);
+    }
+
+    private void validateAuthenticated(Long requesterId) {
+        if (requesterId == null) {
+            throw new MoplException(ErrorCode.UNAUTHORIZED);
+        }
+    }
+
+    private ReviewDto toDto(Review review) {
+        // User 도메인 연동 전이라서 userId만 채우고 나머지는 null
+        ReviewAuthorDto author = new ReviewAuthorDto(review.getUserId(), null, null);
+
+        return new ReviewDto(
+                review.getId(),
+                review.getContentId(),
+                author,
+                review.getText(),
+                review.getRating()
+        );
+    }
+}

--- a/mopl-core/src/main/java/com/mopl/domain/review/entity/Review.java
+++ b/mopl-core/src/main/java/com/mopl/domain/review/entity/Review.java
@@ -34,4 +34,17 @@ public class Review extends BaseTimeEntity {
         this.text = text;
         this.rating = rating;
     }
+
+    public void update(String text, Double rating) {
+        if (text != null && !text.isBlank()) {
+            this.text = text.trim();
+        }
+        if (rating != null) {
+            this.rating = rating;
+        }
+    }
+
+    public boolean isAuthor(Long userId) {
+        return userId != null && userId.equals(this.userId);
+    }
 }

--- a/mopl-core/src/main/java/com/mopl/domain/review/repository/ReviewRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/review/repository/ReviewRepository.java
@@ -3,7 +3,11 @@ package com.mopl.domain.review.repository;
 import com.mopl.domain.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     long countByContentId(Long contentId);
+
+    List<Review> findAllByContentIdOrderByCreatedAtDesc(Long contentId);
 }


### PR DESCRIPTION
## 연관 이슈
closes #28

## 🔄 변경 사항
리뷰 관리 API를 추가하고, Swagger 스펙에 맞춰 목록 조회 쿼리 파라미터(커서/정렬/limit)
(커서 페이지네이션 로직은 아직 미구현입니다. 현재는 contentId 기준 단순 조회만 수행합니다)
X-User-Id  임시 헤더에서 실제 인증으로 교체할 예정

## 🧩 작업 사항
- [x] 리뷰 CRUD API 구현 (생성/목록/수정/삭제)
- [x] 목록 조회에 커서 관련 파라미터(cursor, idAfter, limit, sortBy, sortDirection) 수신만 추가(페이지네이션 로직은 추후)
- [x] 기반 인증 및 작성자 권한 검증 적용
- [x] Swagger 문서화 및 응답 코드 정리(POST 201, DELETE 204 등)

## 스크린샷
<img width="2388" height="1098" alt="image" src="https://github.com/user-attachments/assets/9e9c63a7-7325-4af0-81e8-ac5eb0421e31" />
<img width="2031" height="1234" alt="image" src="https://github.com/user-attachments/assets/74bba2e8-cb4e-43fb-b916-8e48967d9ad4" />
<img width="2000" height="1048" alt="image" src="https://github.com/user-attachments/assets/921a2106-6dbf-4c34-a6f8-950426dfd03c" />
<img width="2025" height="921" alt="image" src="https://github.com/user-attachments/assets/2a510a1a-c6e7-4fc1-995d-27e9c49f6b5a" />
