### PR TITLE
[feat]Auth refresh 토큰 재발급 

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/auth/controller/AuthController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/controller/AuthController.java
@@ -36,7 +36,10 @@ public class AuthController {
         return ResponseEntity.ok().build();
     }
 
-//    @PostMapping("/refresh")
-//    public ResponseEntity<JwtDto> refresh(@Valid @RequestBody JwtDto req) {}
+    @PostMapping("/refresh")
+    public ResponseEntity<JwtDto> refresh(@CookieValue("REFRESH_TOKEN") String refreshToken, HttpServletResponse response) {
+        JwtDto jwtDto = authService.refresh(refreshToken, response);
+        return ResponseEntity.ok().body(jwtDto);
+    }
 
 }

--- a/mopl-api/src/main/java/com/mopl/domain/auth/exception/AuthErrorCode.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/exception/AuthErrorCode.java
@@ -1,0 +1,20 @@
+package com.mopl.domain.auth.exception;
+
+import com.mopl.global.exception.DomainErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode implements DomainErrorCode {
+
+    REFRESH_TOKEN_INVALID("A001", "유효하지 않은 리프레시 토큰입니다.", HttpStatus.UNAUTHORIZED),
+
+    ;
+
+    private final String errorCode;
+    private final String message;
+    private final HttpStatus httpStatus;
+}
+

--- a/mopl-api/src/main/java/com/mopl/domain/auth/exception/AuthException.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/exception/AuthException.java
@@ -1,0 +1,12 @@
+package com.mopl.domain.auth.exception;
+
+import com.mopl.global.exception.DomainException;
+import lombok.Getter;
+
+@Getter
+public class AuthException extends DomainException {
+
+    public AuthException(AuthErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
@@ -34,6 +34,12 @@ public class AuthService {
     @Value("${jwt.cookie.same-site:Lax}")  // 기본값 Lax
     private String cookieSameSite;
 
+    @Value("${jwt.access-token-validity}")
+    private int accessTokenMaxAge;
+
+    @Value("${jwt.refresh-token-validity}")
+    private int refreshTokenMaxAge;
+
     public JwtDto login(String username, String password, HttpServletResponse response) {
         User user = userRepository.findByEmail(username)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_EXIST));
@@ -46,8 +52,8 @@ public class AuthService {
 
         JwtDto jwtDto = new JwtDto(userMapper.toDto(user), accessToken);
 
-        addTokenCookie(response, "ACCESS_TOKEN", accessToken, 60 * 60); //1시간
-        addTokenCookie(response, "REFRESH_TOKEN", refreshToken, 60 * 60 * 24 * 14); //2주
+        addTokenCookie(response, "ACCESS_TOKEN", accessToken, accessTokenMaxAge); //1시간
+        addTokenCookie(response, "REFRESH_TOKEN", refreshToken, refreshTokenMaxAge); //2주
 
         return jwtDto;
     }
@@ -56,20 +62,22 @@ public class AuthService {
         deleteCookie(response, "ACCESS_TOKEN");
         deleteCookie(response, "REFRESH_TOKEN");
     }
+
     public JwtDto refresh(String refreshToken, HttpServletResponse response) {
         if (!jwtTokenProvider.validateRefreshToken(refreshToken)) {
             throw new AuthException(AuthErrorCode.REFRESH_TOKEN_INVALID);
         }
         Long userId = jwtTokenProvider.getUserId(refreshToken);
-        User user =  userRepository.findById(userId)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_EXIST));
-        String newaccessToken = jwtTokenProvider.createAccessToken(user);
-        String newrefreshToken = jwtTokenProvider.createRefreshToken(user);
-        JwtDto jwtDto = new JwtDto(userMapper.toDto(user), newaccessToken);
-        addTokenCookie(response, "ACCESS_TOKEN", newaccessToken, 60 * 60); //1시간
-        addTokenCookie(response, "REFRESH_TOKEN", newrefreshToken, 60 * 60 * 24 * 14); //2주
+        String newAccessToken = jwtTokenProvider.createAccessToken(user);
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(user);
+        JwtDto jwtDto = new JwtDto(userMapper.toDto(user), newAccessToken);
 
-        return  jwtDto;
+        addTokenCookie(response, "ACCESS_TOKEN", newAccessToken, accessTokenMaxAge); //1시간
+        addTokenCookie(response, "REFRESH_TOKEN", newRefreshToken, refreshTokenMaxAge); //2주
+
+        return jwtDto;
     }
 
     private void addTokenCookie(HttpServletResponse response, String name, String value, int maxAge) {

--- a/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
@@ -34,12 +34,6 @@ public class AuthService {
     @Value("${jwt.cookie.same-site:Lax}")  // 기본값 Lax
     private String cookieSameSite;
 
-    @Value("${jwt.access-token-validity}")
-    private int accessTokenMaxAge;
-
-    @Value("${jwt.refresh-token-validity}")
-    private int refreshTokenMaxAge;
-
     public JwtDto login(String username, String password, HttpServletResponse response) {
         User user = userRepository.findByEmail(username)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_EXIST));
@@ -52,8 +46,8 @@ public class AuthService {
 
         JwtDto jwtDto = new JwtDto(userMapper.toDto(user), accessToken);
 
-        addTokenCookie(response, "ACCESS_TOKEN", accessToken, accessTokenMaxAge); //1시간
-        addTokenCookie(response, "REFRESH_TOKEN", refreshToken, refreshTokenMaxAge); //2주
+        addTokenCookie(response, "ACCESS_TOKEN", accessToken, 60 * 60); //1시간
+        addTokenCookie(response, "REFRESH_TOKEN", refreshToken, 60 * 60 * 24 * 14); //2주
 
         return jwtDto;
     }
@@ -74,8 +68,8 @@ public class AuthService {
         String newRefreshToken = jwtTokenProvider.createRefreshToken(user);
         JwtDto jwtDto = new JwtDto(userMapper.toDto(user), newAccessToken);
 
-        addTokenCookie(response, "ACCESS_TOKEN", newAccessToken, accessTokenMaxAge);
-        addTokenCookie(response, "REFRESH_TOKEN", newRefreshToken, refreshTokenMaxAge);
+        addTokenCookie(response, "ACCESS_TOKEN", newAccessToken, 60 * 60);
+        addTokenCookie(response, "REFRESH_TOKEN", newRefreshToken, 60 * 60 * 24 * 14);
 
         return jwtDto;
     }

--- a/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
@@ -74,8 +74,8 @@ public class AuthService {
         String newRefreshToken = jwtTokenProvider.createRefreshToken(user);
         JwtDto jwtDto = new JwtDto(userMapper.toDto(user), newAccessToken);
 
-        addTokenCookie(response, "ACCESS_TOKEN", newAccessToken, accessTokenMaxAge); //1시간
-        addTokenCookie(response, "REFRESH_TOKEN", newRefreshToken, refreshTokenMaxAge); //2주
+        addTokenCookie(response, "ACCESS_TOKEN", newAccessToken, accessTokenMaxAge);
+        addTokenCookie(response, "REFRESH_TOKEN", newRefreshToken, refreshTokenMaxAge);
 
         return jwtDto;
     }

--- a/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
@@ -1,6 +1,8 @@
 package com.mopl.domain.auth.service;
 
 import com.mopl.domain.auth.dto.JwtDto;
+import com.mopl.domain.auth.exception.AuthErrorCode;
+import com.mopl.domain.auth.exception.AuthException;
 import com.mopl.domain.auth.jwt.JwtTokenProvider;
 import com.mopl.domain.user.entity.User;
 import com.mopl.domain.user.exception.UserErrorCode;
@@ -54,6 +56,21 @@ public class AuthService {
         deleteCookie(response, "ACCESS_TOKEN");
         deleteCookie(response, "REFRESH_TOKEN");
     }
+    public JwtDto refresh(String refreshToken, HttpServletResponse response) {
+        if (!jwtTokenProvider.validateRefreshToken(refreshToken)) {
+            throw new AuthException(AuthErrorCode.REFRESH_TOKEN_INVALID);
+        }
+        Long userId = jwtTokenProvider.getUserId(refreshToken);
+        User user =  userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_EXIST));
+        String newaccessToken = jwtTokenProvider.createAccessToken(user);
+        String newrefreshToken = jwtTokenProvider.createRefreshToken(user);
+        JwtDto jwtDto = new JwtDto(userMapper.toDto(user), newaccessToken);
+        addTokenCookie(response, "ACCESS_TOKEN", newaccessToken, 60 * 60); //1시간
+        addTokenCookie(response, "REFRESH_TOKEN", newrefreshToken, 60 * 60 * 24 * 14); //2주
+
+        return  jwtDto;
+    }
 
     private void addTokenCookie(HttpServletResponse response, String name, String value, int maxAge) {
         ResponseCookie cookie = ResponseCookie.from(name, value)
@@ -76,5 +93,4 @@ public class AuthService {
                 .build();
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
-
 }


### PR DESCRIPTION
## 연관 이슈
close #120 

## 🔄 변경 사항
요청에서 쿠키에 있던 refresh 토큰을 받아서 토큰 재 발급
AuthController, AuthService에 메서드 추가
AuthException 추가 

관련된 컨트롤러 서비스 
## 🧩 작업 사항
작업한 내용을 간략하게 설명해주세요.
- Controller API 엔드포인트 구현
- exception 추가 
- `Service 비즈니스 로직 구현 - refresh 토큰 유효 인증, 해당 사용자 확인,새로운 토큰 발급
- application.yml 에  선언된 maxage 쓰기 

## 📸 스크린샷
- 프론트에서 refresh가 200 ok 찍히는 것을 확인
- accesstoken이 변경되는 거 확인 
- 15분이 지나도 로그인이 유지되는거 확인 