### PR TITLE
[REFACTOR} Follow - 팔로우 API 인증 객체 UserPrincipal로 교체

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/follow/controller/FollowController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/follow/controller/FollowController.java
@@ -1,5 +1,6 @@
 package com.mopl.domain.follow.controller;
 
+import com.mopl.domain.auth.dto.UserPrincipal;
 import com.mopl.domain.follow.controller.docs.FollowControllerDocs;
 import com.mopl.domain.follow.dto.request.FollowRequest;
 import com.mopl.domain.follow.dto.response.FollowResponse;
@@ -7,9 +8,8 @@ import com.mopl.domain.follow.service.FollowService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.security.Principal;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,11 +20,11 @@ public class FollowController implements FollowControllerDocs {
     // 팔로우 하기 API
     @Override
     public ResponseEntity<FollowResponse> followUser(
-            Principal principal,
+            @AuthenticationPrincipal UserPrincipal user,
             FollowRequest request
     ) {
 
-        Long myId = Long.parseLong(principal.getName());
+        Long myId = user.getUserId();
 
         FollowResponse response = followService.follow(myId, request);
 
@@ -34,11 +34,11 @@ public class FollowController implements FollowControllerDocs {
     // 언팔로우 하기 API
     @Override
     public ResponseEntity<Void> unfollowUser(
-            Principal principal,
+            @AuthenticationPrincipal UserPrincipal user,
             Long followId
     ) {
 
-        Long myId = Long.parseLong(principal.getName());
+        Long myId = user.getUserId();
 
         // 서비스에 내 ID와 언팔로우할 ID를 넘긴다.
         followService.unfollow(myId, followId);

--- a/mopl-api/src/main/java/com/mopl/domain/follow/controller/docs/FollowControllerDocs.java
+++ b/mopl-api/src/main/java/com/mopl/domain/follow/controller/docs/FollowControllerDocs.java
@@ -1,5 +1,6 @@
 package com.mopl.domain.follow.controller.docs;
 
+import com.mopl.domain.auth.dto.UserPrincipal;
 import com.mopl.domain.follow.dto.request.FollowRequest;
 import com.mopl.domain.follow.dto.response.FollowResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,11 +9,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import org.jspecify.annotations.NonNull;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.security.Principal;
 
 @Tag(name = "팔로우 관리", description = "사용자 팔로우 API")
 @RequestMapping("/api/follows")
@@ -28,7 +27,7 @@ public interface FollowControllerDocs {
     })
     @PostMapping
     ResponseEntity<FollowResponse> followUser(
-            Principal principal,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal user,
             @Valid @RequestBody FollowRequest request
     );
 
@@ -45,7 +44,7 @@ public interface FollowControllerDocs {
     })
     @DeleteMapping("/{followId}")
     ResponseEntity<Void> unfollowUser(
-            Principal principal,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal user,
             @Parameter(description = "삭제할 팔로우 ID (PK)") @PathVariable Long followId
     );
 }


### PR DESCRIPTION
## 연관 이슈


## 🔄 변경 사항

팔로우 컨트롤러의 인증 처리 방식(`UserPrincipal`)과 인터페이스 구조를 리팩토링했습니다.

## 🧩 작업 사항

**1. 코드 리팩토링 (Refactor)**

* **인증 객체 교체:** `Principal` 대신 `UserPrincipal`(@AuthenticationPrincipal)을 적용하여 불필요한 ID 파싱 로직 제거


## 📸 스크린샷
