### PR TITLE
[FEAT] Redis 설정 및 JSON 직렬화 기반 마련

### DIFF
--- a/mopl-core/build.gradle
+++ b/mopl-core/build.gradle
@@ -26,6 +26,8 @@ dependencies {
     api 'org.springframework.boot:spring-boot-starter-data-redis'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-redis-test'
 
+    implementation 'org.springframework.boot:spring-boot-starter-json'
+
     // QueryDSL
     api 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
     annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'

--- a/mopl-core/src/main/java/com/mopl/global/redis/RedisConfig.java
+++ b/mopl-core/src/main/java/com/mopl/global/redis/RedisConfig.java
@@ -1,0 +1,51 @@
+package com.mopl.global.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJacksonJsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import tools.jackson.databind.ObjectMapper;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    /**
+     * Redis 연결을 위한 설정
+     * Lettuce 라이브러리를 사용해 Redis 서버와의 커넥션을 관리
+     */
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    /** 실질적으로 Redis에 데이터를 쓰고 읽는 템플릿 */
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory()); // 커넥션 팩토리 연결
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        GenericJacksonJsonRedisSerializer jsonSerializer = new GenericJacksonJsonRedisSerializer(objectMapper);
+
+
+        // key, value 직렬화
+        redisTemplate.setKeySerializer(new StringRedisSerializer()); // key는 String 직렬화
+        redisTemplate.setValueSerializer(jsonSerializer); // value는 JSON 직렬화
+
+        // Hash 구조를 사용할때의 key, value 직렬화
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(jsonSerializer);
+
+        return redisTemplate;
+    }
+}

--- a/mopl-core/src/main/java/com/mopl/global/redis/RedisManager.java
+++ b/mopl-core/src/main/java/com/mopl/global/redis/RedisManager.java
@@ -1,0 +1,49 @@
+package com.mopl.global.redis;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisManager {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    /** 데이터 저장 - 네임스페이스에 정의된 TTL 적용 */
+    public void save(RedisNameSpace namespace, String identifier, Object value) {
+        String key = namespace.createKey(identifier);
+        redisTemplate.opsForValue().set(key, value, namespace.getTtl());
+    }
+
+    /** 데이터 조회 */
+    public <T> Optional<T> findByKey(RedisNameSpace namespace, String identifier, Class<T> clazz) {
+        String key = namespace.createKey(identifier);
+        Object value = redisTemplate.opsForValue().get(key);
+
+        if(value == null) return Optional.empty();
+
+        try {
+            return Optional.of(clazz.cast(value));
+        } catch (ClassCastException e) {
+            log.error("Redis 타입 불일치 발생 - Key: {}, 예상 타입: {}, 실제 데이터 타입: {}",
+                    key, clazz.getSimpleName(), value.getClass().getSimpleName());
+            return Optional.empty();}
+    }
+
+    /** 데이터 삭제 */
+    public void delete(RedisNameSpace namespace, String identifier) {
+        String key = namespace.createKey(identifier);
+        redisTemplate.delete(key);
+    }
+
+    /** 키 존재 여부 확인 */
+    public boolean hasKey(RedisNameSpace namespace, String identifier) {
+        String key = namespace.createKey(identifier);
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+}

--- a/mopl-core/src/main/java/com/mopl/global/redis/RedisNameSpace.java
+++ b/mopl-core/src/main/java/com/mopl/global/redis/RedisNameSpace.java
@@ -1,0 +1,27 @@
+package com.mopl.global.redis;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.Duration;
+
+@Getter
+@RequiredArgsConstructor
+public enum RedisNameSpace {
+    // 인증 토큰
+    AUTH_TOKEN("auth", Duration.ofDays(7), false),
+
+    // 임시 비밀번호
+    TEMP_PASSWORD("cache", Duration.ofMinutes(3), true),
+
+    // 실시간 시청자 수
+    WATCHER_COUNT("chat", Duration.ofHours(1), false);
+
+    private final String prefix;
+    private final Duration ttl;
+    private final boolean evictable;
+
+    public String createKey(String identifier) {
+        return String.format("%s:%s", this.prefix, identifier);
+    }
+}


### PR DESCRIPTION
close #113 

## 🔄 변경 사항
- core 모듈에 jackson-databind 의존성 추가
- RedisManager 및 RedisConfig 구현 (GenericJacksonJson 활용)
- RedisNameSpace를 활용한 데이터 관리 정책 적용

## 🧩 작업 사항
`mopl-core/build.gradle`
- JSON 직렬화 의존성을 추가했습니다. redis에 값을 저장할 때 직렬화 필요

`mopl-core/src/main/java/com/mopl/global/redis/RedisConfig.java`
- Redis 서버와 연결하고, Redis에 저장되는 데이터를 JSON으로 직렬화/역직렬화하기 위한 설정 클래스입니다.
- value를 저장할 때 JSON 방식으로 저장하도록 설정했습니다.
- 이렇게 설정함으로써 RedisManage에서 객체를 그대로 Redis로 저장/삭제가 가능해집니다.

`mopl-core/src/main/java/com/mopl/global/redis/RedisManager.java`
- RedisManager는 RedisTemplate을 감싼 공용 유틸 클래스로, 네임스페이스 기반으로 데이터를 저장·조회·삭제하는 역할을 합니다.

`mopl-core/src/main/java/com/mopl/global/redis/RedisNameSpace.java`
- RedisNameSpace는 Redis key prefix와 TTL 정책을 enum으로 중앙 관리하는 설계입니다.
- 네임스페이스를 통해 단일 Redis를 논리적으로 분리해 사용하기 위해 설계했습니다.