### PR TITLE
[feat] 대화방 단건 조회 API 구현

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/conversation/controller/ConversationController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/controller/ConversationController.java
@@ -50,9 +50,17 @@ public class ConversationController {
 
     @GetMapping("/with")
     public ResponseEntity<ConversationSimpleDto> getConversationWithUser(@AuthenticationPrincipal UserPrincipal userPrincipal,
-                                                                             @RequestParam("userId") Long withUserId) {
+                                                                         @RequestParam("userId") Long withUserId) {
         Long myId = userPrincipal.getUserId();
         ConversationSimpleDto simpleDto = conversationService.findConversationWithUser(myId, withUserId);
         return ResponseEntity.ok(simpleDto);
+    }
+
+    @GetMapping("/{conversationId}")
+    public ResponseEntity<ConversationDto> getConversationById(@AuthenticationPrincipal UserPrincipal userPrincipal,
+                                                @PathVariable Long conversationId) {
+        Long myId = userPrincipal.getUserId();
+        ConversationDto conversationDto = conversationService.findMyConversation(myId, conversationId);
+        return ResponseEntity.ok(conversationDto);
     }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/service/ConversationService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/service/ConversationService.java
@@ -160,29 +160,14 @@ public class ConversationService {
                 .orElseThrow(() -> new ConversationException(CONVERSATION_NOT_FOUND));
 
         return new ConversationSimpleDto(conversation.getId());
-
-/*
-        // 특정 사용자와의 대화 조회할 때 상대방 정보, 최신 메시지, 읽음 상태 등 다른 정보가 추가로 필요한 경우 아래 로직 사용
-        ConversationQueryResult queryResult = conversationRepository.findConversationQueryResult(myId, withUserId)
-                .orElseThrow(() -> new ConversationException(CONVERSATION_NOT_FOUND));
-        return queryResultToDto(queryResult, myId);
-*/
     }
 
     // 특정 대화방 단건 조회
     public ConversationDto findMyConversation(Long myId, Long conversationId) {
-        ReadStatus myReadStatus = readStatusRepository.findByConversationIdAndUserId(conversationId, myId)
+        ConversationQueryResult queryResult = conversationRepository.findConversationDetailByConversationId(myId, conversationId)
                 .orElseThrow(() -> new ConversationException(CONVERSATION_NOT_FOUND));
 
-        Conversation conversation = myReadStatus.getConversation();
-
-        // 해당 대화방의 읽음 상태 중에 userId가 myId가 아닌 유저 조회
-        User targetUser = readStatusRepository.findPartnerByConversationId(conversationId, myId)
-                .orElseThrow(() -> new ConversationException(CONVERSATION_NOT_FOUND));
-
-        DirectMessage lastMessage = directMessageRepository.findTopByConversationIdOrderByCreatedAtDescIdDesc(conversationId)
-                .orElse(null);
-        return convertToDto(conversation, myId, targetUser, myReadStatus, lastMessage);
+        return queryResultToDto(queryResult, myId);
     }
 
     private ConversationDto convertToDto(Conversation conversation, Long myId, User targetUser,

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/service/ConversationService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/service/ConversationService.java
@@ -169,6 +169,22 @@ public class ConversationService {
 */
     }
 
+    // 특정 대화방 단건 조회
+    public ConversationDto findMyConversation(Long myId, Long conversationId) {
+        ReadStatus myReadStatus = readStatusRepository.findByConversationIdAndUserId(conversationId, myId)
+                .orElseThrow(() -> new ConversationException(CONVERSATION_NOT_FOUND));
+
+        Conversation conversation = myReadStatus.getConversation();
+
+        // 해당 대화방의 읽음 상태 중에 userId가 myId가 아닌 유저 조회
+        User targetUser = readStatusRepository.findPartnerByConversationId(conversationId, myId)
+                .orElseThrow(() -> new ConversationException(CONVERSATION_NOT_FOUND));
+
+        DirectMessage lastMessage = directMessageRepository.findTopByConversationIdOrderByCreatedAtDescIdDesc(conversationId)
+                .orElse(null);
+        return convertToDto(conversation, myId, targetUser, myReadStatus, lastMessage);
+    }
+
     private ConversationDto convertToDto(Conversation conversation, Long myId, User targetUser,
                                          ReadStatus myReadStatus, DirectMessage lastMessage) {
 

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ConversationRepositoryCustom.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ConversationRepositoryCustom.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 public interface ConversationRepositoryCustom {
     List<ConversationQueryResult> findMyConversations(Long userId, String keyword, LocalDateTime cursor, Long idAfter, int limit);
 
-    Optional<ConversationQueryResult> findConversationQueryResult(Long myId, Long withUserId);
+    Optional<ConversationQueryResult> findConversationDetailByConversationId(Long myId, Long conversationId);
 }

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ConversationRepositoryCustomImpl.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ConversationRepositoryCustomImpl.java
@@ -70,13 +70,8 @@ public class ConversationRepositoryCustomImpl implements ConversationRepositoryC
                 .fetch();
     }
 
-    /**
-     * 현재 미사용 메서드지만 추후 필요시 사용할 목적으로 작성
-     * 특정 사용자와의 대화방 상세 정보 조회
-     * - 조회: 상대방 정보, 최신 메시지, 나의 읽음 상태를 동시 조회
-     */
     @Override
-    public Optional<ConversationQueryResult> findConversationQueryResult(Long myId, Long withUserId) {
+    public Optional<ConversationQueryResult> findConversationDetailByConversationId(Long myId, Long conversationId) {
         QUser targetUser = new QUser("targetUser");
         QDirectMessage lastMessage = new QDirectMessage("lastMessage");
         QReadStatus myStatus = new QReadStatus("myStatus");
@@ -87,21 +82,23 @@ public class ConversationRepositoryCustomImpl implements ConversationRepositoryC
         JPQLQuery<Long> lastMessageIdSubquery = JPAExpressions
                 .select(subMessage.id.max())
                 .from(subMessage)
-                .where(subMessage.conversation.eq(conversation));
+                .where(subMessage.conversation.id.eq(conversationId));
 
-        return Optional.ofNullable(queryFactory.select(Projections.constructor(ConversationQueryResult.class,
+        return Optional.ofNullable(queryFactory
+                .select(Projections.constructor(ConversationQueryResult.class,
                         conversation,
                         targetUser,
                         lastMessage,
                         myStatus
                 )).from(conversation)
                 // 로그인한 유저가 참여한 방
-                .join(myStatus).on(myStatus.conversation.eq(conversation).and(myStatus.user.id.eq(myId)))
-                // 대화 상대 정보
-                .join(targetStatus).on(targetStatus.conversation.eq(conversation).and(targetStatus.user.id.eq(withUserId)))
+                .join(myStatus).on(myStatus.conversation.id.eq(conversationId).and(myStatus.user.id.eq(myId)))
+                // 상대방 정보 찾기
+                .join(targetStatus).on(targetStatus.conversation.id.eq(conversationId).and(targetStatus.user.id.ne(myId)))
                 .join(targetUser).on(targetStatus.user.eq(targetUser))
                 // 최신 메시지 (메시지 없는 방 고려해 left join)
                 .leftJoin(lastMessage).on(lastMessage.id.eq(lastMessageIdSubquery))
+                .where(conversation.id.eq(conversationId))
                 .fetchOne());
     }
 

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ConversationRepositoryCustomImpl.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ConversationRepositoryCustomImpl.java
@@ -39,9 +39,9 @@ public class ConversationRepositoryCustomImpl implements ConversationRepositoryC
         QDirectMessage message = new QDirectMessage("message");
         QDirectMessage subMessage = new QDirectMessage("subMessage");
 
-        // 각 대화방의 최신 메시지 생성 시간
-        JPQLQuery<LocalDateTime> subquery = JPAExpressions
-                .select(subMessage.createdAt.max())
+        // 각 대화방의 최신 메시지 id
+        JPQLQuery<Long> lastMessageIdSubquery = JPAExpressions
+                .select(subMessage.id.max())
                 .from(subMessage)
                 .where(subMessage.conversation.eq(conversation));
 
@@ -61,7 +61,7 @@ public class ConversationRepositoryCustomImpl implements ConversationRepositoryC
                 .join(targetStatus).on(targetStatus.conversation.eq(conversation).and(targetStatus.user.id.ne(userId)))
                 .join(targetUser).on(targetStatus.user.eq(targetUser))
                 // 최신 메시지 (메시지 없는 방 고려해 left join)
-                .leftJoin(message).on(message.conversation.eq(conversation).and(message.createdAt.eq(subquery)))
+                .leftJoin(message).on(message.id.eq(lastMessageIdSubquery))
                 .where(
                         keywordSearch(keyword, targetUser), // 검색어 조건
                         cursorCondition(cursor, idAfter, sortDateTime) // 커서 조건
@@ -83,9 +83,9 @@ public class ConversationRepositoryCustomImpl implements ConversationRepositoryC
         QReadStatus targetStatus = new QReadStatus("targetStatus");
         QDirectMessage subMessage = new QDirectMessage("subMessage");
 
-        // 각 대화방 최신 메시지 생성 시간 서브쿼리
-        JPQLQuery<LocalDateTime> subquery = JPAExpressions
-                .select(subMessage.createdAt.max())
+        // 각 대화방 최신 메시지 id 서브쿼리
+        JPQLQuery<Long> lastMessageIdSubquery = JPAExpressions
+                .select(subMessage.id.max())
                 .from(subMessage)
                 .where(subMessage.conversation.eq(conversation));
 
@@ -101,7 +101,7 @@ public class ConversationRepositoryCustomImpl implements ConversationRepositoryC
                 .join(targetStatus).on(targetStatus.conversation.eq(conversation).and(targetStatus.user.id.eq(withUserId)))
                 .join(targetUser).on(targetStatus.user.eq(targetUser))
                 // 최신 메시지 (메시지 없는 방 고려해 left join)
-                .leftJoin(lastMessage).on(lastMessage.conversation.eq(conversation).and(lastMessage.createdAt.eq(subquery)))
+                .leftJoin(lastMessage).on(lastMessage.id.eq(lastMessageIdSubquery))
                 .fetchOne());
     }
 

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ReadStatusRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ReadStatusRepository.java
@@ -1,10 +1,7 @@
 package com.mopl.domain.conversation.repository;
 
 import com.mopl.domain.conversation.entity.ReadStatus;
-import com.mopl.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -12,10 +9,4 @@ public interface ReadStatusRepository extends JpaRepository<ReadStatus, Long> {
 
     Optional<ReadStatus> findByConversationIdAndUserId(Long conversationId, Long userId);
 
-    @Query("""
-        SELECT rs.user
-        FROM ReadStatus rs
-        WHERE rs.conversation.id = :conversationId AND rs.user.id != :userId
-    """)
-    Optional<User> findPartnerByConversationId(@Param("conversationId") Long conversationId, @Param("userId") Long userId);
 }

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ReadStatusRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ReadStatusRepository.java
@@ -1,11 +1,21 @@
 package com.mopl.domain.conversation.repository;
 
 import com.mopl.domain.conversation.entity.ReadStatus;
+import com.mopl.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface ReadStatusRepository extends JpaRepository<ReadStatus, Long> {
 
     Optional<ReadStatus> findByConversationIdAndUserId(Long conversationId, Long userId);
+
+    @Query("""
+        SELECT rs.user
+        FROM ReadStatus rs
+        WHERE rs.conversation.id = :conversationId AND rs.user.id != :userId
+    """)
+    Optional<User> findPartnerByConversationId(@Param("conversationId") Long conversationId, @Param("userId") Long userId);
 }


### PR DESCRIPTION
## 연관 이슈
close #42 

## 🔄 변경 사항
- API 엔드포인트 추가: `GET /api/conversations/{conversationId}`
- 대화방 단건 조회 로직 구현:
  - 로그인한 유저가 참여하고 있는 방인지 확인
  - ConversationDto 반환 (대화방 id, 상대방 정보, 대화방의 최신 메시지, 읽음 여부)
- `ReadStatusRepository` 내부에 대화 상대 유저 조회 쿼리 추가 (`findPartnerByConversationId`)
  - 대화 상대를 효율적으로 조회하기 위해 JPQL 쿼리 작성

## 📸 스크린샷
- 성공
  <img width="1918" height="2038" alt="image" src="https://github.com/user-attachments/assets/cacb6bb3-d7cc-4564-a038-de7179e680da" />

- 실패: 내가 참여한 대화방이 아닌 경우
  <img width="1896" height="1400" alt="image" src="https://github.com/user-attachments/assets/9e18e3ac-cd54-49fd-98ed-9ea1a68b699d" />
