### PR TITLE
[feat] 어드민 계정일 때 잠금 상태 변경 

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
@@ -35,7 +35,7 @@ public class AuthService {
     private String cookieSameSite;
 
     public JwtDto login(String username, String password, HttpServletResponse response) {
-        User user = userRepository.findByEmail(username)
+        User user = userRepository.findByEmailAndLockedFalse(username)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_EXIST));
 
         if (!passwordEncoder.matches(password, user.getPassword()))

--- a/mopl-api/src/main/java/com/mopl/domain/auth/service/EmailService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/service/EmailService.java
@@ -73,7 +73,7 @@ public class EmailService {
     /** 이메일 검증 */
     private void emailValid(String email) {
         userRepository.findByEmail(email)
-        .orElseThrow(() -> new UserException(UserErrorCode.EMAIL_NOT_EXIST));
+        .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_EXIST));
     }
 
 

--- a/mopl-api/src/main/java/com/mopl/domain/user/controller/UserController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/user/controller/UserController.java
@@ -3,7 +3,7 @@ package com.mopl.domain.user.controller;
 import com.mopl.domain.user.dto.UserCreateRequest;
 import com.mopl.domain.user.dto.UserDto;
 import com.mopl.domain.user.dto.UserRoleUpdateRequest;
-import com.mopl.domain.user.dto.UserSearchCondition;
+import com.mopl.domain.user.entity.User;
 import com.mopl.domain.user.service.UserService;
 import com.mopl.global.dto.PageResponse;
 import jakarta.validation.Valid;
@@ -30,6 +30,13 @@ public class UserController {
     @PatchMapping("/{userId}/role")
     public ResponseEntity<Void> updateRole(@PathVariable Long userId, @Valid @RequestBody UserRoleUpdateRequest request){
         userService.updateRole(userId, request.role());
+        return ResponseEntity.ok().build();
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PatchMapping("/{userId}/locked")
+    public ResponseEntity<Void> updateLocked(@PathVariable Long userId, @RequestBody UserLockUpdateRequest request){
+        userService.updateLocked(userId, request.locked());
         return ResponseEntity.ok().build();
     }
 

--- a/mopl-api/src/main/java/com/mopl/domain/user/controller/UserController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/user/controller/UserController.java
@@ -1,9 +1,6 @@
 package com.mopl.domain.user.controller;
 
-import com.mopl.domain.user.dto.UserCreateRequest;
-import com.mopl.domain.user.dto.UserDto;
-import com.mopl.domain.user.dto.UserRoleUpdateRequest;
-import com.mopl.domain.user.entity.User;
+import com.mopl.domain.user.dto.*;
 import com.mopl.domain.user.service.UserService;
 import com.mopl.global.dto.PageResponse;
 import jakarta.validation.Valid;

--- a/mopl-api/src/main/java/com/mopl/domain/user/controller/UserController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/user/controller/UserController.java
@@ -32,7 +32,7 @@ public class UserController {
 
     @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("/{userId}/locked")
-    public ResponseEntity<Void> updateLocked(@PathVariable Long userId, @RequestBody UserLockUpdateRequest request){
+    public ResponseEntity<Void> updateLocked(@PathVariable Long userId, @Valid @RequestBody UserLockUpdateRequest request){
         userService.updateLocked(userId, request.locked());
         return ResponseEntity.ok().build();
     }

--- a/mopl-api/src/main/java/com/mopl/domain/user/dto/UserLockUpdateRequest.java
+++ b/mopl-api/src/main/java/com/mopl/domain/user/dto/UserLockUpdateRequest.java
@@ -1,0 +1,6 @@
+package com.mopl.domain.user.dto;
+
+public record UserLockUpdateRequest(
+        boolean locked
+) {
+}

--- a/mopl-api/src/main/java/com/mopl/domain/user/dto/UserLockUpdateRequest.java
+++ b/mopl-api/src/main/java/com/mopl/domain/user/dto/UserLockUpdateRequest.java
@@ -1,6 +1,9 @@
 package com.mopl.domain.user.dto;
 
+import jakarta.validation.constraints.NotNull;
+
 public record UserLockUpdateRequest(
-        boolean locked
+        @NotNull(message = "잠금 여부는 필수 입력값입니다.")
+        Boolean locked
 ) {
 }

--- a/mopl-api/src/main/java/com/mopl/domain/user/exception/UserErrorCode.java
+++ b/mopl-api/src/main/java/com/mopl/domain/user/exception/UserErrorCode.java
@@ -10,9 +10,9 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorCode implements DomainErrorCode {
 
     USER_NOT_EXIST("U001", "존재하지 않는 사용자 입니다.", HttpStatus.NOT_FOUND),
-    PASSWORD_NOT_CORRECT("U002", "비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    PASSWORD_NOT_CORRECT("U002", "아이디 또는 비밀번호가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
     DUPLICATE_USER("U003","이미 존재하는 사용자입니다.", HttpStatus.CONFLICT),
-    EMAIL_NOT_EXIST("U004", "존재하지 않는 이메일 입니다.", HttpStatus.NOT_FOUND),
+//    EMAIL_NOT_EXIST("U004", "존재하지 않는 이메일 입니다.", HttpStatus.NOT_FOUND),
     ;
 
     private final String errorCode;

--- a/mopl-api/src/main/java/com/mopl/domain/user/service/UserService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.mopl.domain.user.service;
 
 import com.mopl.domain.user.dto.UserCreateRequest;
 import com.mopl.domain.user.dto.UserDto;
+import com.mopl.domain.user.dto.UserSearchCondition;
 import com.mopl.domain.user.entity.User;
 import com.mopl.domain.user.enums.Role;
 import com.mopl.domain.user.exception.UserErrorCode;

--- a/mopl-api/src/main/java/com/mopl/domain/user/service/UserService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/user/service/UserService.java
@@ -2,7 +2,6 @@ package com.mopl.domain.user.service;
 
 import com.mopl.domain.user.dto.UserCreateRequest;
 import com.mopl.domain.user.dto.UserDto;
-import com.mopl.domain.user.dto.UserSearchCondition;
 import com.mopl.domain.user.entity.User;
 import com.mopl.domain.user.enums.Role;
 import com.mopl.domain.user.exception.UserErrorCode;
@@ -55,6 +54,13 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_EXIST));
         user.updateRole(newRole);
+    }
+
+    @Transactional
+    public void updateLocked(Long userId, boolean newLocked) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_EXIST));
+        user.updateLocked(newLocked);
     }
 
     public PageResponse<UserDto> findAllUsers(UserSearchCondition searchCondition) {

--- a/mopl-core/src/main/java/com/mopl/domain/user/entity/User.java
+++ b/mopl-core/src/main/java/com/mopl/domain/user/entity/User.java
@@ -53,4 +53,8 @@ public class User extends BaseTimeEntity {
     public void updateRole(Role role){
         this.role = role;
     }
+
+    public void updateLocked(Boolean locked){
+        this.locked = locked;
+    }
 }

--- a/mopl-core/src/main/java/com/mopl/domain/user/repository/UserRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/user/repository/UserRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
     boolean existsByEmail(String email);
     Optional<User> findByEmail(String email);
+    Optional<User> findByEmailAndLockedFalse(String email);
 }


### PR DESCRIPTION
## 연관 이슈
close #117 

## 🔄 변경 사항
어드민 계정일 때 잠금 상태를 변경 가능
로그인 할 때 잠금 상태가 true일 시 로그인 불가 추가 

## 🧩 작업 사항
작업한 내용을 간략하게 설명해주세요.
- dto 추가
- 컨트롤러, 서비스 메서드 추가
- 엔티티에 메서드 추가 

## 📸 스크린샷
- 사용자가 유저일 때 
<img width="875" height="664" alt="image" src="https://github.com/user-attachments/assets/8e0da434-8897-4c72-90f9-5f383aa324ba" />
- 사용자가 어드민일 때 
<img width="596" height="497" alt="image" src="https://github.com/user-attachments/assets/46e6a656-f728-4758-adc6-83733dcb23b2" />
