### PR TITLE
[FEAT] Auth - 비밀번호 초기화 API 구현, 임시 비밀번호 발급 및 이메일 전송

### DIFF
--- a/mopl-api/build.gradle
+++ b/mopl-api/build.gradle
@@ -42,6 +42,10 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
 
+    // Email
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/mopl-api/src/main/java/com/mopl/domain/auth/controller/AuthController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/controller/AuthController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @RestController
 @RequestMapping("/api/auth")

--- a/mopl-api/src/main/java/com/mopl/domain/auth/controller/AuthController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/controller/AuthController.java
@@ -22,7 +22,7 @@ public class AuthController {
     private final EmailService emailService;
 
     @PostMapping("/sign-in")
-    public ResponseEntity<JwtDto> login(@RequestBody SignInRequest req, HttpServletResponse response) {
+    public ResponseEntity<JwtDto> login(@ModelAttribute SignInRequest req, HttpServletResponse response) {
         JwtDto jwtDto = authService.login(req.username(), req.password(), response);
         return ResponseEntity.ok(jwtDto);
     }

--- a/mopl-api/src/main/java/com/mopl/domain/auth/controller/AuthController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/controller/AuthController.java
@@ -1,9 +1,12 @@
 package com.mopl.domain.auth.controller;
 
 import com.mopl.domain.auth.dto.JwtDto;
+import com.mopl.domain.auth.dto.ResetPasswordRequest;
 import com.mopl.domain.auth.dto.SignInRequest;
 import com.mopl.domain.auth.service.AuthService;
+import com.mopl.domain.auth.service.EmailService;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AuthController {
     private final AuthService authService;
+    private final EmailService emailService;
 
     @PostMapping("/sign-in")
     public ResponseEntity<JwtDto> login(@RequestBody SignInRequest req, HttpServletResponse response) {
@@ -26,6 +30,12 @@ public class AuthController {
     @PostMapping("/sign-out")
     public ResponseEntity<?> logout(HttpServletResponse response) {
         authService.logout(response);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/reset-password")
+    public ResponseEntity<Void> resetPassword(@Valid @RequestBody ResetPasswordRequest req) {
+        emailService.resetPassword(req.email());
         return ResponseEntity.ok().build();
     }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/auth/dto/ResetPasswordRequest.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/dto/ResetPasswordRequest.java
@@ -1,0 +1,11 @@
+package com.mopl.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record ResetPasswordRequest(
+        @Email
+        @NotBlank
+        String email
+) {
+}

--- a/mopl-api/src/main/java/com/mopl/domain/auth/service/EmailService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/service/EmailService.java
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
 
@@ -28,18 +27,13 @@ public class EmailService {
     @Value("${spring.mail.username}")
     private String moplEmail;
 
-    @Transactional
     public void resetPassword(String email) {
-        // 이메일 검증
         emailValid(email);
-        // 임시 비밀번호 생성
         String temporaryPassword = createTemporaryPassword(10);
-
         // TODO: Redis에 저장
-
-        // 이메일 전송
         sendEmail(email, temporaryPassword);
     }
+
 
     /** 이메일 전송 */
     private void sendEmail(String email, String temporaryPassword) {
@@ -76,8 +70,11 @@ public class EmailService {
         return sb.toString();
     }
 
+    /** 이메일 검증 */
     private void emailValid(String email) {
         userRepository.findByEmail(email)
         .orElseThrow(() -> new UserException(UserErrorCode.EMAIL_NOT_EXIST));
     }
+
+
 }

--- a/mopl-api/src/main/java/com/mopl/domain/auth/service/EmailService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/service/EmailService.java
@@ -1,5 +1,8 @@
 package com.mopl.domain.auth.service;
 
+import com.mopl.domain.user.exception.UserErrorCode;
+import com.mopl.domain.user.exception.UserException;
+import com.mopl.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -20,12 +23,15 @@ public class EmailService {
     private final JavaMailSender mailSender;
     private final SecureRandom random = new SecureRandom();
     private final SpringTemplateEngine templateEngine;
+    private final UserRepository userRepository;
 
     @Value("${spring.mail.username}")
     private String moplEmail;
 
     @Transactional
     public void resetPassword(String email) {
+        // 이메일 검증
+        emailValid(email);
         // 임시 비밀번호 생성
         String temporaryPassword = createTemporaryPassword(10);
 
@@ -33,7 +39,6 @@ public class EmailService {
 
         // 이메일 전송
         sendEmail(email, temporaryPassword);
-
     }
 
     /** 이메일 전송 */
@@ -69,5 +74,10 @@ public class EmailService {
         }
 
         return sb.toString();
+    }
+
+    private void emailValid(String email) {
+        userRepository.findByEmail(email)
+        .orElseThrow(() -> new UserException(UserErrorCode.EMAIL_NOT_EXIST));
     }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/auth/service/EmailService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/service/EmailService.java
@@ -1,0 +1,73 @@
+package com.mopl.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+import java.security.SecureRandom;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+    private final SecureRandom random = new SecureRandom();
+    private final SpringTemplateEngine templateEngine;
+
+    @Value("${spring.mail.username}")
+    private String moplEmail;
+
+    @Transactional
+    public void resetPassword(String email) {
+        // 임시 비밀번호 생성
+        String temporaryPassword = createTemporaryPassword(10);
+
+        // TODO: Redis에 저장
+
+        // 이메일 전송
+        sendEmail(email, temporaryPassword);
+
+    }
+
+    /** 이메일 전송 */
+    private void sendEmail(String email, String temporaryPassword) {
+        var message = mailSender.createMimeMessage();
+
+        try {
+            var helper = new MimeMessageHelper(message, false, "UTF-8");
+            helper.setFrom(moplEmail, "모두의 플리");
+            helper.setTo(email);
+            helper.setSubject("임시 비밀번호가 발급되었습니다.");
+
+            Context context = new Context();
+            context.setVariable("temporaryPassword", temporaryPassword);
+            String emailTemplate = templateEngine.process("reset-password", context);
+
+            helper.setText(emailTemplate, true);
+
+            mailSender.send(message);
+        } catch (Exception e) {
+            log.error("Error occurred while sending email", e);
+        }
+    }
+
+    /** 임시 비밀번호 생성 */
+    private String createTemporaryPassword(int length) {
+        StringBuilder sb = new StringBuilder(length);
+        String PASSWORD_ALLOW_CHARS = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnpqrstuvwxyz23456789!@#$";
+
+        for (int i = 0; i < length; i++) {
+            int randomIndex = random.nextInt(PASSWORD_ALLOW_CHARS.length());
+            sb.append(PASSWORD_ALLOW_CHARS.charAt(randomIndex));
+        }
+
+        return sb.toString();
+    }
+}

--- a/mopl-api/src/main/java/com/mopl/domain/user/exception/UserErrorCode.java
+++ b/mopl-api/src/main/java/com/mopl/domain/user/exception/UserErrorCode.java
@@ -11,6 +11,7 @@ public enum UserErrorCode {
     USER_NOT_EXIST("U001", "존재하지 않는 사용자 입니다.", HttpStatus.NOT_FOUND),
     PASSWORD_NOT_CORRECT("U002", "비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
     DUPLICATE_USER("U003","이미 존재하는 사용자입니다.", HttpStatus.CONFLICT),
+    EMAIL_NOT_EXIST("U004", "존재하지 않는 이메일 입니다.", HttpStatus.NOT_FOUND)
     ;
 
     private final String errorCode;

--- a/mopl-api/src/main/resources/application.yml
+++ b/mopl-api/src/main/resources/application.yml
@@ -15,6 +15,19 @@ spring:
       max-file-size: 10MB
       max-request-size: 10MB
 
+  # Email
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${GOOGLE_MAIL_USERNAME}
+    password: ${GOOGLE_MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+         auth: true
+         starttls:
+          enable: true
+
 # swagger
 springdoc:
   api-docs:

--- a/mopl-api/src/main/resources/templates/reset-password.html
+++ b/mopl-api/src/main/resources/templates/reset-password.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+</head>
+<body style="font-family: 'Apple SD Gothic Neo', sans-serif; margin: 0; padding: 0;">
+<div style="max-width: 600px; margin: 20px auto; padding: 40px; border: 1px solid #f0f0f0; border-radius: 16px; background-color: #ffffff;">
+    <h2 style="color: #1a1a1a; font-size: 24px; font-weight: 700; margin-bottom: 24px;">임시 비밀번호 발급 안내</h2>
+
+    <p style="color: #4a4a4a; font-size: 16px; line-height: 1.6; margin-bottom: 32px;">
+        안녕하세요, <strong>모두의 플리</strong>입니다.<br/>
+        요청하신 임시 비밀번호가 아래와 같이 안전하게 발급되었습니다.
+    </p>
+
+    <div style="background-color: #f8f9fa; border-radius: 12px; padding: 30px; text-align: center; margin-bottom: 32px;">
+        <p style="color: #888; font-size: 14px; margin-bottom: 8px;">임시 비밀번호</p>
+        <span style="color: #007aff; font-size: 32px; font-weight: 800; letter-spacing: 2px;" th:text="${temporaryPassword}">PASSWORD123</span>
+    </div>
+
+    <p style="color: #d93025; font-size: 14px; margin-bottom: 40px;">
+        * 보안을 위해 로그인 후 반드시 비밀번호를 변경해 주세요.
+    </p>
+
+    <div style="border-top: 1px solid #eee; padding-top: 24px;">
+        <p style="color: #999; font-size: 12px; line-height: 1.5;">
+            본 메일은 발신 전용입니다. 문의 사항이 있으시면 고객 센터를 이용해 주세요.<br/>
+            &copy; 모두의 플리. All rights reserved.
+        </p>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 연관 이슈
close #95 

## 🔄 변경 사항
- 비밀번호 초기화 API 구현
- 임시 비밀번호 발급 메서드
- 이메일 전송

## 🧩 작업 사항
- 일단 제 이메일 계정으로 만들었습니다.
- `build.gradle` 의존성이 반드시 있어야 합니다.
- `aplication.yml` 에 이메일 관련 설정이 있어야 하며, 키는 디스코드 중요자료에 올린 .env 파일을 참고하시면 됩니다.
- [mopl-api/src/main/resources/templates 경로에 `reset-password.html` 정적 리소스가 반드시 있어야 합니다.
- api 테스트 결과 이메일이 정상적으로 오는것을 확인했으며 스크린샷에 따로 첨부했습니다.
- radis에 저장은 미구현 되어 있으며(TODO) 이메일 전송만 구현되어 있습니다.
- 추후 radis 설정이 되면 로직 구현 예정

## 📸 스크린샷
<img width="751" height="583" alt="스크린샷 2026-01-09 오후 2 36 49" src="https://github.com/user-attachments/assets/10ffd667-237a-45fe-a6d7-6980661499f1" />
