### PR TITLE
[feat] DM 목록 조회 API 구현 (커서 페이지네이션)

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/conversation/controller/ConversationController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/controller/ConversationController.java
@@ -3,9 +3,12 @@ package com.mopl.domain.conversation.controller;
 import com.mopl.domain.auth.dto.UserPrincipal;
 import com.mopl.domain.conversation.dto.request.ConversationCreateRequest;
 import com.mopl.domain.conversation.dto.request.ConversationSearchCondition;
+import com.mopl.domain.conversation.dto.request.DMCursorRequest;
 import com.mopl.domain.conversation.dto.response.ConversationDto;
 import com.mopl.domain.conversation.dto.response.ConversationSimpleDto;
+import com.mopl.domain.conversation.dto.response.DirectMessageDto;
 import com.mopl.domain.conversation.service.ConversationService;
+import com.mopl.domain.conversation.service.DirectMessageService;
 import com.mopl.global.dto.PageResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class ConversationController {
 
     private final ConversationService conversationService;
+    private final DirectMessageService directMessageService;
 
     @PostMapping
     public ResponseEntity<ConversationDto> create(@AuthenticationPrincipal UserPrincipal userPrincipal,
@@ -62,5 +66,14 @@ public class ConversationController {
         Long myId = userPrincipal.getUserId();
         ConversationDto conversationDto = conversationService.findMyConversation(myId, conversationId);
         return ResponseEntity.ok(conversationDto);
+    }
+
+    @GetMapping("{conversationId}/direct-messages")
+    public ResponseEntity<PageResponse<DirectMessageDto>> getAllDirectMessages(@AuthenticationPrincipal UserPrincipal userPrincipal,
+                                                                               @PathVariable Long conversationId,
+                                                                               @ModelAttribute @Valid DMCursorRequest cursorRequest) {
+        Long myId = userPrincipal.getUserId();
+        PageResponse<DirectMessageDto> results = directMessageService.findMessages(cursorRequest, myId, conversationId);
+        return ResponseEntity.ok(results);
     }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/controller/ConversationController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/controller/ConversationController.java
@@ -58,7 +58,7 @@ public class ConversationController {
 
     @GetMapping("/{conversationId}")
     public ResponseEntity<ConversationDto> getConversationById(@AuthenticationPrincipal UserPrincipal userPrincipal,
-                                                @PathVariable Long conversationId) {
+                                                               @PathVariable Long conversationId) {
         Long myId = userPrincipal.getUserId();
         ConversationDto conversationDto = conversationService.findMyConversation(myId, conversationId);
         return ResponseEntity.ok(conversationDto);

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/dto/request/DMCursorRequest.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/dto/request/DMCursorRequest.java
@@ -1,0 +1,40 @@
+package com.mopl.domain.conversation.dto.request;
+
+import com.mopl.global.enums.SortDirection;
+import jakarta.validation.constraints.*;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+public record DMCursorRequest(
+        @NotNull(message = "대화방 ID는 필수값입니다.")
+        @Positive(message = "대화방 ID는 양수여야 합니다.")
+        Long conversationId,
+
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        LocalDateTime cursor,
+
+        @Positive(message = "메시지 ID는 양수여야 합니다.")
+        Long idAfter,
+
+        @Min(value = 1, message = "조회 개수는 1 이상이어야 합니다.")
+        @Max(value = 100, message = "한 번에 최대 100개까지만 조회할 수 있습니다.")
+        Integer limit,
+
+        SortDirection sortDirection, // 현재 DM 목록 조회 시 내림차순 고정
+
+        @Pattern(regexp = "^(createdAt)$", message = "정렬 기준은 'createdAt'만 가능합니다.")
+        String sortBy // 현재 DM 목록 조회 시 createdAt 고정
+) {
+    public DMCursorRequest {
+        if (limit == null) {
+            limit = 20;
+        }
+        if (sortDirection == null) {
+            sortDirection = SortDirection.DESCENDING;
+        }
+        if (sortBy == null) {
+            sortBy = "createdAt";
+        }
+    }
+}

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/dto/response/ConversationDto.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/dto/response/ConversationDto.java
@@ -5,7 +5,7 @@ import com.mopl.domain.user.dto.response.UserSummaryDto;
 public record ConversationDto(
         Long id,
         UserSummaryDto with,
-        LastMessage lastestMessage,
+        DirectMessageDto lastestMessage,
         boolean hasUnread
 ) {
 }

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/dto/response/DirectMessageDto.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/dto/response/DirectMessageDto.java
@@ -4,7 +4,7 @@ import com.mopl.domain.user.dto.response.UserSummaryDto;
 
 import java.time.LocalDateTime;
 
-public record LastMessage(
+public record DirectMessageDto(
         Long id,
         Long conversationId,
         LocalDateTime createdAt,

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/exception/ConversationErrorCode.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/exception/ConversationErrorCode.java
@@ -11,6 +11,7 @@ public enum ConversationErrorCode implements DomainErrorCode {
     // Conversation
     CONVERSATION_NOT_FOUND("CV001", "대화방을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     SELF_CONVERSATION_NOT_ALLOWED("CV002", "자기 자신과는 대화할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    CONVERSATION_ID_MISMATCH("CV003", "경로의 대화방 ID와 요청 본문의 ID가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
 
     // DM
     MESSAGE_NOT_FOUND("DM001", "메시지를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/service/ConversationService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/service/ConversationService.java
@@ -5,7 +5,7 @@ import com.mopl.domain.conversation.dto.request.ConversationCreateRequest;
 import com.mopl.domain.conversation.dto.request.ConversationSearchCondition;
 import com.mopl.domain.conversation.dto.response.ConversationDto;
 import com.mopl.domain.conversation.dto.response.ConversationSimpleDto;
-import com.mopl.domain.conversation.dto.response.LastMessage;
+import com.mopl.domain.conversation.dto.response.DirectMessageDto;
 import com.mopl.domain.conversation.entity.Conversation;
 import com.mopl.domain.conversation.entity.DirectMessage;
 import com.mopl.domain.conversation.entity.ReadStatus;
@@ -186,7 +186,7 @@ public class ConversationService {
         UserSummaryDto sender = isSenderMe ? mySummaryDto : with;
         UserSummaryDto receiver = isSenderMe ? with : mySummaryDto;
 
-        LastMessage lastMessageDto = new LastMessage(lastMessage.getId(), conversationId, lastMessage.getCreatedAt(),
+        DirectMessageDto lastMessageDto = new DirectMessageDto(lastMessage.getId(), conversationId, lastMessage.getCreatedAt(),
                                                      sender, receiver, lastMessage.getContent());
 
         long myLastReadMsgId = myReadStatus.getLastReadMessage() != null ? myReadStatus.getLastReadMessage().getId() : 0L;

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/service/DirectMessageService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/service/DirectMessageService.java
@@ -1,0 +1,97 @@
+package com.mopl.domain.conversation.service;
+
+import com.mopl.domain.conversation.dto.request.DMCursorRequest;
+import com.mopl.domain.conversation.dto.response.DirectMessageDto;
+import com.mopl.domain.conversation.entity.DirectMessage;
+import com.mopl.domain.conversation.exception.ConversationException;
+import com.mopl.domain.conversation.repository.DirectMessageRepository;
+import com.mopl.domain.conversation.repository.ReadStatusRepository;
+import com.mopl.domain.user.dto.response.UserSummaryDto;
+import com.mopl.domain.user.entity.User;
+import com.mopl.global.dto.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.mopl.domain.conversation.exception.ConversationErrorCode.CONVERSATION_ID_MISMATCH;
+import static com.mopl.domain.conversation.exception.ConversationErrorCode.CONVERSATION_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DirectMessageService {
+
+    private final DirectMessageRepository directMessageRepository;
+    private final ReadStatusRepository readStatusRepository;
+
+    // 로그인한 사용자의 대화방 메시지 전체 조회
+    public PageResponse<DirectMessageDto> findMessages(DMCursorRequest cursorRequest, Long myId, Long conversationId) {
+        if (!conversationId.equals(cursorRequest.conversationId())) {
+            throw new ConversationException(CONVERSATION_ID_MISMATCH);
+        }
+
+        readStatusRepository.findByConversationIdAndUserId(conversationId, myId)
+                .orElseThrow(() -> new ConversationException(CONVERSATION_NOT_FOUND));
+
+        User targetUser = readStatusRepository.findPartnerByConversationId(conversationId, myId)
+                .orElseThrow(() -> new ConversationException(CONVERSATION_NOT_FOUND));
+
+        int limit = cursorRequest.limit();
+        List<DirectMessage> messages = directMessageRepository.findAllMessagesByCursor(
+                conversationId,
+                cursorRequest.cursor(),
+                cursorRequest.idAfter(),
+                limit + 1);
+
+        boolean hasNext = false;
+        if (messages.size() > limit) {
+            hasNext = true;
+            messages.remove(limit);
+        }
+
+        UserSummaryDto mySummaryDto = new UserSummaryDto(myId, "me", null);
+        UserSummaryDto withUserDto = new UserSummaryDto(targetUser.getId(), targetUser.getName(), targetUser.getProfileImageUrl());
+
+        List<DirectMessageDto> messageDtos = messages.stream()
+                .map(message -> convertToDto(myId, conversationId, message, mySummaryDto, withUserDto))
+                .toList();
+
+        String nextCursor = null;
+        String nextIdAfter = null;
+        if (hasNext) {
+            DirectMessage lastEntity = messages.get(messages.size() - 1);
+            nextCursor = String.valueOf(lastEntity.getCreatedAt());
+            nextIdAfter = String.valueOf(lastEntity.getId());
+        }
+
+        return PageResponse.<DirectMessageDto>builder()
+                .data(messageDtos)
+                .nextCursor(nextCursor)
+                .nextIdAfter(nextIdAfter)
+                .hasNext(hasNext)
+                .totalCount(0)
+                .sortBy(cursorRequest.sortBy())
+                .sortDirection(cursorRequest.sortDirection())
+                .build();
+    }
+
+    private DirectMessageDto convertToDto(Long myId, Long conversationId, DirectMessage message, UserSummaryDto mySummaryDto, UserSummaryDto withUserDto) {
+        Long messageId = message.getId();
+        LocalDateTime createdAt = message.getCreatedAt();
+
+        boolean isSenderMe = message.getAuthor().getId().equals(myId);
+        UserSummaryDto sender = isSenderMe ? mySummaryDto : withUserDto;
+        UserSummaryDto receiver = isSenderMe ? withUserDto : mySummaryDto;
+
+        return new DirectMessageDto(
+                messageId,
+                conversationId,
+                createdAt,
+                sender,
+                receiver,
+                message.getContent());
+    }
+}

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/repository/DirectMessageRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/repository/DirectMessageRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface DirectMessageRepository extends JpaRepository<DirectMessage, Long> {
+public interface DirectMessageRepository extends JpaRepository<DirectMessage, Long>, DirectMessageRepositoryCustom {
 
     // createdAt이 같을 수 있으므로 id로 2차 정렬
     Optional<DirectMessage> findTopByConversationIdOrderByCreatedAtDescIdDesc(Long conversationId);

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/repository/DirectMessageRepositoryCustom.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/repository/DirectMessageRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.mopl.domain.conversation.repository;
+
+import com.mopl.domain.conversation.entity.DirectMessage;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface DirectMessageRepositoryCustom {
+    List<DirectMessage> findAllMessagesByCursor(Long conversationId, LocalDateTime cursor, Long idAfter, int limit);
+}

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/repository/DirectMessageRepositoryCustomImpl.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/repository/DirectMessageRepositoryCustomImpl.java
@@ -1,0 +1,41 @@
+package com.mopl.domain.conversation.repository;
+
+import com.mopl.domain.conversation.entity.DirectMessage;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.mopl.domain.conversation.entity.QDirectMessage.directMessage;
+
+@Repository
+@RequiredArgsConstructor
+public class DirectMessageRepositoryCustomImpl implements DirectMessageRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<DirectMessage> findAllMessagesByCursor(Long conversationId, LocalDateTime cursor, Long idAfter, int limit) {
+
+        return queryFactory
+                .selectFrom(directMessage)
+                .where(
+                        directMessage.conversation.id.eq(conversationId),
+                        cursorCondition(cursor, idAfter))
+                .orderBy(directMessage.createdAt.desc(), directMessage.id.desc()) // 채팅은 최신순 조회로 고정
+                .limit(limit)
+                .fetch();
+    }
+
+    private BooleanExpression cursorCondition(LocalDateTime cursor, Long idAfter) {
+        if (cursor == null || idAfter == null) {
+            return null;
+        }
+
+        return directMessage.createdAt.lt(cursor)
+                .or(directMessage.createdAt.eq(cursor).and(directMessage.id.lt(idAfter)));
+    }
+}

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ReadStatusRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/repository/ReadStatusRepository.java
@@ -1,7 +1,10 @@
 package com.mopl.domain.conversation.repository;
 
 import com.mopl.domain.conversation.entity.ReadStatus;
+import com.mopl.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -9,4 +12,10 @@ public interface ReadStatusRepository extends JpaRepository<ReadStatus, Long> {
 
     Optional<ReadStatus> findByConversationIdAndUserId(Long conversationId, Long userId);
 
+    @Query("""
+        SELECT rs.user
+        FROM ReadStatus rs
+        WHERE rs.conversation.id = :conversationId AND rs.user.id != :userId
+    """)
+    Optional<User> findPartnerByConversationId(@Param("conversationId") Long conversationId, @Param("userId") Long userId);
 }


### PR DESCRIPTION
## 연관 이슈
close #43 

## 🧩 작업 사항
1. DM 목록 조회 API 구현 (커서 페이징)
  - 엔드포인트: `GET /api/conversations/{conversationId}/direct-messages`
  - 커서 페이징: QueryDSL을 활용해 커서 기반 페이징 처리
2. 아키텍처 개선 및 리팩토링
  - Service 분리: 메시지 관련 로직을 `DirectMessageService`로 분리해 관심사를 명확히 함
  - DTO 명칭 변경: `LastMessage` 레코드를 `DirectMessageDto`로 변경해 대화방 목록의 미리보기 뿐만 아니라 DM 목록 데이터에도 사용할 수 있도록 개선 (범용성 고려)
3. 성능 최적화 (N+1 방지)
  - User 조회 최적화: DM 목록 조회시 작성자 정보를 fetch join 하는 대신 미리 조회된 `UserSummaryDto`와 id만 비교하는 방식을 적용해 불필요한 join과 쿼리 발생 방지
 4. 검증
   - 데이터 무결성 검증: PathVariable의 대화방 id와 requestDTO의 id가 불일치하는 경우 `CONVERSATION_ID_MISMATCH` 예외 발생
   - 로그인한 사용자의 대화방 DM만 조회하도록 검증

## 📸 스크린샷
- 성공
  <img width="1886" height="2608" alt="image" src="https://github.com/user-attachments/assets/b1626319-0935-4bb2-b88e-274b67746441" />

- 실패: 경로변수 id와 request의 id 불일치
  <img width="1898" height="1394" alt="image" src="https://github.com/user-attachments/assets/d2903821-9fd4-4416-97ce-5377555743c4" />
