### PR TITLE
[feat] Follow - (POST /api/follows) 기능 구현 

### DIFF
--- a/mopl-api/build.gradle
+++ b/mopl-api/build.gradle
@@ -41,4 +41,8 @@ dependencies {
     implementation 'org.mapstruct:mapstruct:1.6.3'
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
+
+    // Test
+    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/mopl-api/src/main/java/com/mopl/domain/follow/controller/FollowController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/follow/controller/FollowController.java
@@ -1,0 +1,56 @@
+package com.mopl.domain.follow.controller;
+
+import com.mopl.domain.follow.dto.request.FollowRequest;
+import com.mopl.domain.follow.dto.response.FollowResponse;
+import com.mopl.domain.follow.service.FollowService;
+import com.mopl.global.exception.ErrorCode;
+import com.mopl.global.exception.MoplException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+@Tag(name = "팔로우 관리", description = "사용자 팔로우 API")
+@RestController
+@RequestMapping("/api/follows")
+@RequiredArgsConstructor
+public class FollowController {
+
+    private final FollowService followService;
+
+    @Operation(summary = "사용자 팔로우", description = "특정 사용자를 팔로우합니다. (자기 자신 팔로우 불가)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "팔로우 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (자기 자신, 이미 팔로우 중)"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "사용자 찾을 수 없음")
+    })
+
+    // 팔로우 하기 API
+    @PostMapping
+    public ResponseEntity<@NonNull FollowResponse> followUser(
+            Principal principal,
+            @RequestBody @Valid FollowRequest request
+    ) {
+        if (principal == null) {
+            throw new MoplException(ErrorCode.UNAUTHORIZED);
+        }
+
+        Long myId = Long.parseLong(principal.getName());
+
+        FollowResponse response = followService.follow(myId, request);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/mopl-api/src/main/java/com/mopl/domain/follow/controller/FollowController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/follow/controller/FollowController.java
@@ -1,5 +1,6 @@
 package com.mopl.domain.follow.controller;
 
+import com.mopl.domain.follow.controller.docs.FollowControllerDocs;
 import com.mopl.domain.follow.dto.request.FollowRequest;
 import com.mopl.domain.follow.dto.response.FollowResponse;
 import com.mopl.domain.follow.service.FollowService;
@@ -25,19 +26,12 @@ import java.security.Principal;
 @RestController
 @RequestMapping("/api/follows")
 @RequiredArgsConstructor
-public class FollowController {
+public class FollowController implements FollowControllerDocs {
 
     private final FollowService followService;
 
-    @Operation(summary = "사용자 팔로우", description = "특정 사용자를 팔로우합니다. (자기 자신 팔로우 불가)")
-    @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "팔로우 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청 (자기 자신, 이미 팔로우 중)"),
-            @ApiResponse(responseCode = "401", description = "인증 실패"),
-            @ApiResponse(responseCode = "404", description = "사용자 찾을 수 없음")
-    })
-
     // 팔로우 하기 API
+    @Override
     @PostMapping
     public ResponseEntity<@NonNull FollowResponse> followUser(
             Principal principal,

--- a/mopl-api/src/main/java/com/mopl/domain/follow/controller/docs/FollowControllerDocs.java
+++ b/mopl-api/src/main/java/com/mopl/domain/follow/controller/docs/FollowControllerDocs.java
@@ -1,0 +1,28 @@
+package com.mopl.domain.follow.controller.docs;
+
+import com.mopl.domain.follow.dto.request.FollowRequest;
+import com.mopl.domain.follow.dto.response.FollowResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.jspecify.annotations.NonNull;
+import org.springframework.http.ResponseEntity;
+
+import java.security.Principal;
+
+@Tag(name = "팔로우 관리", description = "사용자 팔로우 API")
+public interface FollowControllerDocs {
+
+    @Operation(summary = "사용자 팔로우", description = "특정 사용자를 팔로우합니다. (자기 자신 팔로우 불가)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "팔로우 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (자기 자신, 이미 팔로우 중)"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "사용자 찾을 수 없음")
+    })
+    ResponseEntity<@NonNull FollowResponse> followUser(
+            Principal principal,
+            FollowRequest request
+    );
+}

--- a/mopl-api/src/main/java/com/mopl/domain/follow/controller/docs/FollowControllerDocs.java
+++ b/mopl-api/src/main/java/com/mopl/domain/follow/controller/docs/FollowControllerDocs.java
@@ -5,15 +5,13 @@ import com.mopl.domain.follow.dto.response.FollowResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.jspecify.annotations.NonNull;
 import org.springframework.http.ResponseEntity;
-
 import java.security.Principal;
 
-@Tag(name = "팔로우 관리", description = "사용자 팔로우 API")
 public interface FollowControllerDocs {
 
+    // 팔로우 명세서
     @Operation(summary = "사용자 팔로우", description = "특정 사용자를 팔로우합니다. (자기 자신 팔로우 불가)")
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "팔로우 성공"),

--- a/mopl-api/src/main/java/com/mopl/domain/follow/dto/request/FollowRequest.java
+++ b/mopl-api/src/main/java/com/mopl/domain/follow/dto/request/FollowRequest.java
@@ -1,0 +1,9 @@
+package com.mopl.domain.follow.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record FollowRequest(
+        @NotNull(message = "팔로우할 대상의 ID는 필수입니다.")
+        Long followeeId
+) {
+}

--- a/mopl-api/src/main/java/com/mopl/domain/follow/dto/response/FollowResponse.java
+++ b/mopl-api/src/main/java/com/mopl/domain/follow/dto/response/FollowResponse.java
@@ -1,0 +1,18 @@
+package com.mopl.domain.follow.dto.response;
+
+import com.mopl.domain.follow.entity.Follow;
+
+public record FollowResponse(
+        Long id,
+        Long followerId,
+        Long followeeId
+) {
+    public static FollowResponse from(Follow follow) {
+
+        return new FollowResponse(
+                follow.getId(),
+                follow.getFollower().getId(),
+                follow.getFollowee().getId()
+        );
+    }
+}

--- a/mopl-api/src/main/java/com/mopl/domain/follow/service/FollowService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/follow/service/FollowService.java
@@ -1,0 +1,58 @@
+package com.mopl.domain.follow.service;
+
+import com.mopl.domain.follow.dto.request.FollowRequest;
+import com.mopl.domain.follow.dto.response.FollowResponse;
+import com.mopl.domain.follow.entity.Follow;
+import com.mopl.domain.follow.repository.FollowRepository;
+import com.mopl.domain.user.entity.User;
+import com.mopl.domain.user.repository.UserRepository;
+import com.mopl.global.exception.ErrorCode;
+import com.mopl.global.exception.MoplException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FollowService {
+
+    private final FollowRepository followRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public FollowResponse follow(Long myId, FollowRequest request) {
+        Long targetId = request.followeeId();
+
+        // 1. 자기 자신 팔로우 방지 (400)
+        if (myId.equals(targetId)) {
+            throw new MoplException(ErrorCode.CANNOT_FOLLOW_SELF);
+        }
+
+        // 2. 이미 팔로우 중인지 확인 (400)
+        if (followRepository.existsByFollowerIdAndFolloweeId(myId, targetId)) {
+            throw new MoplException(ErrorCode.ALREADY_FOLLOWING);
+        }
+
+        // 3. 사용자 조회 (404)
+        User me = getUserOrThrow(myId);
+        User target = getUserOrThrow(targetId);
+
+        // 4. 팔로우 저장
+        Follow follow = Follow.builder()
+                .follower(me)
+                .followee(target)
+                .build();
+        followRepository.save(follow);
+
+        return FollowResponse.from(follow);
+
+        // TODO 요구사항: "다른 사용자가 나를 팔로우하면 알림을 받습니다."
+        // notificationService.send(target, NotificationType.FOLLOW, me.getName() + "님이 팔로우했습니다.");
+    }
+
+    private User getUserOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new MoplException(ErrorCode.NOT_FOUND));
+    }
+}

--- a/mopl-api/src/main/java/com/mopl/domain/follow/service/FollowService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/follow/service/FollowService.java
@@ -20,6 +20,7 @@ public class FollowService {
     private final FollowRepository followRepository;
     private final UserRepository userRepository;
 
+    // 팔로우 로직
     @Transactional
     public FollowResponse follow(Long myId, FollowRequest request) {
         Long targetId = request.followeeId();
@@ -30,6 +31,7 @@ public class FollowService {
         }
 
         // 2. 이미 팔로우 중인지 확인 (400)
+        // // TODO: 동시성 이슈 체크할 것
         if (followRepository.existsByFollowerIdAndFolloweeId(myId, targetId)) {
             throw new MoplException(ErrorCode.ALREADY_FOLLOWING);
         }

--- a/mopl-api/src/test/java/com/mopl/domain/follow/controller/FollowApiTest.java
+++ b/mopl-api/src/test/java/com/mopl/domain/follow/controller/FollowApiTest.java
@@ -1,0 +1,145 @@
+package com.mopl.domain.follow.controller;
+
+import tools.jackson.databind.ObjectMapper;
+import com.mopl.domain.follow.dto.request.FollowRequest;
+import com.mopl.domain.follow.entity.Follow;
+import com.mopl.domain.follow.repository.FollowRepository;
+import com.mopl.domain.user.entity.User;
+import com.mopl.domain.user.repository.UserRepository;
+import com.mopl.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class FollowApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private FollowRepository followRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    // 테스트용 유저
+    private User user1;
+    private User user2;
+
+    @BeforeEach
+    void setUp() {
+        // 유저 생성
+        user1 = userRepository.save(new User("me", "user1@test.com", "password"));
+        user2 = userRepository.save(new User("you", "user2@test.com", "password"));
+    }
+
+    // 1. 성공 케이스 (201)
+    @Test
+    @DisplayName("[201] 정상적인 팔로우 요청 시 성공한다")
+    void followUser_Success() throws Exception {
+        // Given
+        FollowRequest request = new FollowRequest(user2.getId());
+
+        // When & Then
+        mockMvc.perform(post("/api/follows")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(user(String.valueOf(user1.getId())))) // 로그인
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.followerId").value(user1.getId()))
+                .andExpect(jsonPath("$.followeeId").value(user2.getId()));
+    }
+
+    // 2. 비즈니스 예외 케이스 (400)
+    @Test
+    @DisplayName("[400] 자기 자신을 팔로우하면 CANNOT_FOLLOW_SELF 에러 발생")
+    void followUser_Self_Fail() throws Exception {
+        // Given
+        FollowRequest request = new FollowRequest(user1.getId());
+
+        // When & Then
+        mockMvc.perform(post("/api/follows")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(user(String.valueOf(user1.getId()))))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value(ErrorCode.CANNOT_FOLLOW_SELF.name()))
+                .andExpect(jsonPath("$.detail").value(ErrorCode.CANNOT_FOLLOW_SELF.getMessage()));
+    }
+
+    @Test
+    @DisplayName("[400] 이미 팔로우 중인데 또 요청하면 ALREADY_FOLLOWING 에러 발생")
+    void followUser_Duplicate_Fail() throws Exception {
+        // Given
+        followRepository.save(Follow.builder().follower(user1).followee(user2).build());
+
+        FollowRequest request = new FollowRequest(user2.getId());
+
+        // When & Then
+        mockMvc.perform(post("/api/follows")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(user(String.valueOf(user1.getId()))))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value(ErrorCode.ALREADY_FOLLOWING.name()))
+                .andExpect(jsonPath("$.detail").value(ErrorCode.ALREADY_FOLLOWING.getMessage()));
+    }
+
+    // 3. 리소스 없음 (404)
+
+    @Test
+    @DisplayName("[404] 존재하지 않는 유저를 팔로우하면 NOT_FOUND 에러 발생")
+    void followUser_NotFound_Fail() throws Exception {
+
+        // Given
+        Long nonExistentId = 999999L;
+        FollowRequest request = new FollowRequest(nonExistentId);
+
+        // When & Then
+        mockMvc.perform(post("/api/follows")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(user(String.valueOf(user1.getId()))))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.title").value(ErrorCode.NOT_FOUND.name()));
+    }
+
+    // 4. 인증 실패 (401)
+    @Test
+    @DisplayName("[401] 로그인 정보 없이 요청하면 UNAUTHORIZED 에러 발생")
+    void followUser_Unauthorized_Fail() throws Exception {
+        // Given
+        FollowRequest request = new FollowRequest(user2.getId());
+
+        // When & Then
+        mockMvc.perform(post("/api/follows")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.title").value(ErrorCode.UNAUTHORIZED.name()));
+    }
+
+}

--- a/mopl-core/src/main/java/com/mopl/domain/follow/entity/Follow.java
+++ b/mopl-core/src/main/java/com/mopl/domain/follow/entity/Follow.java
@@ -11,32 +11,32 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @Table(
-    name = "follows",
-    uniqueConstraints = {
-        @UniqueConstraint(
-            name = "uk_follows_relation",
-            columnNames = {"follower_id", "followee_id"}
-        )
-    }
+        name = "follows",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_follows_relation",
+                        columnNames = {"follower_id", "followee_id"}
+                )
+        }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Follow extends BaseCreatedEntity {
 
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "follower_id", nullable = false)
-  private User follower;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "follower_id", nullable = false)
+    private User follower;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "followee_id", nullable = false)
-  private User followee;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "followee_id", nullable = false)
+    private User followee;
 
-  @Builder
-  public Follow(User follower, User followee) {
-    this.follower = follower;
-    this.followee = followee;
-  }
+    @Builder
+    public Follow(User follower, User followee) {
+        this.follower = follower;
+        this.followee = followee;
+    }
 }

--- a/mopl-core/src/main/java/com/mopl/domain/follow/repository/FollowRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/follow/repository/FollowRepository.java
@@ -1,17 +1,19 @@
 package com.mopl.domain.follow.repository;
 
 import com.mopl.domain.follow.entity.Follow;
+import org.jspecify.annotations.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface FollowRepository extends JpaRepository<Follow, Long> {
+public interface FollowRepository extends JpaRepository<@NonNull Follow, @NonNull Long> {
 
-  // 중복 팔로우 체크
-  boolean existsByFollowerIdAndFolloweeId(Long followerId, Long followeeId);
+    // 중복 팔로우 체크
+    boolean existsByFollowerIdAndFolloweeId(Long followerId, Long followeeId);
 
-  // 언팔로우
-  void deleteByFollowerIdAndFolloweeId(Long followerId, Long followeeId);
+    // 언팔로우
+    void deleteByFollowerIdAndFolloweeId(Long followerId, Long followeeId);
 
-  // 팔로워/팔로잉 수 카운트 (마이페이지에 쓰이는것)
-  long countByFollowerId(Long followerId);
-  long countByFolloweeId(Long followeeId);
+    // 팔로워/팔로잉 수 카운트 (마이페이지에 쓰이는것)
+    long countByFollowerId(Long followerId);
+
+    long countByFolloweeId(Long followeeId);
 }


### PR DESCRIPTION
## 연관 이슈

close #49 

## 🔄 변경 사항

* **팔로우 신청 API (`POST /api/follows`)** 개발 완료했습니다.
* **Spring Boot 4 대응:** 테스트 환경 설정을 수정하고 Jackson 3 패키지 변경 사항을 적용했습니다.

## 🧩 작업 사항

**1. API 및 비즈니스 로직 구현**

* `FollowController`:
* `Principal` 객체를 사용하여 Null Safety를 강화하고 테스트 용이성을 높였습니다.
* 로그인하지 않은 사용자에 대한 방어 로직(401 Unauthorized)을 추가했습니다.
* `JSpecify` 어노테이션을 적용하여 IDE 경고를 해결했습니다.
* Swagger(`@Operation`)를 통해 API 명세를 구체화했습니다.
* 알림 관련 개발위해 TODO 주석 자성해두었습니다.


* `FollowService`:
* 자기 자신 팔로우 방지 로직 추가 (400 Bad Request)
* 이미 팔로우한 사용자 중복 요청 방지 로직 추가 (400 Bad Request)
* 존재하지 않는 사용자 요청 시 예외 처리 (404 Not Found)



**2. 테스트 코드 작성 (`FollowApiTest`)**

* 성공 케이스(201) 및 모든 예외 시나리오(400, 401, 404)에 대한 통합 테스트를 작성했습니다.
* `SecurityMockMvcRequestPostProcessors.user()`를 사용하여 동적인 ID 환경에서도 테스트가 통과하도록 구성했습니다.

**3. 설정 및 리팩토링**

* Spring boot 4.0.1 관련 설정

* `build.gradle`: `spring-boot-starter-webmvc-test` 의존성을 추가하여 `@AutoConfigureMockMvc` 호환성 문제를 해결했습니다.
``` java
@Autowired
ObjectMapper
``` 
* `import tools.jackson.databind.ObjectMapper;`라이브러리 패키지 위치 변경되어 호환성 문제를 해결했습니다. 

## 📸 스크린샷

**[테스트 실행 결과]**
모든 시나리오(성공, 자기자신 팔로우, 중복 팔로우, 미인증, 미존재 유저) 통과했습니다.

``` java
> Task :mopl-api:test
...
MockHttpServletResponse: Status = 201 (팔로우 성공)
MockHttpServletResponse: Status = 400 (자기 자신 팔로우 방지)
MockHttpServletResponse: Status = 400 (중복 팔로우 방지)
MockHttpServletResponse: Status = 401 (미인증)
MockHttpServletResponse: Status = 404 (존재하지 않는 유저)
...
BUILD SUCCESSFUL in 1m
7 actionable tasks: 3 executed, 4 up-to-date
``` 