### PR TITLE
[feat] 특정 사용자와의 대화방 조회 API 및 기능 구현 및 conversation 서비스 코드 리팩토링

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/conversation/controller/ConversationController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/controller/ConversationController.java
@@ -22,8 +22,8 @@ public class ConversationController {
     @PostMapping
     public ResponseEntity<ConversationDto> create(@AuthenticationPrincipal UserPrincipal userPrincipal,
                                                   @RequestBody @Valid ConversationCreateRequest createRequest) {
-        Long userId = userPrincipal.getUserId();
-        ConversationDto conversationDto = conversationService.createConversation(userId, createRequest);
+        Long myId = userPrincipal.getUserId();
+        ConversationDto conversationDto = conversationService.createConversation(myId, createRequest);
         return ResponseEntity.ok(conversationDto);
     }
 
@@ -31,8 +31,8 @@ public class ConversationController {
     public ResponseEntity<PageResponse<ConversationDto>> findAll(@AuthenticationPrincipal UserPrincipal userPrincipal,
                                                                  @ModelAttribute @Valid ConversationSearchCondition searchCondition) {
 
-        Long userId = userPrincipal.getUserId();
-        PageResponse<ConversationDto> results = conversationService.findMyAllConversations(searchCondition, userId);
+        Long myId = userPrincipal.getUserId();
+        PageResponse<ConversationDto> results = conversationService.findMyAllConversations(searchCondition, myId);
 
         return ResponseEntity.ok(results);
     }
@@ -42,8 +42,8 @@ public class ConversationController {
                                            @PathVariable Long conversationId,
                                            @PathVariable Long directMessageId) {
 
-        Long userId = userPrincipal.getUserId();
-        conversationService.updateAsRead(userId, conversationId, directMessageId);
+        Long myId = userPrincipal.getUserId();
+        conversationService.updateAsRead(myId, conversationId, directMessageId);
         return ResponseEntity.ok().build();
     }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/controller/ConversationController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/controller/ConversationController.java
@@ -4,6 +4,7 @@ import com.mopl.domain.auth.dto.UserPrincipal;
 import com.mopl.domain.conversation.dto.request.ConversationCreateRequest;
 import com.mopl.domain.conversation.dto.request.ConversationSearchCondition;
 import com.mopl.domain.conversation.dto.response.ConversationDto;
+import com.mopl.domain.conversation.dto.response.ConversationSimpleDto;
 import com.mopl.domain.conversation.service.ConversationService;
 import com.mopl.global.dto.PageResponse;
 import jakarta.validation.Valid;
@@ -45,5 +46,13 @@ public class ConversationController {
         Long myId = userPrincipal.getUserId();
         conversationService.updateAsRead(myId, conversationId, directMessageId);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/with")
+    public ResponseEntity<ConversationSimpleDto> getConversationWithUser(@AuthenticationPrincipal UserPrincipal userPrincipal,
+                                                                             @RequestParam("userId") Long withUserId) {
+        Long myId = userPrincipal.getUserId();
+        ConversationSimpleDto simpleDto = conversationService.findConversationWithUser(myId, withUserId);
+        return ResponseEntity.ok(simpleDto);
     }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/dto/response/ConversationSimpleDto.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/dto/response/ConversationSimpleDto.java
@@ -1,0 +1,6 @@
+package com.mopl.domain.conversation.dto.response;
+
+public record ConversationSimpleDto(
+        Long id // conversationId
+) {
+}

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/exception/ConversationErrorCode.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/exception/ConversationErrorCode.java
@@ -8,8 +8,12 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ConversationErrorCode implements DomainErrorCode {
+    // Conversation
     CONVERSATION_NOT_FOUND("CV001", "대화방을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    SELF_CONVERSATION_NOT_ALLOWED("CV002", "자기 자신과는 대화할 수 없습니다.", HttpStatus.BAD_REQUEST)
+    SELF_CONVERSATION_NOT_ALLOWED("CV002", "자기 자신과는 대화할 수 없습니다.", HttpStatus.BAD_REQUEST),
+
+    // DM
+    MESSAGE_NOT_FOUND("DM001", "메시지를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     ;
 
     private final String errorCode;

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/service/ConversationService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/service/ConversationService.java
@@ -26,8 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static com.mopl.domain.conversation.exception.ConversationErrorCode.CONVERSATION_NOT_FOUND;
-import static com.mopl.domain.conversation.exception.ConversationErrorCode.SELF_CONVERSATION_NOT_ALLOWED;
+import static com.mopl.domain.conversation.exception.ConversationErrorCode.*;
 
 @Slf4j
 @Service
@@ -150,7 +149,7 @@ public class ConversationService {
                 .orElseThrow(() -> new ConversationException(CONVERSATION_NOT_FOUND));
 
         DirectMessage message = directMessageRepository.findByIdAndConversationId(directMessageId, conversationId)
-                .orElseThrow(() -> new ConversationException(CONVERSATION_NOT_FOUND));
+                .orElseThrow(() -> new ConversationException(MESSAGE_NOT_FOUND));
 
         myStatus.updateLastReadMsg(message);
     }

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/service/ConversationService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/service/ConversationService.java
@@ -41,17 +41,17 @@ public class ConversationService {
     private final DirectMessageRepository directMessageRepository;
 
     @Transactional
-    public ConversationDto createConversation(Long userId, ConversationCreateRequest createRequest) {
+    public ConversationDto createConversation(Long myId, ConversationCreateRequest createRequest) {
         Long withUserId = createRequest.withUserId();
-        if (userId.equals(withUserId)) {
+        if (myId.equals(withUserId)) {
             throw new ConversationException(SELF_CONVERSATION_NOT_ALLOWED);
         }
 
-        User me = getUserOrThrow(userId);
+        User me = getUserOrThrow(myId);
         User targetUser = getUserOrThrow(withUserId);
 
-        return conversationRepository.findByParticipants(userId, withUserId)
-                .map(conversation -> convertToDtoWithTarget(conversation, me, targetUser))
+        return conversationRepository.findByParticipants(myId, withUserId)
+                .map(conversation -> fetchDetailsAndConvertToDto(conversation, me.getId(), targetUser))
                 .orElseGet(() -> createNewConversation(me, targetUser));
     }
 
@@ -64,59 +64,20 @@ public class ConversationService {
         ReadStatus targetReadStatus = ReadStatus.create(newConversation, target);
         readStatusRepository.saveAll(List.of(myReadStatus, targetReadStatus));
 
-        UserSummaryDto targetUserDto = new UserSummaryDto(target.getId(), target.getName(), target.getProfileImageUrl());
-
-        return new ConversationDto(
-                newConversation.getId(),
-                targetUserDto,
-                null,
-                false
-        );
+        return convertToDto(newConversation, me.getId(), target, myReadStatus, null);
     }
 
-    private ConversationDto convertToDtoWithTarget(Conversation conversation, User me, User target) {
-        UserSummaryDto withUserDto = new UserSummaryDto(target.getId(), target.getName(), target.getProfileImageUrl());
-
+    /**
+     * 추가 정보(채팅방의 마지막 메시지, 나의 읽음 상태) DB 조회 후 DTO로 컨버팅
+     */
+    private ConversationDto fetchDetailsAndConvertToDto(Conversation conversation, Long myId, User target) {
         DirectMessage lastMessage = directMessageRepository.findTopByConversationIdOrderByCreatedAtDescIdDesc(conversation.getId())
                 .orElse(null);
 
-        if (lastMessage == null) {
-            return new ConversationDto(conversation.getId(),
-                    withUserDto,
-                    null,
-                    false);
-        }
-
-        User sender = lastMessage.getAuthor();
-        UserSummaryDto senderDto = null;
-        UserSummaryDto receiverDto = null;
-
-        if (sender.getId().equals(me.getId())) {
-            senderDto = new UserSummaryDto(me.getId(),
-                    me.getName(),
-                    me.getProfileImageUrl());
-            receiverDto = new UserSummaryDto(target.getId(), target.getName(), target.getProfileImageUrl());
-        } else {
-            senderDto = new UserSummaryDto(target.getId(), target.getName(), target.getProfileImageUrl());
-            receiverDto = new UserSummaryDto(me.getId(),
-                    me.getName(),
-                    me.getProfileImageUrl());
-        }
-
-        LastMessage lastMessageDto = new LastMessage(lastMessage.getId(),
-                conversation.getId(),
-                lastMessage.getCreatedAt(),
-                senderDto,
-                receiverDto,
-                lastMessage.getContent());
-
-        ReadStatus myReadStatus = readStatusRepository.findByConversationIdAndUserId(conversation.getId(), me.getId())
+        ReadStatus myReadStatus = readStatusRepository.findByConversationIdAndUserId(conversation.getId(), myId)
                 .orElseThrow(() -> new ConversationException(CONVERSATION_NOT_FOUND));
 
-        long lastReadMsgId = myReadStatus.getLastReadMessage() != null ? myReadStatus.getLastReadMessage().getId() : 0L;
-        boolean hasUnread = lastReadMsgId < lastMessage.getId();
-
-        return new ConversationDto(conversation.getId(), withUserDto, lastMessageDto, hasUnread);
+        return convertToDto(conversation, myId, target, myReadStatus, lastMessage);
     }
 
     private User getUserOrThrow(Long userId) {
@@ -125,13 +86,13 @@ public class ConversationService {
     }
 
     // 대화 목록 전체 조회 (커서 페이지네이션)
-    public PageResponse<ConversationDto> findMyAllConversations(ConversationSearchCondition searchCondition, long userId) {
+    public PageResponse<ConversationDto> findMyAllConversations(ConversationSearchCondition searchCondition, long myId) {
         String keyword = searchCondition.keywordLike();
         LocalDateTime cursor = searchCondition.cursor();
         Long idAfter = searchCondition.idAfter();
         int limit = searchCondition.limit();
 
-        List<Tuple> myConversations = conversationRepository.findMyConversations(userId, keyword, cursor, idAfter, limit + 1);
+        List<Tuple> myConversations = conversationRepository.findMyConversations(myId, keyword, cursor, idAfter, limit + 1);
 
         boolean hasNext = false;
         if (myConversations.size() > limit) {
@@ -140,7 +101,7 @@ public class ConversationService {
         }
 
         List<ConversationDto> dtos = myConversations.stream()
-                .map(tuple -> convertToDto(tuple, userId))
+                .map(tuple -> tupleToDto(tuple, myId))
                 .toList();
 
         String nextCursor = null;
@@ -172,48 +133,50 @@ public class ConversationService {
                 .build();
     }
 
-    private ConversationDto convertToDto(Tuple tuple, Long userId) {
+    // 추후 리포지토리에서 DTO를 받아오게 변경할 예정
+    private ConversationDto tupleToDto(Tuple tuple, Long myId) {
         Conversation conversation = tuple.get(0, Conversation.class);
         User targetUser = tuple.get(1, User.class);
         DirectMessage message = tuple.get(2, DirectMessage.class);
         ReadStatus myStatus = tuple.get(3, ReadStatus.class);
 
-        UserSummaryDto withUserDto = new UserSummaryDto(targetUser.getId(), targetUser.getName(), targetUser.getProfileImageUrl());
-
-        if (message == null) {
-            return new ConversationDto(conversation.getId(), withUserDto, null, false);
-        }
-
-        boolean isSenderMe = message.getAuthor().getId().equals(userId);
-        UserSummaryDto meSummaryDto = new UserSummaryDto(userId, "me", null); // 아이디 외 정보 생략
-
-        UserSummaryDto sender = isSenderMe ? meSummaryDto : withUserDto;
-        UserSummaryDto receiver = isSenderMe ? withUserDto : meSummaryDto;
-
-        LastMessage lastMessageDto = new LastMessage(
-                message.getId(),
-                conversation.getId(),
-                message.getCreatedAt(),
-                sender,
-                receiver,
-                message.getContent()
-        );
-
-        long lastReadMsgId = myStatus.getLastReadMessage() != null ? myStatus.getLastReadMessage().getId() : 0L;
-        boolean hasUnread = lastReadMsgId < message.getId();
-
-        return new ConversationDto(conversation.getId(), withUserDto, lastMessageDto, hasUnread);
+        return convertToDto(conversation, myId, targetUser, myStatus, message);
     }
 
     // 대화방의 메시지 읽음 처리
     @Transactional
-    public void updateAsRead(Long userId, Long conversationId, Long directMessageId) {
-        ReadStatus myStatus = readStatusRepository.findByConversationIdAndUserId(conversationId, userId)
+    public void updateAsRead(Long myId, Long conversationId, Long directMessageId) {
+        ReadStatus myStatus = readStatusRepository.findByConversationIdAndUserId(conversationId, myId)
                 .orElseThrow(() -> new ConversationException(CONVERSATION_NOT_FOUND));
 
         DirectMessage message = directMessageRepository.findByIdAndConversationId(directMessageId, conversationId)
                 .orElseThrow(() -> new ConversationException(CONVERSATION_NOT_FOUND));
 
         myStatus.updateLastReadMsg(message);
+    }
+
+    private ConversationDto convertToDto(Conversation conversation, Long myId, User targetUser,
+                                         ReadStatus myReadStatus, DirectMessage lastMessage) {
+
+        Long conversationId = conversation.getId();
+        UserSummaryDto with = new UserSummaryDto(targetUser.getId(), targetUser.getName(), targetUser.getProfileImageUrl());
+
+        if (lastMessage == null) {
+            return new ConversationDto(conversationId, with, null, false);
+        }
+
+        boolean isSenderMe = lastMessage.getAuthor().getId().equals(myId);
+        UserSummaryDto mySummaryDto = new UserSummaryDto(myId, "me", null); // 아이디 외 정보 생략
+
+        UserSummaryDto sender = isSenderMe ? mySummaryDto : with;
+        UserSummaryDto receiver = isSenderMe ? with : mySummaryDto;
+
+        LastMessage lastMessageDto = new LastMessage(lastMessage.getId(), conversationId, lastMessage.getCreatedAt(),
+                                                     sender, receiver, lastMessage.getContent());
+
+        long myLastReadMsgId = myReadStatus.getLastReadMessage() != null ? myReadStatus.getLastReadMessage().getId() : 0L;
+        boolean hasUnread = myLastReadMsgId < lastMessage.getId();
+
+        return new ConversationDto(conversationId, with, lastMessageDto, hasUnread);
     }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/service/ConversationService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/service/ConversationService.java
@@ -4,6 +4,7 @@ import com.mopl.domain.conversation.dto.ConversationQueryResult;
 import com.mopl.domain.conversation.dto.request.ConversationCreateRequest;
 import com.mopl.domain.conversation.dto.request.ConversationSearchCondition;
 import com.mopl.domain.conversation.dto.response.ConversationDto;
+import com.mopl.domain.conversation.dto.response.ConversationSimpleDto;
 import com.mopl.domain.conversation.dto.response.LastMessage;
 import com.mopl.domain.conversation.entity.Conversation;
 import com.mopl.domain.conversation.entity.DirectMessage;
@@ -151,6 +152,21 @@ public class ConversationService {
                 .orElseThrow(() -> new ConversationException(MESSAGE_NOT_FOUND));
 
         myStatus.updateLastReadMsg(message);
+    }
+
+    // 특정 사용자와의 대화 조회
+    public ConversationSimpleDto findConversationWithUser(Long myId, Long withUserId) {
+        Conversation conversation = conversationRepository.findByParticipants(myId, withUserId)
+                .orElseThrow(() -> new ConversationException(CONVERSATION_NOT_FOUND));
+
+        return new ConversationSimpleDto(conversation.getId());
+
+/*
+        // 특정 사용자와의 대화 조회할 때 상대방 정보, 최신 메시지, 읽음 상태 등 다른 정보가 추가로 필요한 경우 아래 로직 사용
+        ConversationQueryResult queryResult = conversationRepository.findConversationQueryResult(myId, withUserId)
+                .orElseThrow(() -> new ConversationException(CONVERSATION_NOT_FOUND));
+        return queryResultToDto(queryResult, myId);
+*/
     }
 
     private ConversationDto convertToDto(Conversation conversation, Long myId, User targetUser,

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/service/ConversationService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/service/ConversationService.java
@@ -1,5 +1,6 @@
 package com.mopl.domain.conversation.service;
 
+import com.mopl.domain.conversation.dto.ConversationQueryResult;
 import com.mopl.domain.conversation.dto.request.ConversationCreateRequest;
 import com.mopl.domain.conversation.dto.request.ConversationSearchCondition;
 import com.mopl.domain.conversation.dto.response.ConversationDto;
@@ -17,7 +18,6 @@ import com.mopl.domain.user.exception.UserErrorCode;
 import com.mopl.domain.user.exception.UserException;
 import com.mopl.domain.user.repository.UserRepository;
 import com.mopl.global.dto.PageResponse;
-import com.querydsl.core.Tuple;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -91,7 +91,7 @@ public class ConversationService {
         Long idAfter = searchCondition.idAfter();
         int limit = searchCondition.limit();
 
-        List<Tuple> myConversations = conversationRepository.findMyConversations(myId, keyword, cursor, idAfter, limit + 1);
+        List<ConversationQueryResult> myConversations = conversationRepository.findMyConversations(myId, keyword, cursor, idAfter, limit + 1);
 
         boolean hasNext = false;
         if (myConversations.size() > limit) {
@@ -100,7 +100,7 @@ public class ConversationService {
         }
 
         List<ConversationDto> dtos = myConversations.stream()
-                .map(tuple -> tupleToDto(tuple, myId))
+                .map(tuple -> queryResultToDto(tuple, myId))
                 .toList();
 
         String nextCursor = null;
@@ -112,8 +112,8 @@ public class ConversationService {
             if (lastConversation.lastestMessage() != null) {
                 nextCursor = lastConversation.lastestMessage().createdAt().toString();
             } else {
-                Tuple lastTuple = myConversations.get(myConversations.size() - 1);
-                Conversation lastEntity = lastTuple.get(0, Conversation.class);
+                ConversationQueryResult lastQueryResult = myConversations.get(myConversations.size() - 1);
+                Conversation lastEntity = lastQueryResult.conversation();
 
                 nextCursor = lastEntity.getCreatedAt().toString();
             }
@@ -132,12 +132,11 @@ public class ConversationService {
                 .build();
     }
 
-    // 추후 리포지토리에서 DTO를 받아오게 변경할 예정
-    private ConversationDto tupleToDto(Tuple tuple, Long myId) {
-        Conversation conversation = tuple.get(0, Conversation.class);
-        User targetUser = tuple.get(1, User.class);
-        DirectMessage message = tuple.get(2, DirectMessage.class);
-        ReadStatus myStatus = tuple.get(3, ReadStatus.class);
+    private ConversationDto queryResultToDto(ConversationQueryResult queryResult, Long myId) {
+        Conversation conversation = queryResult.conversation();
+        User targetUser = queryResult.targetUser();
+        DirectMessage message = queryResult.lastMessage();
+        ReadStatus myStatus = queryResult.myReadStatus();
 
         return convertToDto(conversation, myId, targetUser, myStatus, message);
     }

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/service/ConversationService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/service/ConversationService.java
@@ -101,7 +101,7 @@ public class ConversationService {
         }
 
         List<ConversationDto> dtos = myConversations.stream()
-                .map(tuple -> queryResultToDto(tuple, myId))
+                .map(result -> queryResultToDto(result, myId))
                 .toList();
 
         String nextCursor = null;

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/dto/ConversationQueryResult.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/dto/ConversationQueryResult.java
@@ -1,0 +1,14 @@
+package com.mopl.domain.conversation.dto;
+
+import com.mopl.domain.conversation.entity.Conversation;
+import com.mopl.domain.conversation.entity.DirectMessage;
+import com.mopl.domain.conversation.entity.ReadStatus;
+import com.mopl.domain.user.entity.User;
+
+public record ConversationQueryResult(
+        Conversation conversation,
+        User targetUser,
+        DirectMessage lastMessage,
+        ReadStatus myReadStatus
+) {
+}

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ConversationRepositoryCustom.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ConversationRepositoryCustom.java
@@ -1,10 +1,10 @@
 package com.mopl.domain.conversation.repository;
 
-import com.querydsl.core.Tuple;
+import com.mopl.domain.conversation.dto.ConversationQueryResult;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ConversationRepositoryCustom {
-    List<Tuple> findMyConversations(Long userId, String keyword, LocalDateTime cursor, Long idAfter, int limit);
+    List<ConversationQueryResult> findMyConversations(Long userId, String keyword, LocalDateTime cursor, Long idAfter, int limit);
 }

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ConversationRepositoryCustom.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ConversationRepositoryCustom.java
@@ -4,7 +4,10 @@ import com.mopl.domain.conversation.dto.ConversationQueryResult;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface ConversationRepositoryCustom {
     List<ConversationQueryResult> findMyConversations(Long userId, String keyword, LocalDateTime cursor, Long idAfter, int limit);
+
+    Optional<ConversationQueryResult> findConversationQueryResult(Long myId, Long withUserId);
 }

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ConversationRepositoryCustomImpl.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ConversationRepositoryCustomImpl.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static com.mopl.domain.conversation.entity.QConversation.conversation;
 
@@ -67,6 +68,41 @@ public class ConversationRepositoryCustomImpl implements ConversationRepositoryC
                 ).orderBy(sortDateTime.desc(), conversation.id.desc())
                 .limit(limit)
                 .fetch();
+    }
+
+    /**
+     * 현재 미사용 메서드지만 추후 필요시 사용할 목적으로 작성
+     * 특정 사용자와의 대화방 상세 정보 조회
+     * - 조회: 상대방 정보, 최신 메시지, 나의 읽음 상태를 동시 조회
+     */
+    @Override
+    public Optional<ConversationQueryResult> findConversationQueryResult(Long myId, Long withUserId) {
+        QUser targetUser = new QUser("targetUser");
+        QDirectMessage lastMessage = new QDirectMessage("lastMessage");
+        QReadStatus myStatus = new QReadStatus("myStatus");
+        QReadStatus targetStatus = new QReadStatus("targetStatus");
+        QDirectMessage subMessage = new QDirectMessage("subMessage");
+
+        // 각 대화방 최신 메시지 생성 시간 서브쿼리
+        JPQLQuery<LocalDateTime> subquery = JPAExpressions
+                .select(subMessage.createdAt.max())
+                .from(subMessage)
+                .where(subMessage.conversation.eq(conversation));
+
+        return Optional.ofNullable(queryFactory.select(Projections.constructor(ConversationQueryResult.class,
+                        conversation,
+                        targetUser,
+                        lastMessage,
+                        myStatus
+                )).from(conversation)
+                // 로그인한 유저가 참여한 방
+                .join(myStatus).on(myStatus.conversation.eq(conversation).and(myStatus.user.id.eq(myId)))
+                // 대화 상대 정보
+                .join(targetStatus).on(targetStatus.conversation.eq(conversation).and(targetStatus.user.id.eq(withUserId)))
+                .join(targetUser).on(targetStatus.user.eq(targetUser))
+                // 최신 메시지 (메시지 없는 방 고려해 left join)
+                .leftJoin(lastMessage).on(lastMessage.conversation.eq(conversation).and(lastMessage.createdAt.eq(subquery)))
+                .fetchOne());
     }
 
     // 검색 조건 - 상대 이름 or 메시지 내용

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ConversationRepositoryCustomImpl.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ConversationRepositoryCustomImpl.java
@@ -1,10 +1,11 @@
 package com.mopl.domain.conversation.repository;
 
+import com.mopl.domain.conversation.dto.ConversationQueryResult;
 import com.mopl.domain.conversation.entity.QDirectMessage;
 import com.mopl.domain.conversation.entity.QReadStatus;
 import com.mopl.domain.user.entity.QUser;
-import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.jpa.JPAExpressions;
@@ -30,7 +31,7 @@ public class ConversationRepositoryCustomImpl implements ConversationRepositoryC
      * - 조회: 상대방 정보, 최신 메시지, 나의 읽음 상태를 동시 조회
      */
     @Override
-    public List<Tuple> findMyConversations(Long userId, String keyword, LocalDateTime cursor, Long idAfter, int limit) {
+    public List<ConversationQueryResult> findMyConversations(Long userId, String keyword, LocalDateTime cursor, Long idAfter, int limit) {
         QReadStatus myStatus = new QReadStatus("myStatus");
         QReadStatus targetStatus = new QReadStatus("targetStatus");
         QUser targetUser = new QUser("targetUser");
@@ -47,12 +48,12 @@ public class ConversationRepositoryCustomImpl implements ConversationRepositoryC
         DateTimeExpression<LocalDateTime> sortDateTime = message.createdAt.coalesce(conversation.createdAt);
 
         return queryFactory
-                .select(
+                .select(Projections.constructor(ConversationQueryResult.class,
                         conversation,
                         targetUser,
                         message,
                         myStatus
-                ).from(conversation)
+                )).from(conversation)
                 // 로그인한 유저가 참여한 방
                 .join(myStatus).on(myStatus.conversation.eq(conversation).and(myStatus.user.id.eq(userId)))
                 // 대화 상대 정보


### PR DESCRIPTION
## 연관 이슈
close #38 

## 🔄 변경 사항
- 특정 사용자와의 대화방 조회 API 추가 (`GET /api/conversations/with`)
  - 응답 데이터 최적화: `ConversationSimpleDto` (id 반환)
  - 데이터가 없는 경우 404 에러 반환
- Service 계층에서 QueryDSL 의존 제거
  - Repository 반환 타입 변경: `Tuple` -> `ConversationQueryResult` (DTO)
  - core 모듈 내 `ConversationQueryResult` 추가
- 서비스 중복 코드 제거
- 예외 처리 개선
  - `MESSAGE_NOT_FOUND` 에러 코드 추가

## 🧩 작업 사항
**1. 특정 사용자와의 대화방 조회 기능 구현** (`findConversationWithUser`)
  - 프론트엔드에서 대화방 존재 여부 확인과 리다이렉트를 위해 대화방 ID만 필요한 점을 반영했습니다.
  - 그 외 불필요한 전체 데이터 조회를 방지하기 위해 ID만 포함하는 `ConversationSimpleDto`를 반환하도록 최적화했습니다.
  - 혹시 필요한 상황을 대비해 전체 데이터 조회를 위한 로직은 주석처리로 남겨놓았습니다.
  - 프론트엔드 코드에서는 데이터가 있거나 `404 NOT FOUND` 가 발생하는 경우만 취급하기 때문에 데이터가 없는 경우 404를 반환합니다.
 
**2. QueryDSL Tuple 제거 및 아키텍쳐 개선**
  - 기존에 리포지토리에서 반환하던 Tuple이 서비스 계층까지 침범하던 문제를 해결했습니다.
  - `ConversationQueryResult` DTO를 도입해 리포지토리와 서비스 간 필요한 데이터를 명확히 정의하고 서비스 계층의 순수성을 보장했습니다.
- `ConversationQueryResult`는 서비스와 리포지토리 간 사용되는 DTO이므로 `core` 모듈 내에 위치시켰습니다.

**3. 코드 중복 최소화 및 가독성 개선**
  - `ConversationService` 내부에 흩어져있던 DTO 변환 로직을 `convertToDto` 메서드로 통합해 유지보수성을 높였습니다.
  - 컨트롤러, 서비스의 변수명을 `userId` -> `myId`로 변경해 로그인한 사용자의 id임을 구분할 수 있도록 했습니다.

**4. 에러 처리 세분화**
  - 기존에는 메시지 조회 실패시에도 '대화방 없음' 에러가 발생했습니다 (사용자에게 혼란을 줄 수 있음).
  - MESSAGE_NOT_FOUND 에러 코드를 추가하고 updateAsRead 로직에 적용해 정확한 에러 원인을 파악할 수 있도록 개선했습니다.


## 📸 스크린샷
.