### PR TITLE
[FEAT] Follow domain (Entity, Repository) 구현

### DIFF
--- a/mopl-core/src/main/java/com/mopl/domain/follow/entity/Follow.java
+++ b/mopl-core/src/main/java/com/mopl/domain/follow/entity/Follow.java
@@ -1,0 +1,42 @@
+package com.mopl.domain.follow.entity;
+
+import com.mopl.domain.user.entity.User;
+import com.mopl.global.entity.BaseCreatedEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(
+    name = "follows",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_follows_relation",
+            columnNames = {"follower_id", "followee_id"}
+        )
+    }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Follow extends BaseCreatedEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "follower_id", nullable = false)
+  private User follower;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "followee_id", nullable = false)
+  private User followee;
+
+  @Builder
+  public Follow(User follower, User followee) {
+    this.follower = follower;
+    this.followee = followee;
+  }
+}

--- a/mopl-core/src/main/java/com/mopl/domain/follow/repository/FollowRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/follow/repository/FollowRepository.java
@@ -1,0 +1,17 @@
+package com.mopl.domain.follow.repository;
+
+import com.mopl.domain.follow.entity.Follow;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+  // 중복 팔로우 체크
+  boolean existsByFollowerIdAndFolloweeId(Long followerId, Long followeeId);
+
+  // 언팔로우
+  void deleteByFollowerIdAndFolloweeId(Long followerId, Long followeeId);
+
+  // 팔로워/팔로잉 수 카운트 (마이페이지에 쓰이는것)
+  long countByFollowerId(Long followerId);
+  long countByFolloweeId(Long followeeId);
+}

--- a/mopl-core/src/main/java/com/mopl/global/exception/ErrorCode.java
+++ b/mopl-core/src/main/java/com/mopl/global/exception/ErrorCode.java
@@ -31,9 +31,14 @@ public enum ErrorCode {
 
     // 인가
     FORBIDDEN("접근 권한이 없습니다.", 403),
-    INSUFFICIENT_PERMISSIONS("해당 리소스에 대한 권한이 부족합니다.", 403)
+    INSUFFICIENT_PERMISSIONS("해당 리소스에 대한 권한이 부족합니다.", 403),
+
+    // 팔로우
+    CANNOT_FOLLOW_SELF("자기 자신을 팔로우할 수 없습니다.", 400),
+    FOLLOW_NOT_FOUND("팔로우 관계가 존재하지 않습니다.", 404),
+    ALREADY_FOLLOWING("이미 팔로우 중인 사용자입니다.", 409)
     ;
 
-    private final String message;
+  private final String message;
     private final int status;
 }

--- a/mopl-core/src/main/java/com/mopl/global/exception/ErrorCode.java
+++ b/mopl-core/src/main/java/com/mopl/global/exception/ErrorCode.java
@@ -35,8 +35,8 @@ public enum ErrorCode {
 
     // 팔로우
     CANNOT_FOLLOW_SELF("자기 자신을 팔로우할 수 없습니다.", 400),
-    FOLLOW_NOT_FOUND("팔로우 관계가 존재하지 않습니다.", 404),
-    ALREADY_FOLLOWING("이미 팔로우 중인 사용자입니다.", 409)
+    FOLLOW_NOT_FOUND("팔로우 관계가 존재하지 않습니다.", 400),
+    ALREADY_FOLLOWING("이미 팔로우 중인 사용자입니다.", 400)
     ;
 
   private final String message;


### PR DESCRIPTION
## 연관 이슈

close #47 [follow core 셋팅]

## 🔄 변경 사항

* **팔로우 도메인 추가:** User 간의 N:M 관계를 해소하기 위한 `Follow` 엔티티와 리포지토리를 구현했습니다.
* **에러 코드 추가:** 팔로우 기능 예외 처리를 위한 `ErrorCode` 상수를 추가했습니다.
* **로컬 설정 수정:** 로컬 개발 환경(H2)에서 테이블이 자동 생성되도록 `application.yml`을 수정했습니다.

## 🧩 작업 사항

* `Follow` 엔티티 구현
* `BaseCreatedEntity` 상속 (생성 시간 자동화)
* `follower_id` + `followee_id` 유니크 제약조건 설정 (`uk_follows_relation`)
* `@Builder` 패턴 적용


* `FollowRepository` 인터페이스 구현
* 중복 확인(`exists...`) 및 언팔로우(`delete...`) 메서드 정의


* `ErrorCode` 상수 추가
* `CANNOT_FOLLOW_SELF`, `ALREADY_FOLLOWING`, `FOLLOW_NOT_FOUND` (Status: 400)

## 📸 스크린샷

---