### PR TITLE
[feat] 대화 목록 조회 API 구현

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/conversation/controller/ConversationController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/controller/ConversationController.java
@@ -1,11 +1,13 @@
 package com.mopl.domain.conversation.controller;
 
+import com.mopl.domain.auth.dto.UserPrincipal;
 import com.mopl.domain.conversation.dto.request.ConversationCreateRequest;
 import com.mopl.domain.conversation.dto.response.ConversationDto;
 import com.mopl.domain.conversation.service.ConversationService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,11 +20,11 @@ public class ConversationController {
 
     private final ConversationService conversationService;
 
-    // TODO 회원가입/로그인 완료 후 AuthenticationPrincipal 로 변경 필요
     @PostMapping
-    public ResponseEntity<ConversationDto> create(@RequestBody @Valid ConversationCreateRequest createRequest) {
-        long tempUserId = 1L;
-        ConversationDto conversationDto = conversationService.createConversation(tempUserId, createRequest);
+    public ResponseEntity<ConversationDto> create(@AuthenticationPrincipal UserPrincipal userPrincipal,
+                                                  @RequestBody @Valid ConversationCreateRequest createRequest) {
+        Long userId = userPrincipal.getUserId();
+        ConversationDto conversationDto = conversationService.createConversation(userId, createRequest);
         return ResponseEntity.ok(conversationDto);
     }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/controller/ConversationController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/controller/ConversationController.java
@@ -2,16 +2,15 @@ package com.mopl.domain.conversation.controller;
 
 import com.mopl.domain.auth.dto.UserPrincipal;
 import com.mopl.domain.conversation.dto.request.ConversationCreateRequest;
+import com.mopl.domain.conversation.dto.request.ConversationSearchCondition;
 import com.mopl.domain.conversation.dto.response.ConversationDto;
 import com.mopl.domain.conversation.service.ConversationService;
+import com.mopl.global.dto.PageResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/conversations")
@@ -26,5 +25,15 @@ public class ConversationController {
         Long userId = userPrincipal.getUserId();
         ConversationDto conversationDto = conversationService.createConversation(userId, createRequest);
         return ResponseEntity.ok(conversationDto);
+    }
+
+    @GetMapping
+    public ResponseEntity<PageResponse<ConversationDto>> findAll(@AuthenticationPrincipal UserPrincipal userPrincipal,
+                                                                 @ModelAttribute @Valid ConversationSearchCondition searchCondition) {
+
+        Long userId = userPrincipal.getUserId();
+        PageResponse<ConversationDto> results = conversationService.findMyAllConversations(searchCondition, userId);
+
+        return ResponseEntity.ok(results);
     }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/dto/request/ConversationSearchCondition.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/dto/request/ConversationSearchCondition.java
@@ -1,0 +1,39 @@
+package com.mopl.domain.conversation.dto.request;
+
+import com.mopl.global.enums.SortDirection;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+/**
+ * 대화 목록 조회시 최근 메시지 생성일 내림차순 정렬하고
+ * 메시지가 없는 대화방은 대화방 생성일 내림차순으로 정렬하기 때문에 하기 두 파라미터는 쿼리에서 사용하지 않음
+ * @param sortDirection 사용 안 함
+ * @param sortBy 사용 안 함
+ */
+public record ConversationSearchCondition(
+        String keywordLike,
+
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        LocalDateTime cursor,
+
+        @Positive(message = "유효한 값을 입력해주세요.")
+        Long idAfter,
+
+        @NotNull(message = "limit 값은 필수입니다.")
+        @Min(value = 1, message = "조회 개수는 1 이상이어야 합니다.")
+        @Max(value = 50, message = "조회 개수는 50을 초과할 수 없습니다.")
+        Integer limit,
+
+        SortDirection sortDirection,
+        String sortBy
+) {
+        public ConversationSearchCondition {
+                sortBy = "createdAt";
+                sortDirection = SortDirection.DESCENDING;
+        }
+}

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/service/ConversationService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/service/ConversationService.java
@@ -178,17 +178,17 @@ public class ConversationService {
         DirectMessage message = tuple.get(2, DirectMessage.class);
         ReadStatus myStatus = tuple.get(3, ReadStatus.class);
 
-        UserSummaryDto witUserDto = new UserSummaryDto(targetUser.getId(), targetUser.getName(), targetUser.getProfileImageUrl());
+        UserSummaryDto withUserDto = new UserSummaryDto(targetUser.getId(), targetUser.getName(), targetUser.getProfileImageUrl());
 
         if (message == null) {
-            return new ConversationDto(conversation.getId(), witUserDto, null, false);
+            return new ConversationDto(conversation.getId(), withUserDto, null, false);
         }
 
         boolean isSenderMe = message.getAuthor().getId().equals(userId);
         UserSummaryDto meSummaryDto = new UserSummaryDto(userId, "me", null); // 아이디 외 정보 생략
 
-        UserSummaryDto sender = isSenderMe ? meSummaryDto : witUserDto;
-        UserSummaryDto receiver = isSenderMe ? witUserDto : meSummaryDto;
+        UserSummaryDto sender = isSenderMe ? meSummaryDto : withUserDto;
+        UserSummaryDto receiver = isSenderMe ? withUserDto : meSummaryDto;
 
         LastMessage lastMessageDto = new LastMessage(
                 message.getId(),
@@ -202,6 +202,6 @@ public class ConversationService {
         long lastReadMsgId = myStatus.getLastReadMessage() != null ? myStatus.getLastReadMessage().getId() : 0L;
         boolean hasUnread = lastReadMsgId < message.getId();
 
-        return new ConversationDto(conversation.getId(), witUserDto, lastMessageDto, hasUnread);
+        return new ConversationDto(conversation.getId(), withUserDto, lastMessageDto, hasUnread);
     }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/service/ConversationService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/service/ConversationService.java
@@ -1,6 +1,7 @@
 package com.mopl.domain.conversation.service;
 
 import com.mopl.domain.conversation.dto.request.ConversationCreateRequest;
+import com.mopl.domain.conversation.dto.request.ConversationSearchCondition;
 import com.mopl.domain.conversation.dto.response.ConversationDto;
 import com.mopl.domain.conversation.dto.response.LastMessage;
 import com.mopl.domain.conversation.entity.Conversation;
@@ -15,11 +16,14 @@ import com.mopl.domain.user.entity.User;
 import com.mopl.domain.user.exception.UserErrorCode;
 import com.mopl.domain.user.exception.UserException;
 import com.mopl.domain.user.repository.UserRepository;
+import com.mopl.global.dto.PageResponse;
+import com.querydsl.core.Tuple;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.mopl.domain.conversation.exception.ConversationErrorCode.CONVERSATION_NOT_FOUND;
@@ -118,5 +122,86 @@ public class ConversationService {
     private User getUserOrThrow(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_EXIST));
+    }
+
+    // 대화 목록 전체 조회 (커서 페이지네이션)
+    public PageResponse<ConversationDto> findMyAllConversations(ConversationSearchCondition searchCondition, long userId) {
+        String keyword = searchCondition.keywordLike();
+        LocalDateTime cursor = searchCondition.cursor();
+        Long idAfter = searchCondition.idAfter();
+        int limit = searchCondition.limit();
+
+        List<Tuple> myConversations = conversationRepository.findMyConversations(userId, keyword, cursor, idAfter, limit + 1);
+
+        boolean hasNext = false;
+        if (myConversations.size() > limit) {
+            hasNext = true;
+            myConversations.remove(limit);
+        }
+
+        List<ConversationDto> dtos = myConversations.stream()
+                .map(tuple -> convertToDto(tuple, userId))
+                .toList();
+
+        String nextCursor = null;
+        String nextIdAfter = null;
+
+        if (hasNext && !dtos.isEmpty()) {
+            ConversationDto lastConversation = dtos.get(dtos.size() - 1);
+
+            if (lastConversation.lastestMessage() != null) {
+                nextCursor = lastConversation.lastestMessage().createdAt().toString();
+            } else {
+                Tuple lastTuple = myConversations.get(myConversations.size() - 1);
+                Conversation lastEntity = lastTuple.get(0, Conversation.class);
+
+                nextCursor = lastEntity.getCreatedAt().toString();
+            }
+
+            nextIdAfter = lastConversation.id().toString();
+        }
+
+        return PageResponse.<ConversationDto>builder()
+                .data(dtos)
+                .nextCursor(nextCursor)
+                .nextIdAfter(nextIdAfter)
+                .hasNext(hasNext)
+                .totalCount(0)
+                .sortBy(searchCondition.sortBy())
+                .sortDirection(searchCondition.sortDirection())
+                .build();
+    }
+
+    private ConversationDto convertToDto(Tuple tuple, Long userId) {
+        Conversation conversation = tuple.get(0, Conversation.class);
+        User targetUser = tuple.get(1, User.class);
+        DirectMessage message = tuple.get(2, DirectMessage.class);
+        ReadStatus myStatus = tuple.get(3, ReadStatus.class);
+
+        UserSummaryDto witUserDto = new UserSummaryDto(targetUser.getId(), targetUser.getName(), targetUser.getProfileImageUrl());
+
+        if (message == null) {
+            return new ConversationDto(conversation.getId(), witUserDto, null, false);
+        }
+
+        boolean isSenderMe = message.getAuthor().getId().equals(userId);
+        UserSummaryDto meSummaryDto = new UserSummaryDto(userId, "me", null); // 아이디 외 정보 생략
+
+        UserSummaryDto sender = isSenderMe ? meSummaryDto : witUserDto;
+        UserSummaryDto receiver = isSenderMe ? witUserDto : meSummaryDto;
+
+        LastMessage lastMessageDto = new LastMessage(
+                message.getId(),
+                conversation.getId(),
+                message.getCreatedAt(),
+                sender,
+                receiver,
+                message.getContent()
+        );
+
+        long lastReadMsgId = myStatus.getLastReadMessage() != null ? myStatus.getLastReadMessage().getId() : 0L;
+        boolean hasUnread = lastReadMsgId < message.getId();
+
+        return new ConversationDto(conversation.getId(), witUserDto, lastMessageDto, hasUnread);
     }
 }

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ConversationRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ConversationRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-public interface ConversationRepository extends JpaRepository<Conversation, Long> {
+public interface ConversationRepository extends JpaRepository<Conversation, Long>, ConversationRepositoryCustom {
 
     @Query("""
             SELECT c FROM Conversation c

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ConversationRepositoryCustom.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ConversationRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.mopl.domain.conversation.repository;
+
+import com.querydsl.core.Tuple;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface ConversationRepositoryCustom {
+    List<Tuple> findMyConversations(Long userId, String keyword, LocalDateTime cursor, Long idAfter, int limit);
+}

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ConversationRepositoryCustomImpl.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ConversationRepositoryCustomImpl.java
@@ -1,0 +1,99 @@
+package com.mopl.domain.conversation.repository;
+
+import com.mopl.domain.conversation.entity.QDirectMessage;
+import com.mopl.domain.conversation.entity.QReadStatus;
+import com.mopl.domain.user.entity.QUser;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DateTimeExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.mopl.domain.conversation.entity.QConversation.conversation;
+
+@Repository
+@RequiredArgsConstructor
+public class ConversationRepositoryCustomImpl implements ConversationRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 내가 참여한 대화방 목록 조회
+     * - 정렬: 최신 메시지 시간 기준, 빈 대화방이면 대화방 생성일 사용
+     * - 조회: 상대방 정보, 최신 메시지, 나의 읽음 상태를 동시 조회
+     */
+    @Override
+    public List<Tuple> findMyConversations(Long userId, String keyword, LocalDateTime cursor, Long idAfter, int limit) {
+        QReadStatus myStatus = new QReadStatus("myStatus");
+        QReadStatus targetStatus = new QReadStatus("targetStatus");
+        QUser targetUser = new QUser("targetUser");
+        QDirectMessage message = new QDirectMessage("message");
+        QDirectMessage subMessage = new QDirectMessage("subMessage");
+
+        // 각 대화방의 최신 메시지 생성 시간
+        JPQLQuery<LocalDateTime> subquery = JPAExpressions
+                .select(subMessage.createdAt.max())
+                .from(subMessage)
+                .where(subMessage.conversation.eq(conversation));
+
+        // 메시지가 없는 방을 고려해 DM 시간이 null 이면 방 생성 시간을 사용
+        DateTimeExpression<LocalDateTime> sortDateTime = message.createdAt.coalesce(conversation.createdAt);
+
+        return queryFactory
+                .select(
+                        conversation,
+                        targetUser,
+                        message,
+                        myStatus
+                ).from(conversation)
+                // 로그인한 유저가 참여한 방
+                .join(myStatus).on(myStatus.conversation.eq(conversation).and(myStatus.user.id.eq(userId)))
+                // 대화 상대 정보
+                .join(targetStatus).on(targetStatus.conversation.eq(conversation).and(targetStatus.user.id.ne(userId)))
+                .join(targetUser).on(targetStatus.user.eq(targetUser))
+                // 최신 메시지 (메시지 없는 방 고려해 left join)
+                .leftJoin(message).on(message.conversation.eq(conversation).and(message.createdAt.eq(subquery)))
+                .where(
+                        keywordSearch(keyword, targetUser), // 검색어 조건
+                        cursorCondition(cursor, idAfter, sortDateTime) // 커서 조건
+                ).orderBy(sortDateTime.desc(), conversation.id.desc())
+                .limit(limit)
+                .fetch();
+    }
+
+    // 검색 조건 - 상대 이름 or 메시지 내용
+    private BooleanExpression keywordSearch(String keyword, QUser targetUser) {
+        if (keyword == null || keyword.isBlank()) {
+            return null;
+        }
+
+        BooleanExpression nameSearchCond = targetUser.name.contains(keyword);
+
+        QDirectMessage searchMessage = new QDirectMessage("searchMessage");
+        BooleanExpression messageSearchCond = JPAExpressions
+                .selectOne()
+                .from(searchMessage)
+                .where(searchMessage.conversation.eq(conversation)
+                        .and(searchMessage.content.contains(keyword)))
+                .exists();
+
+        return nameSearchCond.or(messageSearchCond);
+    }
+
+    // 커서 조건 - 1: 메시지 생성일 (없다면 대화방 생성일), 2: 대화방 id
+    private Predicate cursorCondition(LocalDateTime cursor, Long idAfter, DateTimeExpression<LocalDateTime> sortDateTime) {
+        if (cursor == null || idAfter == null) {
+            return null;
+        }
+
+        return sortDateTime.lt(cursor)
+                .or(sortDateTime.eq(cursor).and(conversation.id.lt(idAfter)));
+    }
+}


### PR DESCRIPTION
## 연관 이슈
close #37 

## 🔄 변경 사항
대화 목록 조회 API(`GET /api/conversations`) 추가 및 커서 페이징 적용

## 🧩 작업 사항
- QueryDSL 기반 대화 목록 조회 리포지토리 구현
  - 대화방, 사용자, 메시지, 읽음 상태를 한 번에 조회 (Tuple 반환, N+1 문제 방지)
- 동적 정렬 로직
  - 메시지 있는 방은 최신 메시지 생성일 기준
  - 메시지 없는 방은 대화방 생성일 기준
- 상대방 이름, 대화 내용 통합 검색 기능 
- 커서 기반 페이징 처리

## ⭐️ TODO
- 조회 성능 향상을 위한 인덱스 추가 필요

## 📸 스크린샷
- [노션 참고](https://mud-casquette-c34.notion.site/2e228815f6f2809b8f83f47971ad7beb?source=copy_link)