### PR TITLE
[REFACTOR]: 팔로우 에러코드 및 예외처리 리팩토링

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/follow/exception/FollowErrorCode.java
+++ b/mopl-api/src/main/java/com/mopl/domain/follow/exception/FollowErrorCode.java
@@ -1,0 +1,20 @@
+package com.mopl.domain.follow.exception;
+
+import com.mopl.global.exception.DomainErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum FollowErrorCode implements DomainErrorCode {
+
+    CANNOT_FOLLOW_SELF("F001", "자기 자신을 팔로우할 수 없습니다.", HttpStatus.BAD_REQUEST), // 400
+    ALREADY_FOLLOWING("F002", "이미 팔로우 중인 사용자입니다.", HttpStatus.BAD_REQUEST), // 400
+    FOLLOW_NOT_FOUND("F003", "팔로우 관계가 존재하지 않습니다.", HttpStatus.NOT_FOUND) // 404
+    ;
+
+    private final String errorCode;
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/mopl-api/src/main/java/com/mopl/domain/follow/exception/FollowException.java
+++ b/mopl-api/src/main/java/com/mopl/domain/follow/exception/FollowException.java
@@ -1,0 +1,12 @@
+package com.mopl.domain.follow.exception;
+
+import com.mopl.global.exception.DomainException;
+import lombok.Getter;
+
+@Getter
+public class FollowException extends DomainException {
+
+    public FollowException(FollowErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/mopl-api/src/main/java/com/mopl/domain/follow/service/FollowService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/follow/service/FollowService.java
@@ -3,6 +3,8 @@ package com.mopl.domain.follow.service;
 import com.mopl.domain.follow.dto.request.FollowRequest;
 import com.mopl.domain.follow.dto.response.FollowResponse;
 import com.mopl.domain.follow.entity.Follow;
+import com.mopl.domain.follow.exception.FollowErrorCode;
+import com.mopl.domain.follow.exception.FollowException;
 import com.mopl.domain.follow.repository.FollowRepository;
 import com.mopl.domain.user.entity.User;
 import com.mopl.domain.user.repository.UserRepository;
@@ -27,13 +29,13 @@ public class FollowService {
 
         // 1. 자기 자신 팔로우 방지 (400)
         if (myId.equals(targetId)) {
-            throw new MoplException(ErrorCode.CANNOT_FOLLOW_SELF);
+            throw new FollowException(FollowErrorCode.CANNOT_FOLLOW_SELF);
         }
 
         // 2. 이미 팔로우 중인지 확인 (400)
         // // TODO: 동시성 이슈 체크할 것
         if (followRepository.existsByFollowerIdAndFolloweeId(myId, targetId)) {
-            throw new MoplException(ErrorCode.ALREADY_FOLLOWING);
+            throw new FollowException(FollowErrorCode.ALREADY_FOLLOWING);
         }
 
         // 3. 사용자 조회 (404)
@@ -58,7 +60,7 @@ public class FollowService {
     public void unfollow(Long myId, Long followId) {
         // 1. 팔로우 존재 확인 (404)
         Follow follow = followRepository.findById(followId)
-                .orElseThrow(() -> new MoplException(ErrorCode.FOLLOW_NOT_FOUND));
+                .orElseThrow(() -> new FollowException(FollowErrorCode.FOLLOW_NOT_FOUND));
 
         // 2. 언팔로우 권한 확인 (403)
         if (!follow.getFollower().getId().equals(myId)) {

--- a/mopl-api/src/test/java/com/mopl/domain/follow/controller/FollowApiTest.java
+++ b/mopl-api/src/test/java/com/mopl/domain/follow/controller/FollowApiTest.java
@@ -1,5 +1,6 @@
 package com.mopl.domain.follow.controller;
 
+import com.mopl.domain.follow.exception.FollowErrorCode;
 import tools.jackson.databind.ObjectMapper;
 import com.mopl.domain.follow.dto.request.FollowRequest;
 import com.mopl.domain.follow.entity.Follow;
@@ -83,8 +84,8 @@ class FollowApiTest {
                         .with(user(String.valueOf(user1.getId()))))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.title").value(ErrorCode.CANNOT_FOLLOW_SELF.name()))
-                .andExpect(jsonPath("$.detail").value(ErrorCode.CANNOT_FOLLOW_SELF.getMessage()));
+                .andExpect(jsonPath("$.title").value(FollowErrorCode.CANNOT_FOLLOW_SELF.name()))
+                .andExpect(jsonPath("$.detail").value(FollowErrorCode.CANNOT_FOLLOW_SELF.getMessage()));
     }
 
     @Test
@@ -102,8 +103,8 @@ class FollowApiTest {
                         .with(user(String.valueOf(user1.getId()))))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.title").value(ErrorCode.ALREADY_FOLLOWING.name()))
-                .andExpect(jsonPath("$.detail").value(ErrorCode.ALREADY_FOLLOWING.getMessage()));
+                .andExpect(jsonPath("$.title").value(FollowErrorCode.ALREADY_FOLLOWING.name()))
+                .andExpect(jsonPath("$.detail").value(FollowErrorCode.ALREADY_FOLLOWING.getMessage()));
     }
 
     // 3. 인증 실패 (401)

--- a/mopl-api/src/test/java/com/mopl/domain/follow/controller/UnFollowApiTest.java
+++ b/mopl-api/src/test/java/com/mopl/domain/follow/controller/UnFollowApiTest.java
@@ -1,6 +1,7 @@
 package com.mopl.domain.follow.controller;
 
 import com.mopl.domain.follow.entity.Follow;
+import com.mopl.domain.follow.exception.FollowErrorCode;
 import com.mopl.domain.follow.repository.FollowRepository;
 import com.mopl.domain.user.entity.User;
 import com.mopl.domain.user.repository.UserRepository;
@@ -100,7 +101,7 @@ class UnFollowApiTest {
                         .with(user(String.valueOf(user1.getId()))))
                 .andDo(print())
                 .andExpect(status().isNotFound()) // 404
-                .andExpect(jsonPath("$.title").value(ErrorCode.FOLLOW_NOT_FOUND.name()));
+                .andExpect(jsonPath("$.title").value(FollowErrorCode.FOLLOW_NOT_FOUND.name()));
     }
 
 }

--- a/mopl-core/src/main/java/com/mopl/global/exception/ErrorCode.java
+++ b/mopl-core/src/main/java/com/mopl/global/exception/ErrorCode.java
@@ -32,12 +32,7 @@ public enum ErrorCode {
 
     // 인가
     FORBIDDEN("접근 권한이 없습니다.", 403),
-    INSUFFICIENT_PERMISSIONS("해당 리소스에 대한 권한이 부족합니다.", 403),
-
-    // 팔로우
-    CANNOT_FOLLOW_SELF("자기 자신을 팔로우할 수 없습니다.", 400),
-    ALREADY_FOLLOWING("이미 팔로우 중인 사용자입니다.", 400),
-    FOLLOW_NOT_FOUND("팔로우 관계가 존재하지 않습니다.", 404)
+    INSUFFICIENT_PERMISSIONS("해당 리소스에 대한 권한이 부족합니다.", 403)
     ;
 
   private final String message;


### PR DESCRIPTION
## 연관 이슈


## 🔄 변경 사항

* **예외 처리:** 팔로우 도메인 전용 예외(`FollowException`, `FollowErrorCode`) 도입

## 🧩 작업 사항

**3. 팔로우 예외 처리 개선 (Refactor)**

* `FollowErrorCode` 및 `FollowException` 신규 생성 (기존 `MoplException` 대체)
* 서비스 로직 내 `CANNOT_FOLLOW_SELF`, `ALREADY_FOLLOWING` 등 예외 처리 교체

## 📸 스크린샷
