### PR TITLE
[feat] 대화방 생성(1:1 채팅) 기능 구현

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/conversation/controller/ConversationController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/controller/ConversationController.java
@@ -1,0 +1,29 @@
+package com.mopl.domain.conversation.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.mopl.domain.conversation.dto.request.ConversationCreateRequest;
+import com.mopl.domain.conversation.dto.response.ConversationDto;
+import com.mopl.domain.conversation.service.ConversationService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/conversations")
+@RequiredArgsConstructor
+public class ConversationController {
+
+    private final ConversationService conversationService;
+
+    // TODO 회원가입/로그인 완료 후 AuthenticationPrincipal 로 변경 필요
+    @PostMapping
+    public ResponseEntity<ConversationDto> create(@RequestBody @Valid ConversationCreateRequest createRequest) throws JsonProcessingException {
+        long tempUserId = 1L;
+        ConversationDto conversationDto = conversationService.createConversation(tempUserId, createRequest);
+        return ResponseEntity.ok(conversationDto);
+    }
+}

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/controller/ConversationController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/controller/ConversationController.java
@@ -1,6 +1,5 @@
 package com.mopl.domain.conversation.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.mopl.domain.conversation.dto.request.ConversationCreateRequest;
 import com.mopl.domain.conversation.dto.response.ConversationDto;
 import com.mopl.domain.conversation.service.ConversationService;
@@ -21,7 +20,7 @@ public class ConversationController {
 
     // TODO 회원가입/로그인 완료 후 AuthenticationPrincipal 로 변경 필요
     @PostMapping
-    public ResponseEntity<ConversationDto> create(@RequestBody @Valid ConversationCreateRequest createRequest) throws JsonProcessingException {
+    public ResponseEntity<ConversationDto> create(@RequestBody @Valid ConversationCreateRequest createRequest) {
         long tempUserId = 1L;
         ConversationDto conversationDto = conversationService.createConversation(tempUserId, createRequest);
         return ResponseEntity.ok(conversationDto);

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/dto/request/ConversationCreateRequest.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/dto/request/ConversationCreateRequest.java
@@ -1,0 +1,6 @@
+package com.mopl.domain.conversation.dto.request;
+
+public record ConversationCreateRequest(
+        Long withUserId
+) {
+}

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/dto/request/ConversationCreateRequest.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/dto/request/ConversationCreateRequest.java
@@ -1,6 +1,9 @@
 package com.mopl.domain.conversation.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+
 public record ConversationCreateRequest(
+        @NotNull(message = "대화 상대는 필수값입니다.")
         Long withUserId
 ) {
 }

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/dto/response/ConversationDto.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/dto/response/ConversationDto.java
@@ -1,0 +1,11 @@
+package com.mopl.domain.conversation.dto.response;
+
+import com.mopl.domain.user.dto.response.UserSummaryDto;
+
+public record ConversationDto(
+        Long id,
+        UserSummaryDto with,
+        LastMessage lastestMessage,
+        boolean hasUnread
+) {
+}

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/dto/response/LastMessage.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/dto/response/LastMessage.java
@@ -1,0 +1,15 @@
+package com.mopl.domain.conversation.dto.response;
+
+import com.mopl.domain.user.dto.response.UserSummaryDto;
+
+import java.time.LocalDateTime;
+
+public record LastMessage(
+        Long id,
+        Long conversationId,
+        LocalDateTime createdAt,
+        UserSummaryDto sender,
+        UserSummaryDto receiver,
+        String content
+) {
+}

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/exception/ConversationErrorCode.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/exception/ConversationErrorCode.java
@@ -1,0 +1,17 @@
+package com.mopl.domain.conversation.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ConversationErrorCode {
+    CONVERSATION_NOT_FOUND("CV001", "대화방을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    SELF_CONVERSATION_NOT_ALLOWED("CV002", "자기 자신과는 대화할 수 없습니다.", HttpStatus.BAD_REQUEST)
+    ;
+
+    private final String errorCode;
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/exception/ConversationException.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/exception/ConversationException.java
@@ -1,0 +1,14 @@
+package com.mopl.domain.conversation.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ConversationException extends RuntimeException {
+
+    private final ConversationErrorCode errorCode;
+
+    public ConversationException(ConversationErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/service/ConversationService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/service/ConversationService.java
@@ -1,0 +1,122 @@
+package com.mopl.domain.conversation.service;
+
+import com.mopl.domain.conversation.dto.request.ConversationCreateRequest;
+import com.mopl.domain.conversation.dto.response.ConversationDto;
+import com.mopl.domain.conversation.dto.response.LastMessage;
+import com.mopl.domain.conversation.entity.Conversation;
+import com.mopl.domain.conversation.entity.DirectMessage;
+import com.mopl.domain.conversation.entity.ReadStatus;
+import com.mopl.domain.conversation.exception.ConversationException;
+import com.mopl.domain.conversation.repository.ConversationRepository;
+import com.mopl.domain.conversation.repository.DirectMessageRepository;
+import com.mopl.domain.conversation.repository.ReadStatusRepository;
+import com.mopl.domain.user.dto.response.UserSummaryDto;
+import com.mopl.domain.user.entity.User;
+import com.mopl.domain.user.exception.UserErrorCode;
+import com.mopl.domain.user.exception.UserException;
+import com.mopl.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.mopl.domain.conversation.exception.ConversationErrorCode.CONVERSATION_NOT_FOUND;
+import static com.mopl.domain.conversation.exception.ConversationErrorCode.SELF_CONVERSATION_NOT_ALLOWED;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ConversationService {
+
+    private final ConversationRepository conversationRepository;
+    private final UserRepository userRepository;
+    private final ReadStatusRepository readStatusRepository;
+    private final DirectMessageRepository directMessageRepository;
+
+    @Transactional
+    public ConversationDto createConversation(Long userId, ConversationCreateRequest createRequest) {
+        Long withUserId = createRequest.withUserId();
+        if (userId.equals(withUserId)) {
+            throw new ConversationException(SELF_CONVERSATION_NOT_ALLOWED);
+        }
+
+        User me = getUserOrThrow(userId);
+        User targetUser = getUserOrThrow(withUserId);
+
+        return conversationRepository.findByParticipants(userId, withUserId)
+                .map(conversation -> convertToDtoWithTarget(conversation, me, targetUser))
+                .orElseGet(() -> createNewConversation(me, targetUser));
+    }
+
+    // 기존 대화방이 없을 때 새로 생성
+    private ConversationDto createNewConversation(User me, User target) {
+
+        Conversation newConversation = conversationRepository.save(new Conversation());
+
+        ReadStatus myReadStatus = ReadStatus.create(newConversation, me);
+        ReadStatus targetReadStatus = ReadStatus.create(newConversation, target);
+        readStatusRepository.saveAll(List.of(myReadStatus, targetReadStatus));
+
+        UserSummaryDto targetUserDto = new UserSummaryDto(target.getId(), target.getName(), target.getProfileImageUrl());
+
+        return new ConversationDto(
+                newConversation.getId(),
+                targetUserDto,
+                null,
+                false
+        );
+    }
+
+    private ConversationDto convertToDtoWithTarget(Conversation conversation, User me, User target) {
+        UserSummaryDto withUserDto = new UserSummaryDto(target.getId(), target.getName(), target.getProfileImageUrl());
+
+        DirectMessage lastMessage = directMessageRepository.findTopByConversationIdOrderByCreatedAtDescIdDesc(conversation.getId())
+                .orElse(null);
+
+        if (lastMessage == null) {
+            return new ConversationDto(conversation.getId(),
+                    withUserDto,
+                    null,
+                    false);
+        }
+
+        User sender = lastMessage.getAuthor();
+        UserSummaryDto senderDto = null;
+        UserSummaryDto receiverDto = null;
+
+        if (sender.getId().equals(me.getId())) {
+            senderDto = new UserSummaryDto(me.getId(),
+                    me.getName(),
+                    me.getProfileImageUrl());
+            receiverDto = new UserSummaryDto(target.getId(), target.getName(), target.getProfileImageUrl());
+        } else {
+            senderDto = new UserSummaryDto(target.getId(), target.getName(), target.getProfileImageUrl());
+            receiverDto = new UserSummaryDto(me.getId(),
+                    me.getName(),
+                    me.getProfileImageUrl());
+        }
+
+        LastMessage lastMessageDto = new LastMessage(lastMessage.getId(),
+                conversation.getId(),
+                lastMessage.getCreatedAt(),
+                senderDto,
+                receiverDto,
+                lastMessage.getContent());
+
+        ReadStatus myReadStatus = readStatusRepository.findByConversationIdAndUserId(conversation.getId(), me.getId())
+                .orElseThrow(() -> new ConversationException(CONVERSATION_NOT_FOUND));
+
+        long lastReadMsgId = myReadStatus.getLastReadMessage() != null ? myReadStatus.getLastReadMessage().getId() : 0L;
+        boolean hasUnread = lastReadMsgId < lastMessage.getId();
+
+        return new ConversationDto(conversation.getId(), withUserDto, lastMessageDto, hasUnread);
+    }
+
+    private User getUserOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_EXIST));
+    }
+}

--- a/mopl-api/src/main/java/com/mopl/domain/user/dto/response/UserSummaryDto.java
+++ b/mopl-api/src/main/java/com/mopl/domain/user/dto/response/UserSummaryDto.java
@@ -1,0 +1,8 @@
+package com.mopl.domain.user.dto.response;
+
+public record UserSummaryDto(
+        Long userId,
+        String name,
+        String profileImageUrl
+) {
+}

--- a/mopl-api/src/test/java/com/mopl/domain/conversation/service/ConversationServiceTest.java
+++ b/mopl-api/src/test/java/com/mopl/domain/conversation/service/ConversationServiceTest.java
@@ -1,0 +1,127 @@
+package com.mopl.domain.conversation.service;
+
+import com.mopl.domain.conversation.dto.request.ConversationCreateRequest;
+import com.mopl.domain.conversation.dto.response.ConversationDto;
+import com.mopl.domain.conversation.entity.Conversation;
+import com.mopl.domain.conversation.entity.DirectMessage;
+import com.mopl.domain.conversation.entity.ReadStatus;
+import com.mopl.domain.conversation.exception.ConversationErrorCode;
+import com.mopl.domain.conversation.exception.ConversationException;
+import com.mopl.domain.conversation.repository.ConversationRepository;
+import com.mopl.domain.conversation.repository.DirectMessageRepository;
+import com.mopl.domain.conversation.repository.ReadStatusRepository;
+import com.mopl.domain.user.entity.User;
+import com.mopl.domain.user.exception.UserErrorCode;
+import com.mopl.domain.user.exception.UserException;
+import com.mopl.domain.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Slf4j
+@SpringBootTest
+@Transactional
+class ConversationServiceTest {
+
+    @Autowired ConversationService conversationService;
+    @Autowired UserRepository userRepository;
+    @Autowired ConversationRepository conversationRepository;
+    @Autowired ReadStatusRepository readStatusRepository;
+    @Autowired DirectMessageRepository directMessageRepository;
+    @Autowired EntityManager em; // 영속성 컨텍스트 제어용
+
+    @Test
+    @DisplayName("성공: 기존 대화방이 없으면 DB에 새로 생성하고 반환한다")
+    void createConversation_New() {
+        // given
+        User me = userRepository.save(new User("me", "me@test.com", "pw"));
+        User target = userRepository.save(new User("target", "target@test.com", "pw"));
+
+        ConversationCreateRequest request = new ConversationCreateRequest(target.getId());
+
+        // when
+        ConversationDto result = conversationService.createConversation(me.getId(), request);
+
+        // then
+        // 반환값 검증
+        assertThat(result.id()).isNotNull();
+        assertThat(result.with().userId()).isEqualTo(target.getId());
+        assertThat(result.lastestMessage()).isNull();
+        assertThat(result.hasUnread()).isFalse();
+
+        // 실제 DB 저장 확인
+        List<ReadStatus> statuses = readStatusRepository.findAll();
+        assertThat(statuses).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("성공: 이미 존재하는 대화방이 있으면 DB에서 찾아 반환한다")
+    void createConversation_Existing() {
+        // given
+        User me = userRepository.save(new User("me", "me@test.com", "pw"));
+        User target = userRepository.save(new User("target", "target@test.com", "pw"));
+
+        // 기존 대화방 세팅
+        Conversation conversation = conversationRepository.save(new Conversation());
+
+        ReadStatus myStatus = readStatusRepository.save(ReadStatus.create(conversation, me));
+        readStatusRepository.save(ReadStatus.create(conversation, target));
+
+        // 메시지 전송 상황 세팅
+        DirectMessage oldMessage = directMessageRepository.save(new DirectMessage(conversation, target, "이전 메시지"));
+        myStatus.updateLastReadMsg(oldMessage);
+
+        // 2. 상대방이 보낸 최신 메시지 (== 안 읽은 상태)
+        directMessageRepository.save(new DirectMessage(conversation, target, "새로 보낸 메시지!!"));
+
+        em.flush();
+        em.clear();
+
+        for (DirectMessage directMessage : directMessageRepository.findAll()) {
+            log.info("대화방 {}: dm_id: {}, 작성자:{}, 내용: {}",directMessage.getConversation().getId() , directMessage.getId(), directMessage.getAuthor(), directMessage.getContent());
+        }
+
+        ConversationCreateRequest request = new ConversationCreateRequest(target.getId());
+
+        // when
+        ConversationDto result = conversationService.createConversation(me.getId(), request);
+
+        // then
+        assertThat(result.id()).isEqualTo(conversation.getId()); // 기존 대화방 반환하는지 확인
+        assertThat(result.lastestMessage()).isNotNull();
+        assertThat(result.lastestMessage().content()).isEqualTo("새로 보낸 메시지!!"); // 가장 최신에 온 메시지 확인
+        assertThat(result.hasUnread()).isTrue();
+    }
+
+    @Test
+    @DisplayName("실패: 자기 자신과 대화를 시도하면 예외가 발생한다")
+    void createConversation_Self_Fail() {
+        User me = userRepository.save(new User("me", "me@test.com", "pw"));
+        ConversationCreateRequest request = new ConversationCreateRequest(me.getId());
+
+        assertThatThrownBy(() -> conversationService.createConversation(me.getId(), request))
+                .isInstanceOf(ConversationException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ConversationErrorCode.SELF_CONVERSATION_NOT_ALLOWED);
+    }
+
+    @Test
+    @DisplayName("실패: 존재하지 않는 유저와 대화 시도")
+    void createConversation_UserNotFound() {
+        User me = userRepository.save(new User("me", "me@test.com", "pw"));
+        Long unknownId = 9999L;
+        ConversationCreateRequest request = new ConversationCreateRequest(unknownId);
+
+        assertThatThrownBy(() -> conversationService.createConversation(me.getId(), request))
+                .isInstanceOf(UserException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_NOT_EXIST);
+    }
+}

--- a/mopl-api/src/test/java/com/mopl/domain/conversation/service/ConversationServiceTest.java
+++ b/mopl-api/src/test/java/com/mopl/domain/conversation/service/ConversationServiceTest.java
@@ -15,7 +15,6 @@ import com.mopl.domain.user.exception.UserErrorCode;
 import com.mopl.domain.user.exception.UserException;
 import com.mopl.domain.user.repository.UserRepository;
 import jakarta.persistence.EntityManager;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,7 +26,6 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@Slf4j
 @SpringBootTest
 @Transactional
 class ConversationServiceTest {
@@ -85,10 +83,6 @@ class ConversationServiceTest {
 
         em.flush();
         em.clear();
-
-        for (DirectMessage directMessage : directMessageRepository.findAll()) {
-            log.info("대화방 {}: dm_id: {}, 작성자:{}, 내용: {}",directMessage.getConversation().getId() , directMessage.getId(), directMessage.getAuthor(), directMessage.getContent());
-        }
 
         ConversationCreateRequest request = new ConversationCreateRequest(target.getId());
 

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/entity/Conversation.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/entity/Conversation.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "conversations")
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
 public class Conversation extends BaseCreatedEntity {
 
     @Id

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/entity/DirectMessage.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/entity/DirectMessage.java
@@ -27,4 +27,10 @@ public class DirectMessage extends BaseCreatedEntity {
 
     @Column(nullable = false)
     private String content;
+
+    public DirectMessage(Conversation conversation, User author, String content) {
+        this.conversation = conversation;
+        this.author = author;
+        this.content = content;
+    }
 }

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/entity/ReadStatus.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/entity/ReadStatus.java
@@ -28,4 +28,14 @@ public class ReadStatus {
     @JoinColumn(name = "last_message_id")
     private DirectMessage lastReadMessage;
 
+    public static ReadStatus create(Conversation conversation, User user) {
+        ReadStatus readStatus = new ReadStatus();
+        readStatus.conversation = conversation;
+        readStatus.user = user;
+        return readStatus;
+    }
+
+    public void updateLastReadMsg(DirectMessage lastReadMessage) {
+        this.lastReadMessage = lastReadMessage;
+    }
 }

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ConversationRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ConversationRepository.java
@@ -2,7 +2,18 @@ package com.mopl.domain.conversation.repository;
 
 import com.mopl.domain.conversation.entity.Conversation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface ConversationRepository extends JpaRepository<Conversation, Long> {
 
+    @Query("""
+            SELECT c FROM Conversation c
+            JOIN ReadStatus rs1 ON c.id = rs1.conversation.id
+            JOIN ReadStatus rs2 ON c.id = rs2.conversation.id
+            WHERE rs1.user.id = :myId AND rs2.user.id = :targetId
+            """)
+    Optional<Conversation> findByParticipants(@Param("myId") Long myId, @Param("targetId") Long targetId);
 }

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/repository/DirectMessageRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/repository/DirectMessageRepository.java
@@ -3,5 +3,10 @@ package com.mopl.domain.conversation.repository;
 import com.mopl.domain.conversation.entity.DirectMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface DirectMessageRepository extends JpaRepository<DirectMessage, Long> {
+
+    // createdAt이 같을 수 있으므로 id로 2차 정렬
+    Optional<DirectMessage> findTopByConversationIdOrderByCreatedAtDescIdDesc(Long conversationId);
 }

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ReadStatusRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ReadStatusRepository.java
@@ -3,5 +3,9 @@ package com.mopl.domain.conversation.repository;
 import com.mopl.domain.conversation.entity.ReadStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ReadStatusRepository extends JpaRepository<ReadStatus, Long> {
+
+    Optional<ReadStatus> findByConversationIdAndUserId(Long conversationId, Long userId);
 }


### PR DESCRIPTION
## 연관 이슈
close #36 

## 🔄 변경 사항
대화방 생성 api 구현

## 🧩 작업 사항
- 대화방(Conversation), 메시지(DirectMessage), 읽음상태(ReadStatus) 도메인 수정
- 대화방 생성 비즈니스 로직 구현 (기존 방 조회 및 신규 생성 분기 처리)
- 서비스 통합 테스트 작성

## ⭐️ 주의사항
- 현재는 userId=1 이랑만 대화방 생성 가능
- 추후 UserPrincipal로 변경 에정

## 📸 스크린샷
- 테스트
  <img width="475" height="162" alt="image" src="https://github.com/user-attachments/assets/cacffcdd-feb1-45c9-ae4a-82a4fe9ae3c7" />
- 자기 자신과는 대화할 수 없음
  <img width="2022" height="1530" alt="image" src="https://github.com/user-attachments/assets/56394fde-2f0d-4396-ac95-5e9a6d1eaee7" />
- 대화방 생성
  <img width="2012" height="1326" alt="image" src="https://github.com/user-attachments/assets/3797c5e2-3d38-44b5-a385-072dbdb40729" />

