### PR TITLE
[FEAT] Playlist - 목록/구독/콘텐츠 기능 구현

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/playlist/controller/PlaylistController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/playlist/controller/PlaylistController.java
@@ -1,35 +1,37 @@
 package com.mopl.domain.playlist.controller;
 
+import com.mopl.domain.auth.dto.UserPrincipal;
 import com.mopl.domain.playlist.controller.docs.PlaylistControllerDocs;
 import com.mopl.domain.playlist.dto.request.PlaylistCreateRequest;
 import com.mopl.domain.playlist.dto.request.PlaylistUpdateRequest;
 import com.mopl.domain.playlist.dto.response.PlaylistDto;
 import com.mopl.domain.playlist.service.PlaylistService;
+import com.mopl.domain.user.entity.User;
+import com.mopl.domain.user.repository.UserRepository;
 import com.mopl.global.dto.PageResponse;
 import com.mopl.global.enums.SortDirection;
 import com.mopl.global.exception.ErrorCode;
 import com.mopl.global.exception.MoplException;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 
-@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/playlists")
+@Validated
 public class PlaylistController implements PlaylistControllerDocs {
 
     private final PlaylistService playlistService;
+    private final UserRepository userRepository;
 
-    // 1) GET /api/playlists
-    @GetMapping
     @Override
+    @GetMapping
     public ResponseEntity<PageResponse<PlaylistDto>> findAll(
             Principal principal,
             @RequestParam(required = false) String keywordLike,
@@ -37,11 +39,11 @@ public class PlaylistController implements PlaylistControllerDocs {
             @RequestParam(required = false) Long subscriberIdEqual,
             @RequestParam(required = false) String cursor,
             @RequestParam(required = false) String idAfter,
-            @RequestParam(defaultValue = "20") @Min(1) @Max(100) Integer limit,
-            @RequestParam(defaultValue = "DESCENDING") SortDirection sortDirection,
-            @RequestParam(defaultValue = "updatedAt") String sortBy
+            @RequestParam(required = false) Integer limit,
+            @RequestParam(required = false) SortDirection sortDirection,
+            @RequestParam(required = false) String sortBy
     ) {
-        Long requesterId = requireUserId(principal);
+        Long requesterId = resolveRequesterId(principal);
 
         return ResponseEntity.ok(
                 playlistService.findAll(
@@ -58,120 +60,105 @@ public class PlaylistController implements PlaylistControllerDocs {
         );
     }
 
-    // 2) POST /api/playlists
-    @PostMapping
     @Override
+    @PostMapping
     public ResponseEntity<PlaylistDto> create(
             Principal principal,
-            @RequestBody @Valid PlaylistCreateRequest request
+            @Valid @RequestBody PlaylistCreateRequest request
     ) {
-        Long requesterId = requireUserId(principal);
-
-        PlaylistDto response = playlistService.create(requesterId, request);
-        return ResponseEntity.status(201).body(response);
+        Long requesterId = resolveRequesterId(principal);
+        return ResponseEntity.ok(playlistService.create(requesterId, request));
     }
 
-    // 3) POST /api/playlists/{playlistId}/subscription
-    @PostMapping("/{playlistId}/subscription")
     @Override
-    public ResponseEntity<Void> subscribe(
-            Principal principal,
-            @PathVariable Long playlistId
-    ) {
-        Long requesterId = requireUserId(principal);
-
+    @PostMapping("/{playlistId}/subscription")
+    public ResponseEntity<Void> subscribe(Principal principal, @PathVariable Long playlistId) {
+        Long requesterId = resolveRequesterId(principal);
         playlistService.subscribe(requesterId, playlistId);
         return ResponseEntity.noContent().build();
     }
 
-    // 4) DELETE /api/playlists/{playlistId}/subscription
-    @DeleteMapping("/{playlistId}/subscription")
     @Override
-    public ResponseEntity<Void> unsubscribe(
-            Principal principal,
-            @PathVariable Long playlistId
-    ) {
-        Long requesterId = requireUserId(principal);
-
+    @DeleteMapping("/{playlistId}/subscription")
+    public ResponseEntity<Void> unsubscribe(Principal principal, @PathVariable Long playlistId) {
+        Long requesterId = resolveRequesterId(principal);
         playlistService.unsubscribe(requesterId, playlistId);
         return ResponseEntity.noContent().build();
     }
 
-    // 5) POST /api/playlists/{playlistId}/contents/{contentId}
-    @PostMapping("/{playlistId}/contents/{contentId}")
     @Override
+    @PostMapping("/{playlistId}/contents/{contentId}")
     public ResponseEntity<Void> addContent(
             Principal principal,
             @PathVariable Long playlistId,
             @PathVariable Long contentId
     ) {
-        Long requesterId = requireUserId(principal);
-
+        Long requesterId = resolveRequesterId(principal);
         playlistService.addContent(requesterId, playlistId, contentId);
         return ResponseEntity.noContent().build();
     }
 
-    // 6) DELETE /api/playlists/{playlistId}/contents/{contentId}
-    @DeleteMapping("/{playlistId}/contents/{contentId}")
     @Override
+    @DeleteMapping("/{playlistId}/contents/{contentId}")
     public ResponseEntity<Void> removeContent(
             Principal principal,
             @PathVariable Long playlistId,
             @PathVariable Long contentId
     ) {
-        Long requesterId = requireUserId(principal);
-
+        Long requesterId = resolveRequesterId(principal);
         playlistService.removeContent(requesterId, playlistId, contentId);
         return ResponseEntity.noContent().build();
     }
 
-    // 7) GET /api/playlists/{playlistId}
-    @GetMapping("/{playlistId}")
     @Override
-    public ResponseEntity<PlaylistDto> find(
-            Principal principal,
-            @PathVariable Long playlistId
-    ) {
-        Long requesterId = requireUserId(principal);
-
+    @GetMapping("/{playlistId}")
+    public ResponseEntity<PlaylistDto> find(Principal principal, @PathVariable Long playlistId) {
+        Long requesterId = resolveRequesterId(principal);
         return ResponseEntity.ok(playlistService.find(requesterId, playlistId));
     }
 
-    // 8) DELETE /api/playlists/{playlistId}
-    @DeleteMapping("/{playlistId}")
     @Override
-    public ResponseEntity<Void> delete(
-            Principal principal,
-            @PathVariable Long playlistId
-    ) {
-        Long requesterId = requireUserId(principal);
-
+    @DeleteMapping("/{playlistId}")
+    public ResponseEntity<Void> delete(Principal principal, @PathVariable Long playlistId) {
+        Long requesterId = resolveRequesterId(principal);
         playlistService.delete(requesterId, playlistId);
         return ResponseEntity.noContent().build();
     }
 
-    // 9) PATCH /api/playlists/{playlistId}
-    @PatchMapping("/{playlistId}")
     @Override
+    @PatchMapping("/{playlistId}")
     public ResponseEntity<PlaylistDto> update(
             Principal principal,
             @PathVariable Long playlistId,
-            @RequestBody @Valid PlaylistUpdateRequest request
+            @Valid @RequestBody PlaylistUpdateRequest request
     ) {
-        Long requesterId = requireUserId(principal);
-
+        Long requesterId = resolveRequesterId(principal);
         return ResponseEntity.ok(playlistService.update(requesterId, playlistId, request));
     }
 
-    // JWT 인증 주체에서 userId 꺼내기 (FollowController 방식과 동일)
-    private Long requireUserId(Principal principal) {
-        if (principal == null || principal.getName() == null || principal.getName().isBlank()) {
+    private Long resolveRequesterId(Principal principal) {
+        if (principal == null) {
             throw new MoplException(ErrorCode.UNAUTHORIZED);
         }
-        try {
-            return Long.parseLong(principal.getName());
-        } catch (NumberFormatException e) {
+        if (principal instanceof Authentication authentication) {
+            Object authPrincipal = authentication.getPrincipal();
+            if (authPrincipal instanceof UserPrincipal userPrincipal) {
+                return userPrincipal.getUserId();
+            }
+        }
+
+        String name = principal.getName();
+        if (name == null || name.isBlank()) {
             throw new MoplException(ErrorCode.UNAUTHORIZED);
         }
+
+        boolean isNumeric = name.chars().allMatch(Character::isDigit);
+        if (isNumeric) {
+            return Long.parseLong(name);
+        }
+
+        User user = userRepository.findByEmail(name)
+                .orElseThrow(() -> new MoplException(ErrorCode.UNAUTHORIZED));
+        return user.getId();
     }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/playlist/controller/PlaylistController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/playlist/controller/PlaylistController.java
@@ -7,6 +7,8 @@ import com.mopl.domain.playlist.dto.response.PlaylistDto;
 import com.mopl.domain.playlist.service.PlaylistService;
 import com.mopl.global.dto.PageResponse;
 import com.mopl.global.enums.SortDirection;
+import com.mopl.global.exception.ErrorCode;
+import com.mopl.global.exception.MoplException;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -14,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
 
 @Validated
 @RestController
@@ -27,7 +31,7 @@ public class PlaylistController implements PlaylistControllerDocs {
     @GetMapping
     @Override
     public ResponseEntity<PageResponse<PlaylistDto>> findAll(
-            @RequestHeader(value = "X-User-Id", required = false) Long requesterId,
+            Principal principal,
             @RequestParam(required = false) String keywordLike,
             @RequestParam(required = false) Long ownerIdEqual,
             @RequestParam(required = false) Long subscriberIdEqual,
@@ -37,10 +41,19 @@ public class PlaylistController implements PlaylistControllerDocs {
             @RequestParam(defaultValue = "DESCENDING") SortDirection sortDirection,
             @RequestParam(defaultValue = "updatedAt") String sortBy
     ) {
+        Long requesterId = requireUserId(principal);
+
         return ResponseEntity.ok(
                 playlistService.findAll(
-                        requesterId, keywordLike, ownerIdEqual, subscriberIdEqual,
-                        cursor, idAfter, limit, sortBy, sortDirection
+                        requesterId,
+                        keywordLike,
+                        ownerIdEqual,
+                        subscriberIdEqual,
+                        cursor,
+                        idAfter,
+                        limit,
+                        sortBy,
+                        sortDirection
                 )
         );
     }
@@ -49,9 +62,11 @@ public class PlaylistController implements PlaylistControllerDocs {
     @PostMapping
     @Override
     public ResponseEntity<PlaylistDto> create(
-            @RequestHeader(value = "X-User-Id", required = false) Long requesterId,
+            Principal principal,
             @RequestBody @Valid PlaylistCreateRequest request
     ) {
+        Long requesterId = requireUserId(principal);
+
         PlaylistDto response = playlistService.create(requesterId, request);
         return ResponseEntity.status(201).body(response);
     }
@@ -60,9 +75,11 @@ public class PlaylistController implements PlaylistControllerDocs {
     @PostMapping("/{playlistId}/subscription")
     @Override
     public ResponseEntity<Void> subscribe(
-            @RequestHeader(value = "X-User-Id", required = false) Long requesterId,
+            Principal principal,
             @PathVariable Long playlistId
     ) {
+        Long requesterId = requireUserId(principal);
+
         playlistService.subscribe(requesterId, playlistId);
         return ResponseEntity.noContent().build();
     }
@@ -71,9 +88,11 @@ public class PlaylistController implements PlaylistControllerDocs {
     @DeleteMapping("/{playlistId}/subscription")
     @Override
     public ResponseEntity<Void> unsubscribe(
-            @RequestHeader(value = "X-User-Id", required = false) Long requesterId,
+            Principal principal,
             @PathVariable Long playlistId
     ) {
+        Long requesterId = requireUserId(principal);
+
         playlistService.unsubscribe(requesterId, playlistId);
         return ResponseEntity.noContent().build();
     }
@@ -82,10 +101,12 @@ public class PlaylistController implements PlaylistControllerDocs {
     @PostMapping("/{playlistId}/contents/{contentId}")
     @Override
     public ResponseEntity<Void> addContent(
-            @RequestHeader(value = "X-User-Id", required = false) Long requesterId,
+            Principal principal,
             @PathVariable Long playlistId,
             @PathVariable Long contentId
     ) {
+        Long requesterId = requireUserId(principal);
+
         playlistService.addContent(requesterId, playlistId, contentId);
         return ResponseEntity.noContent().build();
     }
@@ -94,10 +115,12 @@ public class PlaylistController implements PlaylistControllerDocs {
     @DeleteMapping("/{playlistId}/contents/{contentId}")
     @Override
     public ResponseEntity<Void> removeContent(
-            @RequestHeader(value = "X-User-Id", required = false) Long requesterId,
+            Principal principal,
             @PathVariable Long playlistId,
             @PathVariable Long contentId
     ) {
+        Long requesterId = requireUserId(principal);
+
         playlistService.removeContent(requesterId, playlistId, contentId);
         return ResponseEntity.noContent().build();
     }
@@ -106,9 +129,11 @@ public class PlaylistController implements PlaylistControllerDocs {
     @GetMapping("/{playlistId}")
     @Override
     public ResponseEntity<PlaylistDto> find(
-            @RequestHeader(value = "X-User-Id", required = false) Long requesterId,
+            Principal principal,
             @PathVariable Long playlistId
     ) {
+        Long requesterId = requireUserId(principal);
+
         return ResponseEntity.ok(playlistService.find(requesterId, playlistId));
     }
 
@@ -116,9 +141,11 @@ public class PlaylistController implements PlaylistControllerDocs {
     @DeleteMapping("/{playlistId}")
     @Override
     public ResponseEntity<Void> delete(
-            @RequestHeader(value = "X-User-Id", required = false) Long requesterId,
+            Principal principal,
             @PathVariable Long playlistId
     ) {
+        Long requesterId = requireUserId(principal);
+
         playlistService.delete(requesterId, playlistId);
         return ResponseEntity.noContent().build();
     }
@@ -127,10 +154,24 @@ public class PlaylistController implements PlaylistControllerDocs {
     @PatchMapping("/{playlistId}")
     @Override
     public ResponseEntity<PlaylistDto> update(
-            @RequestHeader(value = "X-User-Id", required = false) Long requesterId,
+            Principal principal,
             @PathVariable Long playlistId,
             @RequestBody @Valid PlaylistUpdateRequest request
     ) {
+        Long requesterId = requireUserId(principal);
+
         return ResponseEntity.ok(playlistService.update(requesterId, playlistId, request));
+    }
+
+    // JWT 인증 주체에서 userId 꺼내기 (FollowController 방식과 동일)
+    private Long requireUserId(Principal principal) {
+        if (principal == null || principal.getName() == null || principal.getName().isBlank()) {
+            throw new MoplException(ErrorCode.UNAUTHORIZED);
+        }
+        try {
+            return Long.parseLong(principal.getName());
+        } catch (NumberFormatException e) {
+            throw new MoplException(ErrorCode.UNAUTHORIZED);
+        }
     }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/playlist/controller/PlaylistController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/playlist/controller/PlaylistController.java
@@ -6,34 +6,25 @@ import com.mopl.domain.playlist.dto.request.PlaylistCreateRequest;
 import com.mopl.domain.playlist.dto.request.PlaylistUpdateRequest;
 import com.mopl.domain.playlist.dto.response.PlaylistDto;
 import com.mopl.domain.playlist.service.PlaylistService;
-import com.mopl.domain.user.entity.User;
-import com.mopl.domain.user.repository.UserRepository;
 import com.mopl.global.dto.PageResponse;
 import com.mopl.global.enums.SortDirection;
-import com.mopl.global.exception.ErrorCode;
-import com.mopl.global.exception.MoplException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.validation.annotation.Validated;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.security.Principal;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/playlists")
-@Validated
 public class PlaylistController implements PlaylistControllerDocs {
 
     private final PlaylistService playlistService;
-    private final UserRepository userRepository;
 
     @Override
     @GetMapping
     public ResponseEntity<PageResponse<PlaylistDto>> findAll(
-            Principal principal,
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
             @RequestParam(required = false) String keywordLike,
             @RequestParam(required = false) Long ownerIdEqual,
             @RequestParam(required = false) Long subscriberIdEqual,
@@ -43,7 +34,7 @@ public class PlaylistController implements PlaylistControllerDocs {
             @RequestParam(required = false) SortDirection sortDirection,
             @RequestParam(required = false) String sortBy
     ) {
-        Long requesterId = resolveRequesterId(principal);
+        Long requesterId = userPrincipal.getUserId();
 
         return ResponseEntity.ok(
                 playlistService.findAll(
@@ -63,25 +54,31 @@ public class PlaylistController implements PlaylistControllerDocs {
     @Override
     @PostMapping
     public ResponseEntity<PlaylistDto> create(
-            Principal principal,
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Valid @RequestBody PlaylistCreateRequest request
     ) {
-        Long requesterId = resolveRequesterId(principal);
+        Long requesterId = userPrincipal.getUserId();
         return ResponseEntity.ok(playlistService.create(requesterId, request));
     }
 
     @Override
     @PostMapping("/{playlistId}/subscription")
-    public ResponseEntity<Void> subscribe(Principal principal, @PathVariable Long playlistId) {
-        Long requesterId = resolveRequesterId(principal);
+    public ResponseEntity<Void> subscribe(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long playlistId
+    ) {
+        Long requesterId = userPrincipal.getUserId();
         playlistService.subscribe(requesterId, playlistId);
         return ResponseEntity.noContent().build();
     }
 
     @Override
     @DeleteMapping("/{playlistId}/subscription")
-    public ResponseEntity<Void> unsubscribe(Principal principal, @PathVariable Long playlistId) {
-        Long requesterId = resolveRequesterId(principal);
+    public ResponseEntity<Void> unsubscribe(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long playlistId
+    ) {
+        Long requesterId = userPrincipal.getUserId();
         playlistService.unsubscribe(requesterId, playlistId);
         return ResponseEntity.noContent().build();
     }
@@ -89,11 +86,11 @@ public class PlaylistController implements PlaylistControllerDocs {
     @Override
     @PostMapping("/{playlistId}/contents/{contentId}")
     public ResponseEntity<Void> addContent(
-            Principal principal,
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long playlistId,
             @PathVariable Long contentId
     ) {
-        Long requesterId = resolveRequesterId(principal);
+        Long requesterId = userPrincipal.getUserId();
         playlistService.addContent(requesterId, playlistId, contentId);
         return ResponseEntity.noContent().build();
     }
@@ -101,26 +98,32 @@ public class PlaylistController implements PlaylistControllerDocs {
     @Override
     @DeleteMapping("/{playlistId}/contents/{contentId}")
     public ResponseEntity<Void> removeContent(
-            Principal principal,
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long playlistId,
             @PathVariable Long contentId
     ) {
-        Long requesterId = resolveRequesterId(principal);
+        Long requesterId = userPrincipal.getUserId();
         playlistService.removeContent(requesterId, playlistId, contentId);
         return ResponseEntity.noContent().build();
     }
 
     @Override
     @GetMapping("/{playlistId}")
-    public ResponseEntity<PlaylistDto> find(Principal principal, @PathVariable Long playlistId) {
-        Long requesterId = resolveRequesterId(principal);
+    public ResponseEntity<PlaylistDto> find(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long playlistId
+    ) {
+        Long requesterId = userPrincipal.getUserId();
         return ResponseEntity.ok(playlistService.find(requesterId, playlistId));
     }
 
     @Override
     @DeleteMapping("/{playlistId}")
-    public ResponseEntity<Void> delete(Principal principal, @PathVariable Long playlistId) {
-        Long requesterId = resolveRequesterId(principal);
+    public ResponseEntity<Void> delete(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable Long playlistId
+    ) {
+        Long requesterId = userPrincipal.getUserId();
         playlistService.delete(requesterId, playlistId);
         return ResponseEntity.noContent().build();
     }
@@ -128,37 +131,11 @@ public class PlaylistController implements PlaylistControllerDocs {
     @Override
     @PatchMapping("/{playlistId}")
     public ResponseEntity<PlaylistDto> update(
-            Principal principal,
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
             @PathVariable Long playlistId,
             @Valid @RequestBody PlaylistUpdateRequest request
     ) {
-        Long requesterId = resolveRequesterId(principal);
+        Long requesterId = userPrincipal.getUserId();
         return ResponseEntity.ok(playlistService.update(requesterId, playlistId, request));
-    }
-
-    private Long resolveRequesterId(Principal principal) {
-        if (principal == null) {
-            throw new MoplException(ErrorCode.UNAUTHORIZED);
-        }
-        if (principal instanceof Authentication authentication) {
-            Object authPrincipal = authentication.getPrincipal();
-            if (authPrincipal instanceof UserPrincipal userPrincipal) {
-                return userPrincipal.getUserId();
-            }
-        }
-
-        String name = principal.getName();
-        if (name == null || name.isBlank()) {
-            throw new MoplException(ErrorCode.UNAUTHORIZED);
-        }
-
-        boolean isNumeric = name.chars().allMatch(Character::isDigit);
-        if (isNumeric) {
-            return Long.parseLong(name);
-        }
-
-        User user = userRepository.findByEmail(name)
-                .orElseThrow(() -> new MoplException(ErrorCode.UNAUTHORIZED));
-        return user.getId();
     }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/playlist/controller/docs/PlaylistControllerDocs.java
+++ b/mopl-api/src/main/java/com/mopl/domain/playlist/controller/docs/PlaylistControllerDocs.java
@@ -1,5 +1,6 @@
 package com.mopl.domain.playlist.controller.docs;
 
+import com.mopl.domain.auth.dto.UserPrincipal;
 import com.mopl.domain.playlist.dto.request.PlaylistCreateRequest;
 import com.mopl.domain.playlist.dto.request.PlaylistUpdateRequest;
 import com.mopl.domain.playlist.dto.response.PlaylistDto;
@@ -13,9 +14,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
-
-import java.security.Principal;
 
 @Tag(name = "플레이리스트 관리", description = "플레이리스트 관련 API")
 public interface PlaylistControllerDocs {
@@ -23,12 +23,11 @@ public interface PlaylistControllerDocs {
     @Operation(summary = "플레이리스트 목록 조회 (커서 페이지네이션)")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
             @ApiResponse(responseCode = "401", description = "인증 오류"),
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     ResponseEntity<PageResponse<PlaylistDto>> findAll(
-            @Parameter(hidden = true) Principal principal,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(description = "검색 키워드") String keywordLike,
             @Parameter(description = "소유자 ID") Long ownerIdEqual,
             @Parameter(description = "구독자 ID") Long subscriberIdEqual,
@@ -37,75 +36,65 @@ public interface PlaylistControllerDocs {
             @Parameter(description = "한 번에 가져올 개수") Integer limit,
             @Parameter(schema = @Schema(allowableValues = {"ASCENDING", "DESCENDING"}))
             SortDirection sortDirection,
-            @Parameter(schema = @Schema(allowableValues = {"updatedAt", "subscribeCount", "subscriberCount"}))
-            String sortBy
+            @Parameter(description = "정렬 기준(예: updatedAt 등)") String sortBy
     );
 
-    @Operation(summary = "플레이리스트 생성", description = "생성한 플레이리스트는 API 요청자 본인의 플레이리리스트로 생성됩니다.")
+    @Operation(summary = "플레이리스트 생성")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공"),
-            @ApiResponse(responseCode = "201", description = "성공"),
             @ApiResponse(responseCode = "400", description = "잘못된 요청"),
             @ApiResponse(responseCode = "401", description = "인증 오류"),
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     ResponseEntity<PlaylistDto> create(
-            @Parameter(hidden = true) Principal principal,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Valid @RequestBody PlaylistCreateRequest request
     );
 
     @Operation(summary = "플레이리스트 구독")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "성공"),
             @ApiResponse(responseCode = "204", description = "성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
             @ApiResponse(responseCode = "401", description = "인증 오류"),
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     ResponseEntity<Void> subscribe(
-            @Parameter(hidden = true) Principal principal,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(description = "playlistId") Long playlistId
     );
 
     @Operation(summary = "플레이리스트 구독 취소")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "성공"),
             @ApiResponse(responseCode = "204", description = "성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
             @ApiResponse(responseCode = "401", description = "인증 오류"),
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     ResponseEntity<Void> unsubscribe(
-            @Parameter(hidden = true) Principal principal,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(description = "playlistId") Long playlistId
     );
 
-    @Operation(summary = "플레이리스트에 콘텐츠 추가", description = "플레이리스트 소유자만 콘텐츠를 추가할 수 있습니다.")
+    @Operation(summary = "플레이리스트에 콘텐츠 추가")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "성공"),
             @ApiResponse(responseCode = "204", description = "성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
             @ApiResponse(responseCode = "401", description = "인증 오류"),
             @ApiResponse(responseCode = "403", description = "권한 오류"),
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     ResponseEntity<Void> addContent(
-            @Parameter(hidden = true) Principal principal,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(description = "playlistId") Long playlistId,
             @Parameter(description = "contentId") Long contentId
     );
 
-    @Operation(summary = "플레이리스트에서 콘텐츠 삭제", description = "플레이리스트 소유자만 콘텐츠를 삭제할 수 있습니다.")
+    @Operation(summary = "플레이리스트에서 콘텐츠 삭제")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "성공"),
             @ApiResponse(responseCode = "204", description = "성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
             @ApiResponse(responseCode = "401", description = "인증 오류"),
             @ApiResponse(responseCode = "403", description = "권한 오류"),
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     ResponseEntity<Void> removeContent(
-            @Parameter(hidden = true) Principal principal,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(description = "playlistId") Long playlistId,
             @Parameter(description = "contentId") Long contentId
     );
@@ -113,29 +102,27 @@ public interface PlaylistControllerDocs {
     @Operation(summary = "플레이리스트 단건 조회")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
             @ApiResponse(responseCode = "401", description = "인증 오류"),
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     ResponseEntity<PlaylistDto> find(
-            @Parameter(hidden = true) Principal principal,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(description = "playlistId") Long playlistId
     );
 
-    @Operation(summary = "플레이리스트 삭제", description = "플레이리스트 소유자만 삭제할 수 있습니다.")
+    @Operation(summary = "플레이리스트 삭제")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "204", description = "성공"),
             @ApiResponse(responseCode = "401", description = "인증 오류"),
             @ApiResponse(responseCode = "403", description = "권한 오류"),
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     ResponseEntity<Void> delete(
-            @Parameter(hidden = true) Principal principal,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(description = "playlistId") Long playlistId
     );
 
-    @Operation(summary = "플레이리스트 수정", description = "플레이리스트 소유자만 수정할 수 있습니다.")
+    @Operation(summary = "플레이리스트 수정")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공"),
             @ApiResponse(responseCode = "400", description = "잘못된 요청"),
@@ -144,7 +131,7 @@ public interface PlaylistControllerDocs {
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     ResponseEntity<PlaylistDto> update(
-            @Parameter(hidden = true) Principal principal,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Parameter(description = "playlistId") Long playlistId,
             @Valid @RequestBody PlaylistUpdateRequest request
     );

--- a/mopl-api/src/main/java/com/mopl/domain/playlist/controller/docs/PlaylistControllerDocs.java
+++ b/mopl-api/src/main/java/com/mopl/domain/playlist/controller/docs/PlaylistControllerDocs.java
@@ -11,11 +11,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
+
+import java.security.Principal;
 
 @Tag(name = "플레이리스트 관리", description = "플레이리스트 관련 API")
 public interface PlaylistControllerDocs {
@@ -29,13 +28,13 @@ public interface PlaylistControllerDocs {
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     ResponseEntity<PageResponse<PlaylistDto>> findAll(
-            @Parameter(hidden = true) Long requesterId,
+            @Parameter(hidden = true) Principal principal,
             @Parameter(description = "검색 키워드") String keywordLike,
             @Parameter(description = "소유자 ID") Long ownerIdEqual,
             @Parameter(description = "구독자 ID") Long subscriberIdEqual,
             @Parameter(description = "커서 키") String cursor,
             @Parameter(description = "보조 커서") String idAfter,
-            @Parameter(description = "한 번에 가져올 개수") @Min(1) @Max(100) Integer limit,
+            @Parameter(description = "한 번에 가져올 개수") Integer limit,
             @Schema(allowableValues = {"ASCENDING", "DESCENDING"}) SortDirection sortDirection,
             @Schema(allowableValues = {"updatedAt", "subscribeCount"}) String sortBy
     );
@@ -50,8 +49,8 @@ public interface PlaylistControllerDocs {
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     ResponseEntity<PlaylistDto> create(
-            @Parameter(hidden = true) Long requesterId,
-            @RequestBody @Valid PlaylistCreateRequest request
+            @Parameter(hidden = true) Principal principal,
+            @RequestBody PlaylistCreateRequest request
     );
 
     // 3) POST /api/playlists/{playlistId}/subscription
@@ -64,7 +63,7 @@ public interface PlaylistControllerDocs {
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     ResponseEntity<Void> subscribe(
-            @Parameter(hidden = true) Long requesterId,
+            @Parameter(hidden = true) Principal principal,
             @Parameter(description = "playlistId") Long playlistId
     );
 
@@ -78,7 +77,7 @@ public interface PlaylistControllerDocs {
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     ResponseEntity<Void> unsubscribe(
-            @Parameter(hidden = true) Long requesterId,
+            @Parameter(hidden = true) Principal principal,
             @Parameter(description = "playlistId") Long playlistId
     );
 
@@ -93,7 +92,7 @@ public interface PlaylistControllerDocs {
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     ResponseEntity<Void> addContent(
-            @Parameter(hidden = true) Long requesterId,
+            @Parameter(hidden = true) Principal principal,
             @Parameter(description = "playlistId") Long playlistId,
             @Parameter(description = "contentId") Long contentId
     );
@@ -109,7 +108,7 @@ public interface PlaylistControllerDocs {
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     ResponseEntity<Void> removeContent(
-            @Parameter(hidden = true) Long requesterId,
+            @Parameter(hidden = true) Principal principal,
             @Parameter(description = "playlistId") Long playlistId,
             @Parameter(description = "contentId") Long contentId
     );
@@ -123,7 +122,7 @@ public interface PlaylistControllerDocs {
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     ResponseEntity<PlaylistDto> find(
-            @Parameter(hidden = true) Long requesterId,
+            @Parameter(hidden = true) Principal principal,
             @Parameter(description = "playlistId") Long playlistId
     );
 
@@ -137,7 +136,7 @@ public interface PlaylistControllerDocs {
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     ResponseEntity<Void> delete(
-            @Parameter(hidden = true) Long requesterId,
+            @Parameter(hidden = true) Principal principal,
             @Parameter(description = "playlistId") Long playlistId
     );
 
@@ -151,8 +150,8 @@ public interface PlaylistControllerDocs {
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     ResponseEntity<PlaylistDto> update(
-            @Parameter(hidden = true) Long requesterId,
+            @Parameter(hidden = true) Principal principal,
             @Parameter(description = "playlistId") Long playlistId,
-            @RequestBody @Valid PlaylistUpdateRequest request
+            @RequestBody PlaylistUpdateRequest request
     );
 }

--- a/mopl-api/src/main/java/com/mopl/domain/playlist/controller/docs/PlaylistControllerDocs.java
+++ b/mopl-api/src/main/java/com/mopl/domain/playlist/controller/docs/PlaylistControllerDocs.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -19,7 +20,6 @@ import java.security.Principal;
 @Tag(name = "플레이리스트 관리", description = "플레이리스트 관련 API")
 public interface PlaylistControllerDocs {
 
-    // 1) GET /api/playlists
     @Operation(summary = "플레이리스트 목록 조회 (커서 페이지네이션)")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공"),
@@ -35,12 +35,13 @@ public interface PlaylistControllerDocs {
             @Parameter(description = "커서 키") String cursor,
             @Parameter(description = "보조 커서") String idAfter,
             @Parameter(description = "한 번에 가져올 개수") Integer limit,
-            @Schema(allowableValues = {"ASCENDING", "DESCENDING"}) SortDirection sortDirection,
-            @Schema(allowableValues = {"updatedAt", "subscribeCount"}) String sortBy
+            @Parameter(schema = @Schema(allowableValues = {"ASCENDING", "DESCENDING"}))
+            SortDirection sortDirection,
+            @Parameter(schema = @Schema(allowableValues = {"updatedAt", "subscribeCount", "subscriberCount"}))
+            String sortBy
     );
 
-    // 2) POST /api/playlists
-    @Operation(summary = "플레이리스트 생성", description = "생성한 플레이리스트는 API 요청자 본인의 플레이리스트로 생성됩니다.")
+    @Operation(summary = "플레이리스트 생성", description = "생성한 플레이리스트는 API 요청자 본인의 플레이리리스트로 생성됩니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공"),
             @ApiResponse(responseCode = "201", description = "성공"),
@@ -50,10 +51,9 @@ public interface PlaylistControllerDocs {
     })
     ResponseEntity<PlaylistDto> create(
             @Parameter(hidden = true) Principal principal,
-            @RequestBody PlaylistCreateRequest request
+            @Valid @RequestBody PlaylistCreateRequest request
     );
 
-    // 3) POST /api/playlists/{playlistId}/subscription
     @Operation(summary = "플레이리스트 구독")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공"),
@@ -67,7 +67,6 @@ public interface PlaylistControllerDocs {
             @Parameter(description = "playlistId") Long playlistId
     );
 
-    // 4) DELETE /api/playlists/{playlistId}/subscription
     @Operation(summary = "플레이리스트 구독 취소")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공"),
@@ -81,7 +80,6 @@ public interface PlaylistControllerDocs {
             @Parameter(description = "playlistId") Long playlistId
     );
 
-    // 5) POST /api/playlists/{playlistId}/contents/{contentId}
     @Operation(summary = "플레이리스트에 콘텐츠 추가", description = "플레이리스트 소유자만 콘텐츠를 추가할 수 있습니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공"),
@@ -97,7 +95,6 @@ public interface PlaylistControllerDocs {
             @Parameter(description = "contentId") Long contentId
     );
 
-    // 6) DELETE /api/playlists/{playlistId}/contents/{contentId}
     @Operation(summary = "플레이리스트에서 콘텐츠 삭제", description = "플레이리스트 소유자만 콘텐츠를 삭제할 수 있습니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공"),
@@ -113,7 +110,6 @@ public interface PlaylistControllerDocs {
             @Parameter(description = "contentId") Long contentId
     );
 
-    // 7) GET /api/playlists/{playlistId}
     @Operation(summary = "플레이리스트 단건 조회")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공"),
@@ -126,7 +122,6 @@ public interface PlaylistControllerDocs {
             @Parameter(description = "playlistId") Long playlistId
     );
 
-    // 8) DELETE /api/playlists/{playlistId}
     @Operation(summary = "플레이리스트 삭제", description = "플레이리스트 소유자만 삭제할 수 있습니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공"),
@@ -140,7 +135,6 @@ public interface PlaylistControllerDocs {
             @Parameter(description = "playlistId") Long playlistId
     );
 
-    // 9) PATCH /api/playlists/{playlistId}
     @Operation(summary = "플레이리스트 수정", description = "플레이리스트 소유자만 수정할 수 있습니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공"),
@@ -152,6 +146,6 @@ public interface PlaylistControllerDocs {
     ResponseEntity<PlaylistDto> update(
             @Parameter(hidden = true) Principal principal,
             @Parameter(description = "playlistId") Long playlistId,
-            @RequestBody PlaylistUpdateRequest request
+            @Valid @RequestBody PlaylistUpdateRequest request
     );
 }

--- a/mopl-api/src/main/java/com/mopl/domain/playlist/service/PlaylistService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/playlist/service/PlaylistService.java
@@ -130,7 +130,8 @@ public class PlaylistService {
             return;
         }
         playlistSubscribeRepository.save(new PlaylistSubscribe(requesterId, playlistId));
-        playlist.increaseSubscriberCount();
+        // Race Condition 방지: 엔티티 더티체킹 대신 원자 UPDATE 사용
+        playlistRepository.increaseSubscriberCount(playlistId);
     }
 
     // 플레이리스트 구독 취소
@@ -143,12 +144,11 @@ public class PlaylistService {
         if (Objects.equals(playlist.getUserId(), requesterId)) {
             return;
         }
-        if (!playlistSubscribeRepository.existsByUserIdAndPlaylistId(requesterId, playlistId)) {
-            return;
-        }
-        playlistSubscribeRepository.deleteByUserIdAndPlaylistId(requesterId, playlistId);
 
-        safeDecreaseSubscriberCount(playlist);
+        long deleted = playlistSubscribeRepository.deleteByUserIdAndPlaylistId(requesterId, playlistId);
+        if (deleted > 0) {
+            playlistRepository.decreaseSubscriberCount(playlistId);
+        }
     }
 
     // 플레이리스트 콘텐츠 추가
@@ -231,7 +231,10 @@ public class PlaylistService {
         Map<Long, List<PlaylistDto.Content>> contentsMap = loadContentsByPlaylistIds(playlistIds);
 
         List<PlaylistDto> data = page.stream().map(p -> {
-            PlaylistDto.Owner owner = ownerMap.getOrDefault(p.getUserId(), new PlaylistDto.Owner(p.getUserId(), null, null));
+            PlaylistDto.Owner owner = ownerMap.getOrDefault(
+                    p.getUserId(),
+                    new PlaylistDto.Owner(p.getUserId(), null, null)
+            );
 
             boolean subscribedByMe = requesterId != null
                     && (Objects.equals(p.getUserId(), requesterId) || subscribedPlaylistIds.contains(p.getId()));
@@ -274,6 +277,7 @@ public class PlaylistService {
                 .sortDirection(normalizedDirection)
                 .build();
     }
+
     // contents 로딩/매핑
     private List<PlaylistDto.Content> loadContentsByPlaylistId(Long playlistId) {
         List<PlaylistContent> pcs = playlistContentRepository.findAllByPlaylistId(playlistId);
@@ -408,8 +412,6 @@ public class PlaylistService {
 
         String v = sortBy.trim();
         if ("updatedAt".equalsIgnoreCase(v)) return "updatedAt";
-
-        // 요구사항: subscribeCount(subscriberCount)
         if ("subscribeCount".equalsIgnoreCase(v) || "subscriberCount".equalsIgnoreCase(v)) {
             return "subscriberCount";
         }
@@ -493,12 +495,5 @@ public class PlaylistService {
             return true;
         }
         return playlistSubscribeRepository.existsByUserIdAndPlaylistId(requesterId, playlist.getId());
-    }
-
-    private void safeDecreaseSubscriberCount(Playlist playlist) {
-        if (playlist.getSubscriberCount() <= 0L) {
-            return;
-        }
-        playlist.decreaseSubscriberCount();
     }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/playlist/service/PlaylistService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/playlist/service/PlaylistService.java
@@ -4,7 +4,9 @@ import com.mopl.domain.playlist.dto.request.PlaylistCreateRequest;
 import com.mopl.domain.playlist.dto.request.PlaylistUpdateRequest;
 import com.mopl.domain.playlist.dto.response.PlaylistDto;
 import com.mopl.domain.playlist.entity.Playlist;
+import com.mopl.domain.playlist.entity.PlaylistSubscribe;
 import com.mopl.domain.playlist.repository.PlaylistRepository;
+import com.mopl.domain.playlist.repository.PlaylistSubscribeRepository;
 import com.mopl.domain.user.entity.User;
 import com.mopl.domain.user.repository.UserRepository;
 import com.mopl.global.dto.PageResponse;
@@ -23,6 +25,7 @@ import java.util.Objects;
 public class PlaylistService {
 
     private final PlaylistRepository playlistRepository;
+    private final PlaylistSubscribeRepository playlistSubscribeRepository;
     private final UserRepository userRepository;
 
     // 플레이리스트 생성
@@ -43,7 +46,7 @@ public class PlaylistService {
                 saved.getUpdatedAt(),
                 saved.getSubscriberCount(),
                 true,
-                List.of()   // 콘텐츠 기능 미완성: 빈 리스트
+                List.of()
         );
     }
 
@@ -101,10 +104,23 @@ public class PlaylistService {
         playlistRepository.delete(playlist);
     }
 
-    // 플레이리스트 구독 (TODO)
+    // 플레이리스트 구독
     @Transactional
     public void subscribe(Long requesterId, Long playlistId) {
-        throw new UnsupportedOperationException("TODO: implement in next commits (subscribe)");
+        validateAuthenticated(requesterId);
+
+        Playlist playlist = playlistRepository.findById(playlistId)
+                .orElseThrow(() -> new MoplException(ErrorCode.NOT_FOUND));
+
+        if (Objects.equals(playlist.getUserId(), requesterId)) {
+            return;
+        }
+        if (playlistSubscribeRepository.existsByUserIdAndPlaylistId(requesterId, playlistId)) {
+            return;
+        }
+        // 구독 저장
+        playlistSubscribeRepository.save(new PlaylistSubscribe(requesterId, playlistId));
+        playlist.increaseSubscriberCount();
     }
 
     // 플레이리스트 구독 취소 (TODO)
@@ -166,6 +182,9 @@ public class PlaylistService {
 
     // 구독 여부
     private boolean isSubscribedByMe(Long requesterId, Playlist playlist) {
-        return Objects.equals(playlist.getUserId(), requesterId);
+        if (Objects.equals(playlist.getUserId(), requesterId)) {
+            return true;
+        }
+        return playlistSubscribeRepository.existsByUserIdAndPlaylistId(requesterId, playlist.getId());
     }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/playlist/service/PlaylistService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/playlist/service/PlaylistService.java
@@ -1,5 +1,6 @@
 package com.mopl.domain.playlist.service;
 
+import com.mopl.domain.content.entity.Content;
 import com.mopl.domain.content.repository.ContentRepository;
 import com.mopl.domain.playlist.dto.request.PlaylistCreateRequest;
 import com.mopl.domain.playlist.dto.request.PlaylistUpdateRequest;
@@ -20,8 +21,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -65,6 +65,7 @@ public class PlaylistService {
 
         PlaylistDto.Owner owner = loadOwner(playlist.getUserId());
         boolean subscribedByMe = isSubscribedByMe(requesterId, playlist);
+        List<PlaylistDto.Content> contents = loadContentsByPlaylistId(playlist.getId());
 
         return new PlaylistDto(
                 playlist.getId(),
@@ -74,7 +75,7 @@ public class PlaylistService {
                 playlist.getUpdatedAt(),
                 playlist.getSubscriberCount(),
                 subscribedByMe,
-                List.of() // 콘텐츠 기능 미완성: 빈 리스트
+                contents
         );
     }
 
@@ -136,12 +137,11 @@ public class PlaylistService {
         if (Objects.equals(playlist.getUserId(), requesterId)) {
             return;
         }
-
         if (!playlistSubscribeRepository.existsByUserIdAndPlaylistId(requesterId, playlistId)) {
             return;
         }
         playlistSubscribeRepository.deleteByUserIdAndPlaylistId(requesterId, playlistId);
-        // 0 아래로 내려가지 않도록 방어
+
         safeDecreaseSubscriberCount(playlist);
     }
 
@@ -152,26 +152,23 @@ public class PlaylistService {
         Playlist playlist = playlistRepository.findById(playlistId)
                 .orElseThrow(() -> new MoplException(ErrorCode.NOT_FOUND));
         validateOwner(requesterId, playlist);
-        //콘텐츠 존재 검증
         if (!contentRepository.existsById(contentId)) {
             throw new MoplException(ErrorCode.NOT_FOUND);
         }
-        boolean alreadyExists = playlistContentRepository.existsByPlaylistIdAndContentId(playlistId, contentId);
-        if (alreadyExists) {
+        if (playlistContentRepository.existsByPlaylistIdAndContentId(playlistId, contentId)) {
             return;
         }
         playlistContentRepository.save(new PlaylistContent(playlistId, contentId));
     }
 
-    // 플레이리스트에서 콘텐츠 삭제 (TODO)
+    // 플레이리스트에서 콘텐츠 삭제
     @Transactional
     public void removeContent(Long requesterId, Long playlistId, Long contentId) {
         validateAuthenticated(requesterId);
         Playlist playlist = playlistRepository.findById(playlistId)
                 .orElseThrow(() -> new MoplException(ErrorCode.NOT_FOUND));
         validateOwner(requesterId, playlist);
-        boolean exists = playlistContentRepository.existsByPlaylistIdAndContentId(playlistId, contentId);
-        if (!exists) {
+        if (!playlistContentRepository.existsByPlaylistIdAndContentId(playlistId, contentId)) {
             return;
         }
         playlistContentRepository.deleteByPlaylistIdAndContentId(playlistId, contentId);
@@ -193,6 +190,57 @@ public class PlaylistService {
         throw new UnsupportedOperationException("TODO: implement in next commits (findAll)");
     }
 
+    // contents 로딩/매핑
+    private List<PlaylistDto.Content> loadContentsByPlaylistId(Long playlistId) {
+        List<PlaylistContent> pcs = playlistContentRepository.findAllByPlaylistId(playlistId);
+        if (pcs.isEmpty()) return List.of();
+
+        pcs.sort(Comparator.comparing(PlaylistContent::getId));
+
+        List<Long> contentIds = pcs.stream()
+                .map(PlaylistContent::getContentId)
+                .toList();
+
+        Map<Long, Content> contentMap = loadContentMap(contentIds);
+
+        List<PlaylistDto.Content> result = new ArrayList<>();
+        for (Long contentId : contentIds) {
+            Content content = contentMap.get(contentId);
+            if (content == null) continue;
+            result.add(toPlaylistContentDto(content));
+        }
+        return result;
+    }
+
+    private Map<Long, Content> loadContentMap(Collection<Long> contentIds) {
+        if (contentIds == null || contentIds.isEmpty()) return Map.of();
+
+        List<Content> fetched = contentRepository.findAllByIdInWithTags(contentIds);
+
+        Map<Long, Content> map = new LinkedHashMap<>();
+        for (Content c : fetched) {
+            map.putIfAbsent(c.getId(), c);
+        }
+        return map;
+    }
+
+    private PlaylistDto.Content toPlaylistContentDto(Content content) {
+        List<String> tags = content.getContentTags().stream()
+                .map(ct -> ct.getTag().getTag())
+                .distinct()
+                .toList();
+
+        return new PlaylistDto.Content(
+                content.getId(),
+                content.getContentType() == null ? null : content.getContentType().name(),
+                content.getTitle(),
+                content.getDescription(),
+                content.getThumbnailUrl(),
+                tags,
+                content.getAverageRating(),
+                content.getReviewCount()
+        );
+    }
     // 인증 체크
     private void validateAuthenticated(Long requesterId) {
         if (requesterId == null) {
@@ -207,7 +255,7 @@ public class PlaylistService {
         }
     }
 
-    // owner 로드 (없으면 null 필드로)
+    // owner 로드
     private PlaylistDto.Owner loadOwner(Long ownerId) {
         User owner = userRepository.findById(ownerId).orElse(null);
         if (owner == null) {
@@ -226,6 +274,9 @@ public class PlaylistService {
 
     // subscriber_count 감소 방어
     private void safeDecreaseSubscriberCount(Playlist playlist) {
+        if (playlist.getSubscriberCount() <= 0L) {
+            return;
+        }
         playlist.decreaseSubscriberCount();
     }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/playlist/service/PlaylistService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/playlist/service/PlaylistService.java
@@ -21,11 +21,17 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.*;
 
 @Service
 @RequiredArgsConstructor
 public class PlaylistService {
+
+    private static final int DEFAULT_LIMIT = 20;
+    private static final int MAX_LIMIT = 100;
 
     private final PlaylistRepository playlistRepository;
     private final PlaylistSubscribeRepository playlistSubscribeRepository;
@@ -149,9 +155,11 @@ public class PlaylistService {
     @Transactional
     public void addContent(Long requesterId, Long playlistId, Long contentId) {
         validateAuthenticated(requesterId);
+
         Playlist playlist = playlistRepository.findById(playlistId)
                 .orElseThrow(() -> new MoplException(ErrorCode.NOT_FOUND));
         validateOwner(requesterId, playlist);
+
         if (!contentRepository.existsById(contentId)) {
             throw new MoplException(ErrorCode.NOT_FOUND);
         }
@@ -165,16 +173,18 @@ public class PlaylistService {
     @Transactional
     public void removeContent(Long requesterId, Long playlistId, Long contentId) {
         validateAuthenticated(requesterId);
+
         Playlist playlist = playlistRepository.findById(playlistId)
                 .orElseThrow(() -> new MoplException(ErrorCode.NOT_FOUND));
         validateOwner(requesterId, playlist);
+
         if (!playlistContentRepository.existsByPlaylistIdAndContentId(playlistId, contentId)) {
             return;
         }
         playlistContentRepository.deleteByPlaylistIdAndContentId(playlistId, contentId);
     }
 
-    // 플레이리스트 목록 조회 (커서 페이지네이션) (TODO)
+    // 플레이리스트 목록 조회 (커서 페이지네이션)
     @Transactional(readOnly = true)
     public PageResponse<PlaylistDto> findAll(
             Long requesterId,
@@ -187,9 +197,83 @@ public class PlaylistService {
             String sortBy,
             SortDirection sortDirection
     ) {
-        throw new UnsupportedOperationException("TODO: implement in next commits (findAll)");
-    }
+        int size = normalizeLimit(limit);
 
+        String normalizedSortBy = normalizeSortBy(sortBy);
+        SortDirection normalizedDirection = (sortDirection == null) ? SortDirection.DESCENDING : sortDirection;
+
+        CursorKey key = parseCursorKey(cursor, idAfter, normalizedSortBy);
+
+        // limit+1 조회로 hasNext 판별
+        List<Playlist> fetched = playlistRepository.cursorFindAll(
+                keywordLike,
+                ownerIdEqual,
+                subscriberIdEqual,
+                key.cursorUpdatedAt,
+                key.cursorSubscriberCount,
+                key.idAfter,
+                size + 1,
+                normalizedSortBy,
+                normalizedDirection
+        );
+
+        boolean hasNext = fetched.size() > size;
+        List<Playlist> page = hasNext ? fetched.subList(0, size) : fetched;
+
+        List<Long> playlistIds = page.stream().map(Playlist::getId).toList();
+
+        Map<Long, PlaylistDto.Owner> ownerMap = loadOwnerMap(
+                page.stream().map(Playlist::getUserId).collect(java.util.stream.Collectors.toSet())
+        );
+
+        Set<Long> subscribedPlaylistIds = loadSubscribedPlaylistIds(requesterId, playlistIds);
+
+        Map<Long, List<PlaylistDto.Content>> contentsMap = loadContentsByPlaylistIds(playlistIds);
+
+        List<PlaylistDto> data = page.stream().map(p -> {
+            PlaylistDto.Owner owner = ownerMap.getOrDefault(p.getUserId(), new PlaylistDto.Owner(p.getUserId(), null, null));
+
+            boolean subscribedByMe = requesterId != null
+                    && (Objects.equals(p.getUserId(), requesterId) || subscribedPlaylistIds.contains(p.getId()));
+
+            List<PlaylistDto.Content> contents = contentsMap.getOrDefault(p.getId(), List.of());
+
+            return new PlaylistDto(
+                    p.getId(),
+                    owner,
+                    p.getTitle(),
+                    p.getDescription(),
+                    p.getUpdatedAt(),
+                    p.getSubscriberCount(),
+                    subscribedByMe,
+                    contents
+            );
+        }).toList();
+
+        String nextCursor = null;
+        Long nextIdAfter = null;
+
+        if (hasNext && !page.isEmpty()) {
+            Playlist last = page.get(page.size() - 1);
+            nextIdAfter = last.getId();
+
+            if ("updatedAt".equalsIgnoreCase(normalizedSortBy)) {
+                nextCursor = formatDateTimeCursor(last.getUpdatedAt());
+            } else {
+                nextCursor = String.valueOf(last.getSubscriberCount());
+            }
+        }
+
+        return PageResponse.<PlaylistDto>builder()
+                .data(data)
+                .nextCursor(nextCursor)
+                .nextIdAfter(nextIdAfter)
+                .hasNext(hasNext)
+                .totalCount(0L)
+                .sortBy(normalizedSortBy)
+                .sortDirection(normalizedDirection)
+                .build();
+    }
     // contents 로딩/매핑
     private List<PlaylistDto.Content> loadContentsByPlaylistId(Long playlistId) {
         List<PlaylistContent> pcs = playlistContentRepository.findAllByPlaylistId(playlistId);
@@ -208,6 +292,49 @@ public class PlaylistService {
             Content content = contentMap.get(contentId);
             if (content == null) continue;
             result.add(toPlaylistContentDto(content));
+        }
+        return result;
+    }
+
+    // 목록 조회용
+    private Map<Long, List<PlaylistDto.Content>> loadContentsByPlaylistIds(List<Long> playlistIds) {
+        if (playlistIds == null || playlistIds.isEmpty()) return Map.of();
+
+        List<PlaylistContent> pcs = playlistContentRepository.findAllByPlaylistIdIn(playlistIds);
+        if (pcs.isEmpty()) {
+            Map<Long, List<PlaylistDto.Content>> empty = new HashMap<>();
+            for (Long pid : playlistIds) empty.put(pid, List.of());
+            return empty;
+        }
+
+        pcs.sort(Comparator.comparing(PlaylistContent::getId));
+
+        Map<Long, List<Long>> playlistToContentIds = new HashMap<>();
+        Set<Long> allContentIds = new LinkedHashSet<>();
+
+        for (PlaylistContent pc : pcs) {
+            playlistToContentIds.computeIfAbsent(pc.getPlaylistId(), k -> new ArrayList<>())
+                    .add(pc.getContentId());
+            allContentIds.add(pc.getContentId());
+        }
+
+        Map<Long, Content> contentMap = loadContentMap(allContentIds);
+
+        Map<Long, List<PlaylistDto.Content>> result = new HashMap<>();
+        for (Long playlistId : playlistIds) {
+            List<Long> contentIds = playlistToContentIds.getOrDefault(playlistId, List.of());
+            if (contentIds.isEmpty()) {
+                result.put(playlistId, List.of());
+                continue;
+            }
+
+            List<PlaylistDto.Content> dtos = new ArrayList<>();
+            for (Long contentId : contentIds) {
+                Content content = contentMap.get(contentId);
+                if (content == null) continue;
+                dtos.add(toPlaylistContentDto(content));
+            }
+            result.put(playlistId, dtos);
         }
         return result;
     }
@@ -241,21 +368,118 @@ public class PlaylistService {
                 content.getReviewCount()
         );
     }
-    // 인증 체크
+
+    // owner
+    private Map<Long, PlaylistDto.Owner> loadOwnerMap(Set<Long> ownerIds) {
+        if (ownerIds == null || ownerIds.isEmpty()) return Map.of();
+
+        List<User> owners = userRepository.findAllById(ownerIds);
+
+        Map<Long, PlaylistDto.Owner> map = new HashMap<>();
+        for (User u : owners) {
+            map.put(u.getId(), new PlaylistDto.Owner(u.getId(), u.getName(), u.getProfileImageUrl()));
+        }
+        return map;
+    }
+
+    private Set<Long> loadSubscribedPlaylistIds(Long requesterId, List<Long> playlistIds) {
+        if (requesterId == null || playlistIds == null || playlistIds.isEmpty()) return Set.of();
+
+        List<PlaylistSubscribe> subs = playlistSubscribeRepository.findAllByUserIdAndPlaylistIdIn(requesterId, playlistIds);
+
+        Set<Long> set = new HashSet<>();
+        for (PlaylistSubscribe s : subs) {
+            set.add(s.getPlaylistId());
+        }
+        return set;
+    }
+
+    // cursor
+    private int normalizeLimit(Integer limit) {
+        if (limit == null) return DEFAULT_LIMIT;
+        if (limit < 1 || limit > MAX_LIMIT) {
+            throw new MoplException(ErrorCode.INVALID_REQUEST);
+        }
+        return limit;
+    }
+
+    private String normalizeSortBy(String sortBy) {
+        if (sortBy == null || sortBy.isBlank()) return "updatedAt";
+
+        String v = sortBy.trim();
+        if ("updatedAt".equalsIgnoreCase(v)) return "updatedAt";
+
+        // 요구사항: subscribeCount(subscriberCount)
+        if ("subscribeCount".equalsIgnoreCase(v) || "subscriberCount".equalsIgnoreCase(v)) {
+            return "subscriberCount";
+        }
+
+        throw new MoplException(ErrorCode.INVALID_REQUEST);
+    }
+
+    private CursorKey parseCursorKey(String cursorRaw, String idAfterRaw, String normalizedSortBy) {
+        boolean hasCursor = cursorRaw != null && !cursorRaw.isBlank();
+        boolean hasIdAfter = idAfterRaw != null && !idAfterRaw.isBlank();
+
+        if (hasCursor != hasIdAfter) {
+            throw new MoplException(ErrorCode.INVALID_REQUEST);
+        }
+
+        if (!hasCursor) {
+            return new CursorKey(null, null, null);
+        }
+
+        Long parsedIdAfter = parseLong(idAfterRaw);
+
+        if ("updatedAt".equalsIgnoreCase(normalizedSortBy)) {
+            LocalDateTime updatedAt = parseDateTimeCursor(cursorRaw);
+            return new CursorKey(updatedAt, null, parsedIdAfter);
+        } else {
+            Long subscriberCount = parseLong(cursorRaw);
+            return new CursorKey(null, subscriberCount, parsedIdAfter);
+        }
+    }
+
+    private Long parseLong(String raw) {
+        try {
+            return Long.parseLong(raw.trim());
+        } catch (Exception e) {
+            throw new MoplException(ErrorCode.INVALID_REQUEST);
+        }
+    }
+
+    private LocalDateTime parseDateTimeCursor(String raw) {
+        String normalized = raw.trim().replace(" ", "T");
+        try {
+            return LocalDateTime.parse(normalized, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+        } catch (DateTimeParseException e) {
+            throw new MoplException(ErrorCode.INVALID_REQUEST);
+        }
+    }
+
+    private String formatDateTimeCursor(LocalDateTime value) {
+        return value.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+    }
+
+    private record CursorKey(
+            LocalDateTime cursorUpdatedAt,
+            Long cursorSubscriberCount,
+            Long idAfter
+    ) {}
+
+    // 인증/인가
     private void validateAuthenticated(Long requesterId) {
         if (requesterId == null) {
             throw new MoplException(ErrorCode.UNAUTHORIZED);
         }
     }
 
-    // 소유자 체크
     private void validateOwner(Long requesterId, Playlist playlist) {
         if (!Objects.equals(playlist.getUserId(), requesterId)) {
             throw new MoplException(ErrorCode.FORBIDDEN);
         }
     }
 
-    // owner 로드
     private PlaylistDto.Owner loadOwner(Long ownerId) {
         User owner = userRepository.findById(ownerId).orElse(null);
         if (owner == null) {
@@ -264,7 +488,6 @@ public class PlaylistService {
         return new PlaylistDto.Owner(owner.getId(), owner.getName(), owner.getProfileImageUrl());
     }
 
-    // 구독 여부
     private boolean isSubscribedByMe(Long requesterId, Playlist playlist) {
         if (Objects.equals(playlist.getUserId(), requesterId)) {
             return true;
@@ -272,7 +495,6 @@ public class PlaylistService {
         return playlistSubscribeRepository.existsByUserIdAndPlaylistId(requesterId, playlist.getId());
     }
 
-    // subscriber_count 감소 방어
     private void safeDecreaseSubscriberCount(Playlist playlist) {
         if (playlist.getSubscriberCount() <= 0L) {
             return;

--- a/mopl-api/src/main/java/com/mopl/domain/playlist/service/PlaylistService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/playlist/service/PlaylistService.java
@@ -1,10 +1,13 @@
 package com.mopl.domain.playlist.service;
 
+import com.mopl.domain.content.repository.ContentRepository;
 import com.mopl.domain.playlist.dto.request.PlaylistCreateRequest;
 import com.mopl.domain.playlist.dto.request.PlaylistUpdateRequest;
 import com.mopl.domain.playlist.dto.response.PlaylistDto;
 import com.mopl.domain.playlist.entity.Playlist;
+import com.mopl.domain.playlist.entity.PlaylistContent;
 import com.mopl.domain.playlist.entity.PlaylistSubscribe;
+import com.mopl.domain.playlist.repository.PlaylistContentRepository;
 import com.mopl.domain.playlist.repository.PlaylistRepository;
 import com.mopl.domain.playlist.repository.PlaylistSubscribeRepository;
 import com.mopl.domain.user.entity.User;
@@ -27,6 +30,8 @@ public class PlaylistService {
     private final PlaylistRepository playlistRepository;
     private final PlaylistSubscribeRepository playlistSubscribeRepository;
     private final UserRepository userRepository;
+    private final PlaylistContentRepository playlistContentRepository;
+    private final ContentRepository contentRepository;
 
     // 플레이리스트 생성
     @Transactional
@@ -140,10 +145,22 @@ public class PlaylistService {
         safeDecreaseSubscriberCount(playlist);
     }
 
-    // 플레이리스트에 콘텐츠 추가 (TODO)
+    // 플레이리스트 콘텐츠 추가
     @Transactional
     public void addContent(Long requesterId, Long playlistId, Long contentId) {
-        throw new UnsupportedOperationException("TODO: implement in next commits (addContent)");
+        validateAuthenticated(requesterId);
+        Playlist playlist = playlistRepository.findById(playlistId)
+                .orElseThrow(() -> new MoplException(ErrorCode.NOT_FOUND));
+        validateOwner(requesterId, playlist);
+        //콘텐츠 존재 검증
+        if (!contentRepository.existsById(contentId)) {
+            throw new MoplException(ErrorCode.NOT_FOUND);
+        }
+        boolean alreadyExists = playlistContentRepository.existsByPlaylistIdAndContentId(playlistId, contentId);
+        if (alreadyExists) {
+            return;
+        }
+        playlistContentRepository.save(new PlaylistContent(playlistId, contentId));
     }
 
     // 플레이리스트에서 콘텐츠 삭제 (TODO)

--- a/mopl-api/src/main/java/com/mopl/domain/playlist/service/PlaylistService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/playlist/service/PlaylistService.java
@@ -111,22 +111,33 @@ public class PlaylistService {
 
         Playlist playlist = playlistRepository.findById(playlistId)
                 .orElseThrow(() -> new MoplException(ErrorCode.NOT_FOUND));
-
         if (Objects.equals(playlist.getUserId(), requesterId)) {
             return;
         }
         if (playlistSubscribeRepository.existsByUserIdAndPlaylistId(requesterId, playlistId)) {
             return;
         }
-        // 구독 저장
         playlistSubscribeRepository.save(new PlaylistSubscribe(requesterId, playlistId));
         playlist.increaseSubscriberCount();
     }
 
-    // 플레이리스트 구독 취소 (TODO)
+    // 플레이리스트 구독 취소
     @Transactional
     public void unsubscribe(Long requesterId, Long playlistId) {
-        throw new UnsupportedOperationException("TODO: implement in next commits (unsubscribe)");
+        validateAuthenticated(requesterId);
+
+        Playlist playlist = playlistRepository.findById(playlistId)
+                .orElseThrow(() -> new MoplException(ErrorCode.NOT_FOUND));
+        if (Objects.equals(playlist.getUserId(), requesterId)) {
+            return;
+        }
+
+        if (!playlistSubscribeRepository.existsByUserIdAndPlaylistId(requesterId, playlistId)) {
+            return;
+        }
+        playlistSubscribeRepository.deleteByUserIdAndPlaylistId(requesterId, playlistId);
+        // 0 아래로 내려가지 않도록 방어
+        safeDecreaseSubscriberCount(playlist);
     }
 
     // 플레이리스트에 콘텐츠 추가 (TODO)
@@ -186,5 +197,10 @@ public class PlaylistService {
             return true;
         }
         return playlistSubscribeRepository.existsByUserIdAndPlaylistId(requesterId, playlist.getId());
+    }
+
+    // subscriber_count 감소 방어
+    private void safeDecreaseSubscriberCount(Playlist playlist) {
+        playlist.decreaseSubscriberCount();
     }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/playlist/service/PlaylistService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/playlist/service/PlaylistService.java
@@ -166,7 +166,15 @@ public class PlaylistService {
     // 플레이리스트에서 콘텐츠 삭제 (TODO)
     @Transactional
     public void removeContent(Long requesterId, Long playlistId, Long contentId) {
-        throw new UnsupportedOperationException("TODO: implement in next commits (removeContent)");
+        validateAuthenticated(requesterId);
+        Playlist playlist = playlistRepository.findById(playlistId)
+                .orElseThrow(() -> new MoplException(ErrorCode.NOT_FOUND));
+        validateOwner(requesterId, playlist);
+        boolean exists = playlistContentRepository.existsByPlaylistIdAndContentId(playlistId, contentId);
+        if (!exists) {
+            return;
+        }
+        playlistContentRepository.deleteByPlaylistIdAndContentId(playlistId, contentId);
     }
 
     // 플레이리스트 목록 조회 (커서 페이지네이션) (TODO)

--- a/mopl-core/src/main/java/com/mopl/domain/content/repository/ContentRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/content/repository/ContentRepository.java
@@ -2,6 +2,21 @@ package com.mopl.domain.content.repository;
 
 import com.mopl.domain.content.entity.Content;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Collection;
+import java.util.List;
 
 public interface ContentRepository extends JpaRepository<Content, Long>, ContentRepositoryCustom {
+
+    //playlist 조회 시 tags까지 한 번에 끌고 오기 위한 fetch join (N+1 방지)
+    @Query("""
+        select distinct c
+        from Content c
+        left join fetch c.contentTags ct
+        left join fetch ct.tag t
+        where c.id in :ids
+    """)
+    List<Content> findAllByIdInWithTags(@Param("ids") Collection<Long> ids);
 }

--- a/mopl-core/src/main/java/com/mopl/domain/playlist/repository/PlaylistContentRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/playlist/repository/PlaylistContentRepository.java
@@ -11,7 +11,7 @@ public interface PlaylistContentRepository extends JpaRepository<PlaylistContent
 
     List<PlaylistContent> findAllByPlaylistId(Long playlistId);
 
-    List<PlaylistContent> findAllByPlaylistIdIn(Collection<Long> playlistIds);
+    List<PlaylistContent> findAllByPlaylistIdIn(List<Long> playlistIds);
 
     boolean existsByPlaylistIdAndContentId(Long playlistId, Long contentId);
 

--- a/mopl-core/src/main/java/com/mopl/domain/playlist/repository/PlaylistContentRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/playlist/repository/PlaylistContentRepository.java
@@ -15,8 +15,6 @@ public interface PlaylistContentRepository extends JpaRepository<PlaylistContent
 
     boolean existsByPlaylistIdAndContentId(Long playlistId, Long contentId);
 
-    Optional<PlaylistContent> findByPlaylistIdAndContentId(Long playlistId, Long contentId);
-
     void deleteByPlaylistIdAndContentId(Long playlistId, Long contentId);
 
     void deleteAllByPlaylistId(Long playlistId);

--- a/mopl-core/src/main/java/com/mopl/domain/playlist/repository/PlaylistRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/playlist/repository/PlaylistRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
+public interface PlaylistRepository extends JpaRepository<Playlist, Long>, PlaylistRepositoryCustom {
 
     boolean existsByIdAndUserId(Long id, Long userId);
 

--- a/mopl-core/src/main/java/com/mopl/domain/playlist/repository/PlaylistRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/playlist/repository/PlaylistRepository.java
@@ -2,12 +2,19 @@ package com.mopl.domain.playlist.repository;
 
 import com.mopl.domain.playlist.entity.Playlist;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.Optional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PlaylistRepository extends JpaRepository<Playlist, Long>, PlaylistRepositoryCustom {
 
     boolean existsByIdAndUserId(Long id, Long userId);
 
-    Optional<Playlist> findByIdAndUserId(Long id, Long userId);
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Playlist p SET p.subscriberCount = p.subscriberCount + 1 WHERE p.id = :id")
+    int increaseSubscriberCount(@Param("id") Long id);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Playlist p SET p.subscriberCount = p.subscriberCount - 1 WHERE p.id = :id AND p.subscriberCount > 0")
+    int decreaseSubscriberCount(@Param("id") Long id);
 }

--- a/mopl-core/src/main/java/com/mopl/domain/playlist/repository/PlaylistRepositoryCustom.java
+++ b/mopl-core/src/main/java/com/mopl/domain/playlist/repository/PlaylistRepositoryCustom.java
@@ -1,0 +1,22 @@
+package com.mopl.domain.playlist.repository;
+
+import com.mopl.domain.playlist.entity.Playlist;
+import com.mopl.global.enums.SortDirection;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface PlaylistRepositoryCustom {
+
+    List<Playlist> cursorFindAll(
+            String keywordLike,
+            Long ownerIdEqual,
+            Long subscriberIdEqual,
+            LocalDateTime cursorUpdatedAt,
+            Long cursorSubscriberCount,
+            Long idAfter,
+            int limitPlusOne,
+            String sortBy,
+            SortDirection sortDirection
+    );
+}

--- a/mopl-core/src/main/java/com/mopl/domain/playlist/repository/PlaylistRepositoryCustomImpl.java
+++ b/mopl-core/src/main/java/com/mopl/domain/playlist/repository/PlaylistRepositoryCustomImpl.java
@@ -1,0 +1,120 @@
+package com.mopl.domain.playlist.repository;
+
+import com.mopl.domain.playlist.entity.Playlist;
+import com.mopl.domain.playlist.entity.QPlaylist;
+import com.mopl.domain.playlist.entity.QPlaylistSubscribe;
+import com.mopl.global.enums.SortDirection;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PlaylistRepositoryCustomImpl implements PlaylistRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    private final QPlaylist playlist = QPlaylist.playlist;
+    private final QPlaylistSubscribe subscribe = QPlaylistSubscribe.playlistSubscribe;
+
+    @Override
+    public List<Playlist> cursorFindAll(
+            String keywordLike,
+            Long ownerIdEqual,
+            Long subscriberIdEqual,
+            LocalDateTime cursorUpdatedAt,
+            Long cursorSubscriberCount,
+            Long idAfter,
+            int limitPlusOne,
+            String sortBy,
+            SortDirection sortDirection
+    ) {
+        BooleanBuilder where = new BooleanBuilder();
+
+        // (title/description)
+        if (keywordLike != null && !keywordLike.isBlank()) {
+            where.and(
+                    playlist.title.contains(keywordLike)
+                            .or(playlist.description.contains(keywordLike))
+            );
+        }
+
+        // ownerIdEqual
+        if (ownerIdEqual != null) {
+            where.and(playlist.userId.eq(ownerIdEqual));
+        }
+
+        // (구독한 목록 + 본인 소유도 포함)
+        if (subscriberIdEqual != null) {
+            where.and(
+                    playlist.userId.eq(subscriberIdEqual)
+                            .or(
+                                    JPAExpressions.selectOne()
+                                            .from(subscribe)
+                                            .where(
+                                                    subscribe.userId.eq(subscriberIdEqual)
+                                                            .and(subscribe.playlistId.eq(playlist.id))
+                                            )
+                                            .exists()
+                            )
+            );
+        }
+
+        boolean isDesc = (sortDirection == null) || sortDirection == SortDirection.DESCENDING;
+
+        // 커서 조건 (cursor + idAfter)
+        if ("updatedAt".equalsIgnoreCase(sortBy)) {
+            if (cursorUpdatedAt != null && idAfter != null) {
+                if (isDesc) {
+                    where.and(
+                            playlist.updatedAt.lt(cursorUpdatedAt)
+                                    .or(playlist.updatedAt.eq(cursorUpdatedAt).and(playlist.id.lt(idAfter)))
+                    );
+                } else {
+                    where.and(
+                            playlist.updatedAt.gt(cursorUpdatedAt)
+                                    .or(playlist.updatedAt.eq(cursorUpdatedAt).and(playlist.id.gt(idAfter)))
+                    );
+                }
+            }
+        } else { // subscriberCount 정렬
+            if (cursorSubscriberCount != null && idAfter != null) {
+                if (isDesc) {
+                    where.and(
+                            playlist.subscriberCount.lt(cursorSubscriberCount)
+                                    .or(playlist.subscriberCount.eq(cursorSubscriberCount).and(playlist.id.lt(idAfter)))
+                    );
+                } else {
+                    where.and(
+                            playlist.subscriberCount.gt(cursorSubscriberCount)
+                                    .or(playlist.subscriberCount.eq(cursorSubscriberCount).and(playlist.id.gt(idAfter)))
+                    );
+                }
+            }
+        }
+
+        Order order = isDesc ? Order.DESC : Order.ASC;
+        List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+
+        if ("updatedAt".equalsIgnoreCase(sortBy)) {
+            orderSpecifiers.add(new OrderSpecifier<>(order, playlist.updatedAt));
+        } else {
+            orderSpecifiers.add(new OrderSpecifier<>(order, playlist.subscriberCount));
+        }
+        orderSpecifiers.add(new OrderSpecifier<>(order, playlist.id)); // tie-breaker
+
+        return queryFactory.selectFrom(playlist)
+                .where(where)
+                .orderBy(orderSpecifiers.toArray(new OrderSpecifier[0]))
+                .limit(limitPlusOne)
+                .fetch();
+    }
+}

--- a/mopl-core/src/main/java/com/mopl/domain/playlist/repository/PlaylistSubscribeRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/playlist/repository/PlaylistSubscribeRepository.java
@@ -17,7 +17,7 @@ public interface PlaylistSubscribeRepository extends JpaRepository<PlaylistSubsc
 
     List<PlaylistSubscribe> findAllByUserId(Long userId);
 
-    List<PlaylistSubscribe> findAllByUserIdAndPlaylistIdIn(Long userId, Collection<Long> playlistIds);
+    List<PlaylistSubscribe> findAllByUserIdAndPlaylistIdIn(Long userId, List<Long> playlistIds);
 
     void deleteAllByPlaylistId(Long playlistId);
 

--- a/mopl-core/src/main/java/com/mopl/domain/playlist/repository/PlaylistSubscribeRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/playlist/repository/PlaylistSubscribeRepository.java
@@ -13,13 +13,13 @@ public interface PlaylistSubscribeRepository extends JpaRepository<PlaylistSubsc
 
     Optional<PlaylistSubscribe> findByUserIdAndPlaylistId(Long userId, Long playlistId);
 
-    void deleteByUserIdAndPlaylistId(Long userId, Long playlistId);
+    long deleteByUserIdAndPlaylistId(Long userId, Long playlistId);
 
     List<PlaylistSubscribe> findAllByUserId(Long userId);
 
     List<PlaylistSubscribe> findAllByUserIdAndPlaylistIdIn(Long userId, List<Long> playlistIds);
 
-    void deleteAllByPlaylistId(Long playlistId);
+    long deleteAllByPlaylistId(Long playlistId);
 
     long countByPlaylistId(Long playlistId);
 }


### PR DESCRIPTION
close #72

## 🔄 변경 사항

- 인증 방식은 임시 X-User-Id에서 Principal 기반 전환
- Swagger Docs/Controller 간 검증 설정 불일치로 발생하던 HV000151 오류 수정

## 🧩 작업 사항
- [x] 플레이리스트 구독 / 구독 취소 API 구현
- [x] 플레이리스트에 콘텐츠 추가 / 삭제 API 구현
- [x] 단건 조회 응답에 contents/tags를 함께 채워 반환하도록 구현
- [x] 플레이리스트 목록 조회 커서 페이지네이션 구현 (정렬/커서 기반)
- [x] 요청자 식별을 Principal 기반으로 전환하고 X-User-Id 제거
- [x] PlaylistControllerDocs ↔ PlaylistController 간 검증(Validation) 설정 불일치로 발생한 HV000151 오류 수정

## 📸 스크린샷

- 구독 기능
<img width="1648" height="834" alt="image" src="https://github.com/user-attachments/assets/f2b8daa6-642a-4803-bba0-8846fb229c8b" />
<img width="1651" height="867" alt="image" src="https://github.com/user-attachments/assets/7aa5aa94-a3da-4c88-8c56-f2d3272b8304" />
<img width="1866" height="662" alt="image" src="https://github.com/user-attachments/assets/5013a947-3f1b-44c3-b39f-f2b82ba87fb2" />

- 목록 조회
<img width="1896" height="1252" alt="image" src="https://github.com/user-attachments/assets/f32b7103-8fab-42d2-bdc9-c7e419b37efa" />
<img width="1878" height="645" alt="image" src="https://github.com/user-attachments/assets/33e0d06e-df8d-40de-921c-8c800151a1dc" />

- 콘텐츠 기능
<img width="1944" height="927" alt="image" src="https://github.com/user-attachments/assets/a04c22ac-0c67-4508-ab2f-d5794b71cbf4" />
<img width="1837" height="944" alt="image" src="https://github.com/user-attachments/assets/a49412ce-564d-48b3-9f6d-3657a0e9919c" />
<img width="1867" height="682" alt="image" src="https://github.com/user-attachments/assets/5438780a-4448-4cc9-975d-b8f0246e8191" />
