### PR TITLE
[FEAT] ContentChat - 실시간 메시지 수신 및 알림 전송을 위한 Websocket 설정 및 SSE 인프라 구현 

### DIFF
--- a/mopl-chat/src/main/java/com/mopl/domain/contentchat/controller/ContentChatController.java
+++ b/mopl-chat/src/main/java/com/mopl/domain/contentchat/controller/ContentChatController.java
@@ -1,0 +1,34 @@
+package com.mopl.domain.contentchat.controller;
+
+import com.mopl.domain.contentchat.dto.ContentChatDto;
+import com.mopl.domain.contentchat.dto.ContentChatSendRequest;
+import com.mopl.domain.contentchat.dto.UserSummary;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class ContentChatController {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    /**
+     * 서버 - 메시지 전송: /pub/contents/{contentId}/chat
+     * 클라이언트 - 메시지 수신: /sub/contents/{contentId}/chat
+     */
+    @MessageMapping("/contents/{contentId}/chat")
+    public void sendMessage(@DestinationVariable Long contentId, ContentChatSendRequest request) {
+
+        // TODO: SecurityContext 또는 세션에서 현재 로그인한 유저 정보(UserSummary)를 가져오는 로직 필요
+        // 임시 데이터
+        UserSummary sender = new UserSummary(1L, "테스트유저", "https://profile.url");
+
+        ContentChatDto response = new ContentChatDto(sender, request.content());
+
+        //메시지 브로드캐스팅
+        messagingTemplate.convertAndSend("/sub/contents/" + contentId + "/chat", response);
+    }
+}

--- a/mopl-chat/src/main/java/com/mopl/domain/contentchat/dto/ContentChatDto.java
+++ b/mopl-chat/src/main/java/com/mopl/domain/contentchat/dto/ContentChatDto.java
@@ -1,0 +1,7 @@
+package com.mopl.domain.contentchat.dto;
+
+public record ContentChatDto(
+    UserSummary sender,
+    String content
+) {
+}

--- a/mopl-chat/src/main/java/com/mopl/domain/contentchat/dto/ContentChatSendRequest.java
+++ b/mopl-chat/src/main/java/com/mopl/domain/contentchat/dto/ContentChatSendRequest.java
@@ -1,0 +1,6 @@
+package com.mopl.domain.contentchat.dto;
+
+public record ContentChatSendRequest(
+    String content
+) {
+}

--- a/mopl-chat/src/main/java/com/mopl/domain/contentchat/dto/UserSummary.java
+++ b/mopl-chat/src/main/java/com/mopl/domain/contentchat/dto/UserSummary.java
@@ -1,0 +1,8 @@
+package com.mopl.domain.contentchat.dto;
+
+public record UserSummary(
+    Long userId,
+    String username,
+    String profileImageUrl
+) {
+}

--- a/mopl-chat/src/main/java/com/mopl/global/config/KafkaConfig.java
+++ b/mopl-chat/src/main/java/com/mopl/global/config/KafkaConfig.java
@@ -1,0 +1,4 @@
+package com.mopl.global.config;
+
+public class KafkaConfig {
+}

--- a/mopl-chat/src/main/java/com/mopl/global/config/SecurityConfig.java
+++ b/mopl-chat/src/main/java/com/mopl/global/config/SecurityConfig.java
@@ -1,0 +1,4 @@
+package com.mopl.global.config;
+
+public class SecurityConfig {
+}

--- a/mopl-chat/src/main/java/com/mopl/global/config/SecurityConfig.java
+++ b/mopl-chat/src/main/java/com/mopl/global/config/SecurityConfig.java
@@ -1,4 +1,30 @@
 package com.mopl.global.config;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
 public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                // 세션을 사용하지 않고 Stateless(JWT 등) 방식을 지향합니다.
+                .sessionManagement(session -> session
+                    .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                // 요청 권한 설정
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/sse/**").permitAll()
+                        // 그 외 모든 요청은 인증이 필요합니다. (추후 JWT 필터 적용 시 수정)
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
 }

--- a/mopl-chat/src/main/java/com/mopl/global/config/SseConfig.java
+++ b/mopl-chat/src/main/java/com/mopl/global/config/SseConfig.java
@@ -1,0 +1,16 @@
+package com.mopl.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class SseConfig implements WebMvcConfigurer {
+
+    @Override
+    public void configureAsyncSupport(AsyncSupportConfigurer configurer) {
+        // 프론트엔드 재연결 주기에 맞춰 60초로 설정해 안정적인 연결을 유지
+        configurer.setDefaultTimeout(60 * 1000L);
+    }
+
+}

--- a/mopl-chat/src/main/java/com/mopl/global/config/WebSocketConfig.java
+++ b/mopl-chat/src/main/java/com/mopl/global/config/WebSocketConfig.java
@@ -1,0 +1,37 @@
+package com.mopl.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    // TODO: JWT 인증 인터셉터 구현 - private final StompHandler stompHandler;
+
+    @Override
+    public void registerStompEndpoints(org.springframework.web.socket.config.annotation.StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws") // 클라이언트가 웹소켓 연결을 시작할 엔드포인트
+            .setAllowedOrigins("*") // 운영 시 보안을 위해 * 대신 실제 도메인 넣어야 함 ex) https://www.mopl.com
+            .withSockJS(); // SockJS 지원 (웹소켓 미지원 브라우저 대응)
+    }
+
+    /** websocket을 사용하는 도메인: 실시간 채팅(chat) DM, 실시간 시청자 */
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/sub"); // 메시지를 구독(수신)하는 접두사
+        registry.setApplicationDestinationPrefixes("/pub"); // 메시지를 발행(송신)하는 접두사
+    }
+
+    @Override
+    public void configureClientInboundChannel(@NonNull ChannelRegistration registration) {
+        // TODO: 메시지가 들어오는 통로에 인터셉터를 등록하여 JWT 인증 등을 처리
+        // registration.interceptors(stompHandler);
+    }
+}

--- a/mopl-chat/src/main/java/com/mopl/global/config/WebSocketConfig.java
+++ b/mopl-chat/src/main/java/com/mopl/global/config/WebSocketConfig.java
@@ -18,7 +18,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(org.springframework.web.socket.config.annotation.StompEndpointRegistry registry) {
         registry.addEndpoint("/ws") // 클라이언트가 웹소켓 연결을 시작할 엔드포인트
-            .setAllowedOrigins("*") // 운영 시 보안을 위해 * 대신 실제 도메인 넣어야 함 ex) https://www.mopl.com
+            .setAllowedOrigins("http://localhost:3000") // 운영 시 실제 도메인 넣어야 함
             .withSockJS(); // SockJS 지원 (웹소켓 미지원 브라우저 대응)
     }
 

--- a/mopl-chat/src/main/java/com/mopl/global/sse/SseController.java
+++ b/mopl-chat/src/main/java/com/mopl/global/sse/SseController.java
@@ -1,0 +1,27 @@
+package com.mopl.global.sse;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequestMapping("/api/sse")
+@RequiredArgsConstructor
+public class SseController {
+
+    private final SseManager sseManager;
+
+    @GetMapping(produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(
+        @RequestParam(value = "LastEventId", required = false, defaultValue = "")
+        String lastEventId
+    ) {
+        // TODO: 인증 시스템(JWT) 연동 후 실제 사용자 ID 할당 필요
+        Long userId = 1L; // 임시 user
+        return sseManager.subscribe(userId);
+    }
+}

--- a/mopl-chat/src/main/java/com/mopl/global/sse/SseManager.java
+++ b/mopl-chat/src/main/java/com/mopl/global/sse/SseManager.java
@@ -1,0 +1,60 @@
+package com.mopl.global.sse;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component
+public class SseManager {
+
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    /**
+     * 클라이언트와 서버 간의 SSE 파이프라인을 생성하고 관리합니다.
+     * 생성된 연결은 실시간 채팅, 알림 서비스 등의 단방향 이벤트 전송에 활용됩니다.
+     *
+     * @param userId 연결을 식별할 사용자 ID
+     * @return 실시간 통신을 위한 SseEmitter 객체
+     */
+    public SseEmitter subscribe(Long userId) {
+        SseEmitter emitter = new SseEmitter();
+        emitters.put(userId, emitter);
+
+        emitter.onCompletion(() -> emitters.remove(userId));
+        emitter.onTimeout(() -> emitters.remove(userId));
+        emitter.onError((e) -> emitters.remove(userId));
+
+        try {
+            emitter.send(SseEmitter.event().name("connect").data("connected!"));
+        } catch (IOException e) {
+            emitters.remove(userId);
+        }
+
+        return emitter;
+    }
+
+    /**
+     * 특정 사용자에게 구축된 파이프라인을 통해 실시간 이벤트를 전송합니다.
+     * 전송 실패 시 해당 사용자의 연결을 관리 목록에서 제거합니다.
+     *
+     * @param userId 이벤트를 수신할 사용자 ID
+     * @param eventName 이벤트 종류 (예: "chat", "notification")
+     * @param data 전송할 데이터 객체
+     */
+    public void sendToUser(Long userId, String eventName, Object data) {
+        SseEmitter emitter = emitters.get(userId);
+        if (emitter != null) {
+            try {
+                emitter.send(SseEmitter.event().name(eventName).data(data));
+            } catch (IOException e) {
+                log.error("SSE 전송 실패, userId: {}", userId);
+                emitters.remove(userId);
+            }
+        }
+    }
+}

--- a/mopl-chat/src/main/java/com/mopl/global/sse/SseManager.java
+++ b/mopl-chat/src/main/java/com/mopl/global/sse/SseManager.java
@@ -22,7 +22,7 @@ public class SseManager {
      * @return 실시간 통신을 위한 SseEmitter 객체
      */
     public SseEmitter subscribe(Long userId) {
-        SseEmitter emitter = new SseEmitter();
+        SseEmitter emitter = new SseEmitter(60_000L); // 프론트엔 재연결 주기 기준
         emitters.put(userId, emitter);
 
         emitter.onCompletion(() -> emitters.remove(userId));


### PR DESCRIPTION
## 연관 이슈
close #75 

## 🧩 작업 사항
- STOMP 기반 메시지 브로커 설정 (WebSocketConfig)
- 추후 확장을 위한 Security, Kafka 설정 파일 추가
- `@MessageMapping` 기반의 채팅 메시지 송신 로직 구현
- 메시지 전송 및 응답을 위한 DTO(ContentChatDto, UserSummary 등) 추가
- `SseEmitter`를 관리하기 위한 SseManager 클래스 추가
- SSE 구독 및 연결을 위한 SseController 구현
- 비동기 타임아웃 설정을 위한 SseConfig 추가 (60초 설정)
- `SecurityConfig`에서 SSE 엔드포인트(/api/sse/**) 접근 허용 설정

## 📸 스크린샷
<img width="749" height="532" alt="스크린샷 2026-01-08 오후 4 44 45" src="https://github.com/user-attachments/assets/b60e2295-cc77-4220-938a-ef2687f63538" />
