### PR TITLE
[FEAT] DM 읽음 처리 API 구현

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/conversation/controller/ConversationController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/controller/ConversationController.java
@@ -36,4 +36,14 @@ public class ConversationController {
 
         return ResponseEntity.ok(results);
     }
+
+    @PostMapping("/{conversationId}/direct-messages/{directMessageId}/read")
+    public ResponseEntity<Void> markAsRead(@AuthenticationPrincipal UserPrincipal userPrincipal,
+                                           @PathVariable Long conversationId,
+                                           @PathVariable Long directMessageId) {
+
+        Long userId = userPrincipal.getUserId();
+        conversationService.updateAsRead(userId, conversationId, directMessageId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/service/ConversationService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/service/ConversationService.java
@@ -204,4 +204,16 @@ public class ConversationService {
 
         return new ConversationDto(conversation.getId(), withUserDto, lastMessageDto, hasUnread);
     }
+
+    // 대화방의 메시지 읽음 처리
+    @Transactional
+    public void updateAsRead(Long userId, Long conversationId, Long directMessageId) {
+        ReadStatus myStatus = readStatusRepository.findByConversationIdAndUserId(conversationId, userId)
+                .orElseThrow(() -> new ConversationException(CONVERSATION_NOT_FOUND));
+
+        DirectMessage message = directMessageRepository.findByIdAndConversationId(directMessageId, conversationId)
+                .orElseThrow(() -> new ConversationException(CONVERSATION_NOT_FOUND));
+
+        myStatus.updateLastReadMsg(message);
+    }
 }

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/entity/ReadStatus.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/entity/ReadStatus.java
@@ -28,6 +28,9 @@ public class ReadStatus {
     @JoinColumn(name = "last_message_id")
     private DirectMessage lastReadMessage;
 
+    @Column(name = "last_message_id", insertable = false, updatable = false)
+    private Long lastReadMessageId;
+
     public static ReadStatus create(Conversation conversation, User user) {
         ReadStatus readStatus = new ReadStatus();
         readStatus.conversation = conversation;
@@ -35,7 +38,14 @@ public class ReadStatus {
         return readStatus;
     }
 
-    public void updateLastReadMsg(DirectMessage lastReadMessage) {
-        this.lastReadMessage = lastReadMessage;
+    public void updateLastReadMsg(DirectMessage newMessage) {
+        if (this.lastReadMessageId == null) {
+            this.lastReadMessage = newMessage;
+            return;
+        }
+
+        if (newMessage.getId() > this.lastReadMessageId) {
+            this.lastReadMessage = newMessage;
+        }
     }
 }

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/repository/DirectMessageRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/repository/DirectMessageRepository.java
@@ -9,4 +9,6 @@ public interface DirectMessageRepository extends JpaRepository<DirectMessage, Lo
 
     // createdAt이 같을 수 있으므로 id로 2차 정렬
     Optional<DirectMessage> findTopByConversationIdOrderByCreatedAtDescIdDesc(Long conversationId);
+
+    Optional<DirectMessage> findByIdAndConversationId(Long directMessageId, Long conversationId);
 }


### PR DESCRIPTION
## 연관 이슈
close #44

## 🔄 변경 사항
DM 읽음 처리 API 추가

## 🧩 작업 사항
- 대화방의 특정 메시지까지 읽음 처리하는 엔드포인트 추가
- ReadStatus의 lastReadMessage 업데이트
- 해당 대화방의 참여자인지 확인하기 위해 다음처럼 조회
  - `readStatusRepository.findByConversationIdAndUserId(..)`,
  - `directMessageRepository.findByIdAndConversationId(..)`
- 코드 리뷰 반영
  - 네트워크 지연 등으로 과거 메시지 읽음 요청이 늦게 도착할 경우, 최신 읽음 상태가 덮어씌워지는 문제 방지
  - ReadStatus 엔티티 내 읽기 전용 lastReadMessageId 필드 추가
  - 메시지 객체 로딩 없이 ID 값만으로 비교해 불필요한 쿼리 발생 차단

## 📸 스크린샷
- 읽기 전 조회
  <img width="1354" height="1137" alt="image" src="https://github.com/user-attachments/assets/fee953a0-dd11-4895-9c66-179baf21bbcd" />

- 읽음처리 후 조회 (동일 조건)
  <img width="1356" height="728" alt="image" src="https://github.com/user-attachments/assets/e9b5b816-c9a4-4929-b3dc-0b4ab5e167c2" />

- 예외: 해당 메시지의 대화방 정보가 일치하지 않은 경우
  <img width="1354" height="210" alt="image" src="https://github.com/user-attachments/assets/f1eb9449-8df3-426a-b16d-fa6e93bb3e69" />

- 예외: 본인이 속한 대화방이 아닌 것을 조회한 경우
  - 사용자에게 상세 에러를 노출하지 않기 위해 CONVERSATION_NOT_FOUND로 통일
  <img width="1352" height="207" alt="image" src="https://github.com/user-attachments/assets/825af3fb-7c64-4bd1-889e-a215d7f990ca" />
