### PR TITLE
[FEAT] Content - 단건 조회, 목록 조회 API 구현

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/content/controller/ContentController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/content/controller/ContentController.java
@@ -1,11 +1,13 @@
 package com.mopl.domain.content.controller;
 
 import com.mopl.domain.content.dto.ContentDto;
+import com.mopl.domain.content.dto.ContentQueryParams;
 import com.mopl.domain.content.dto.CreateContentDto;
 import com.mopl.domain.content.dto.UpdateContentDto;
 import com.mopl.domain.content.exception.ContentErrorCode;
 import com.mopl.domain.content.exception.ContentException;
 import com.mopl.domain.content.service.ContentService;
+import com.mopl.global.dto.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -59,7 +61,7 @@ public class ContentController {
 
     @Operation(summary = "콘텐츠 목록 조회")
     @GetMapping
-    public void list() {
-        //TODO: 콘텐츠 목록 조회 서비스 호출
+    public ResponseEntity<PageResponse<Object>> list(ContentQueryParams params) {
+        return ResponseEntity.ok(contentService.list(params));
     }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/content/controller/ContentController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/content/controller/ContentController.java
@@ -6,6 +6,7 @@ import com.mopl.domain.content.dto.UpdateContentDto;
 import com.mopl.domain.content.exception.ContentErrorCode;
 import com.mopl.domain.content.exception.ContentException;
 import com.mopl.domain.content.service.ContentService;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -20,6 +21,7 @@ public class ContentController {
 
     private final ContentService contentService;
 
+    @Operation(summary = "콘텐츠 생성")
     @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<ContentDto> create(
             @RequestPart("request") @Valid CreateContentDto request,
@@ -32,6 +34,7 @@ public class ContentController {
         return ResponseEntity.ok(contentService.create(request, thumbnail));
     }
 
+    @Operation(summary = "콘텐츠 수정")
     @PatchMapping(value = "/{contentId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<ContentDto> update(
             @PathVariable Long contentId,
@@ -41,17 +44,20 @@ public class ContentController {
         return ResponseEntity.ok(contentService.update(contentId, request, thumbnail));
     }
 
+    @Operation(summary = "콘텐츠 삭제")
     @DeleteMapping(value = "/{contentId}")
     public ResponseEntity<Void> delete(@PathVariable Long contentId) {
         contentService.delete(contentId);
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "콘텐츠 단건 조회")
     @GetMapping(value = "/{contentId}")
-    public void detail(@PathVariable Long contentId) {
-        //TODO: 콘텐츠 단건 조회 서비스 호출
+    public ResponseEntity<ContentDto> detail(@PathVariable Long contentId) {
+        return ResponseEntity.ok(contentService.detail(contentId));
     }
 
+    @Operation(summary = "콘텐츠 목록 조회")
     @GetMapping
     public void list() {
         //TODO: 콘텐츠 목록 조회 서비스 호출

--- a/mopl-api/src/main/java/com/mopl/domain/content/service/ContentService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/content/service/ContentService.java
@@ -98,8 +98,23 @@ public class ContentService {
         log.info("콘텐츠 삭제 완료: id={}", contentId);
     }
 
-    public void detail() {
-        // TODO: 콘텐츠 단건 조회 로직 구현
+    public ContentDto detail(Long contentId) {
+        Content content = getContentOrThrow(contentId);
+        List<String> tagNames = content.getContentTags().stream()
+                .map(Contenttag -> Contenttag.getTag().getTag()).toList();
+        int watchCount = 0; // TODO: redis에서 가져오기
+
+        return new ContentDto(
+                content.getId(),
+                content.getContentType(),
+                content.getTitle(),
+                content.getDescription(),
+                content.getThumbnailUrl(),
+                tagNames,
+                content.getAverageRating(),
+                content.getReviewCount(),
+                watchCount
+        );
     }
 
     public void list() {

--- a/mopl-api/src/main/java/com/mopl/domain/content/service/ContentService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/content/service/ContentService.java
@@ -1,6 +1,7 @@
 package com.mopl.domain.content.service;
 
 import com.mopl.domain.content.dto.ContentDto;
+import com.mopl.domain.content.dto.ContentQueryParams;
 import com.mopl.domain.content.dto.CreateContentDto;
 import com.mopl.domain.content.dto.UpdateContentDto;
 import com.mopl.domain.content.entity.Content;
@@ -9,6 +10,7 @@ import com.mopl.domain.content.exception.ContentErrorCode;
 import com.mopl.domain.content.exception.ContentException;
 import com.mopl.domain.content.repository.ContentRepository;
 import com.mopl.domain.content.repository.TagRepository;
+import com.mopl.global.dto.PageResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -16,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Collections;
 import java.util.List;
 
 @Slf4j
@@ -41,7 +44,7 @@ public class ContentService {
         // 저장
         Content newContent = contentRepository.save(content);
 
-        List<String> tagNames = newContent.getContentTags().stream()
+        List<String> tagNames = content.getContentTags().stream()
                                 .map(Contenttag -> Contenttag.getTag().getTag()).toList();
 
         return new ContentDto(
@@ -117,8 +120,47 @@ public class ContentService {
         );
     }
 
-    public void list() {
-        // TODO: 콘텐츠 목록조회 로직 구현
+    public PageResponse<Object> list(ContentQueryParams params) {
+        List<Content> contentList = contentRepository.list(params);
+
+        boolean hasNext = contentList.size() > params.limit();
+        String nextCursor = null;
+        String nextAfter = null;
+
+        if(hasNext) {
+            Content lastContent = contentList.get(contentList.size() - 1);
+            contentList.remove(lastContent);
+            nextCursor = contentList.get(contentList.size()-1).getId().toString();
+            nextAfter = contentList.get(contentList.size()-1).getCreatedAt().toString();
+        }
+
+        List<ContentDto> response = contentList.stream().map(content -> {
+            int watchCount = 0; // TODO: redis에서 가져오기
+            List<String> tagNames = content.getContentTags().stream()
+                    .map(Contenttag -> Contenttag.getTag().getTag()).toList();
+
+            return new ContentDto(
+                    content.getId(),
+                    content.getContentType(),
+                    content.getTitle(),
+                    content.getDescription(),
+                    content.getThumbnailUrl(),
+                    tagNames,
+                    content.getAverageRating(),
+                    content.getReviewCount(),
+                    watchCount
+            );
+        }).toList();
+
+        return PageResponse.builder()
+                .data(Collections.singletonList(response))
+                .nextCursor(nextCursor)
+                .nextIdAfter(nextAfter)
+                .hasNext(hasNext)
+                .totalCount(0)
+                .sortBy(params.sortBy())
+                .sortDirection(params.sortDirection())
+                .build();
     }
 
     private Content getContentOrThrow(Long contentId) {

--- a/mopl-core/src/main/java/com/mopl/domain/content/dto/ContentQueryParams.java
+++ b/mopl-core/src/main/java/com/mopl/domain/content/dto/ContentQueryParams.java
@@ -1,0 +1,17 @@
+package com.mopl.domain.content.dto;
+
+import com.mopl.global.SortDirection;
+
+import java.util.List;
+
+public record ContentQueryParams(
+    String typeEqual,
+    String keywordLike,
+    List<String> tagsIn,
+    String cursor,
+    String idAfter,
+    Integer limit,
+    SortDirection sortDirection,
+    String sortBy
+) {
+}

--- a/mopl-core/src/main/java/com/mopl/domain/content/repository/ContentRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/content/repository/ContentRepository.java
@@ -3,5 +3,5 @@ package com.mopl.domain.content.repository;
 import com.mopl.domain.content.entity.Content;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ContentRepository extends JpaRepository<Content, Long> {
+public interface ContentRepository extends JpaRepository<Content, Long>, ContentRepositoryCustom {
 }

--- a/mopl-core/src/main/java/com/mopl/domain/content/repository/ContentRepositoryCustom.java
+++ b/mopl-core/src/main/java/com/mopl/domain/content/repository/ContentRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.mopl.domain.content.repository;
+
+import com.mopl.domain.content.dto.ContentQueryParams;
+import com.mopl.domain.content.entity.Content;
+
+import java.util.List;
+
+public interface ContentRepositoryCustom {
+    List<Content> list(ContentQueryParams params);
+}

--- a/mopl-core/src/main/java/com/mopl/domain/content/repository/ContentRepositoryCustomImpl.java
+++ b/mopl-core/src/main/java/com/mopl/domain/content/repository/ContentRepositoryCustomImpl.java
@@ -1,0 +1,73 @@
+package com.mopl.domain.content.repository;
+
+
+import com.mopl.domain.content.dto.ContentQueryParams;
+import com.mopl.domain.content.entity.Content;
+import com.mopl.domain.content.entity.QContent;
+import com.mopl.domain.content.enums.ContentType;
+import com.mopl.global.SortDirection;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ContentRepositoryCustomImpl implements ContentRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+    QContent content = QContent.content;
+
+    @Override
+    public List<Content> list(ContentQueryParams params) {
+        BooleanBuilder where = new BooleanBuilder();
+
+        if(params.typeEqual() != null && !params.typeEqual().isEmpty()) {
+            where.and(content.contentType.eq(ContentType.valueOf(params.typeEqual())));
+        }
+
+        if(params.keywordLike() != null && !params.keywordLike().isBlank()) {
+            where.and(content.title.contains(params.keywordLike())
+                    .or(content.description.contains(params.keywordLike())));
+        }
+
+        if(params.tagsIn() != null && !params.tagsIn().isEmpty()) {
+            where.and(content.contentTags.any().tag.tag.in(params.tagsIn()));
+        }
+
+        OrderSpecifier<?>[] orderSpecifier = makeOrderSpecifier(params.sortDirection(), params.sortBy());
+
+        return queryFactory.selectFrom(content)
+                .distinct()
+                .where(where)
+                .orderBy(orderSpecifier)
+                .limit(params.limit() + 1)
+                .fetch();
+    }
+
+    private OrderSpecifier<?>[] makeOrderSpecifier(SortDirection direction, String sortBy) {
+        Order order = "DESCENDING".equalsIgnoreCase(direction.toString()) ? Order.DESC : Order.ASC;
+
+        // 정렬 조건
+        List<OrderSpecifier<?>> specifiers = new ArrayList<>();
+
+        switch (sortBy) {
+            case "rate" -> specifiers.add(new OrderSpecifier<>(order, content.averageRating));
+            case "watcherCount" -> {
+                specifiers.add(new OrderSpecifier<>(order, content.reviewCount));
+                specifiers.add(new OrderSpecifier<>(order, content.averageRating)); // 리뷰 수 같으면 평점 순으로
+            }
+            default -> specifiers.add(new OrderSpecifier<>(order, content.createdAt));
+        }
+
+        // 보조 정렬 조건 추가 (항상 마지막에 ID 역순) - 커서 기반 페이징용
+        specifiers.add(content.id.desc());
+
+        return specifiers.toArray(new OrderSpecifier[0]);
+    }
+}


### PR DESCRIPTION
## 연관 이슈
close #18 

## 🔄 변경 사항
콘텐츠 조회 API구현

## 🧩 작업 사항
작업한 내용을 간략하게 설명해주세요.
- Controller 구현
- Service 구현
- Querydsl repository 구현체와 인터페이스 추가

