### PR TITLE
[FEAT] Playlist - DTO정의

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/playlist/dto/request/PlaylistCreateRequest.java
+++ b/mopl-api/src/main/java/com/mopl/domain/playlist/dto/request/PlaylistCreateRequest.java
@@ -1,0 +1,15 @@
+package com.mopl.domain.playlist.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record PlaylistCreateRequest(
+        @NotBlank
+        @Size(max = 255)
+        String title,
+
+        @NotBlank
+        @Size(max = 255)
+        String description
+) {
+}

--- a/mopl-api/src/main/java/com/mopl/domain/playlist/dto/request/PlaylistUpdateRequest.java
+++ b/mopl-api/src/main/java/com/mopl/domain/playlist/dto/request/PlaylistUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.mopl.domain.playlist.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record PlaylistUpdateRequest(
+        @Size(max = 255)
+        String title,
+
+        @Size(max = 255)
+        String description
+) {
+}

--- a/mopl-api/src/main/java/com/mopl/domain/playlist/dto/response/CursorResponsePlaylistDto.java
+++ b/mopl-api/src/main/java/com/mopl/domain/playlist/dto/response/CursorResponsePlaylistDto.java
@@ -1,0 +1,16 @@
+package com.mopl.domain.playlist.dto.response;
+
+import com.mopl.global.SortDirection;
+
+import java.util.List;
+
+public record CursorResponsePlaylistDto(
+        List<PlaylistDto> data,
+        String nextCursor,
+        Long nextIdAfter,
+        boolean hasNext,
+        long totalCount,
+        String sortBy,
+        SortDirection sortDirection
+) {
+}

--- a/mopl-api/src/main/java/com/mopl/domain/playlist/dto/response/PlaylistDto.java
+++ b/mopl-api/src/main/java/com/mopl/domain/playlist/dto/response/PlaylistDto.java
@@ -1,0 +1,35 @@
+package com.mopl.domain.playlist.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PlaylistDto(
+        Long id,
+        Owner owner,
+        String title,
+        String description,
+        LocalDateTime updatedAt,
+        long subscriberCount,
+        boolean subscribedByMe,
+        List<Content> contents
+) {
+
+    public record Owner(
+            Long userId,
+            String name,
+            String profileImageUrl
+    ) {
+    }
+
+    public record Content(
+            Long id,
+            String type,
+            String title,
+            String description,
+            String thumbnailUrl,
+            List<String> tags,
+            double averageRating,
+            long reviewCount
+    ) {
+    }
+}


### PR DESCRIPTION
closes #40 

## 🧩 작업 사항

- [x] 기능 구현: 플레이리스트 API 스펙에 맞춰 DTO 4종(생성/수정/응답/커서응답) 정의 및 응답 구조