### PR TITLE
[fix] session을 stateless로 수정

### DIFF
--- a/mopl-api/src/main/java/com/mopl/global/config/SecurityConfig.java
+++ b/mopl-api/src/main/java/com/mopl/global/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -29,8 +30,12 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) {
 
         http
-                .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api-docs/**",
@@ -48,7 +53,7 @@ public class SecurityConfig {
                 .headers(headers -> headers
                         .frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
                 .addFilterBefore(new JwtFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
-                .csrf(csrf -> csrf.disable()) // TODO : 나중에 변경예정
+                .csrf(AbstractHttpConfigurer::disable) // TODO : 나중에 변경예정
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint));
 


### PR DESCRIPTION
## 연관 이슈
close #82 

## 🔄 변경 사항
인증을 실패 할때 에러 메시지와 sessionId가 저장이 되어 쓸모 없는 값이 함께 저장되는 문제가 있어서 수정 

## 🧩 작업 사항
-SecurityConfig 수정

## 📸 스크린샷
.