### PR TITLE
[fix] Auth -  ServletException 발생 문제 해결: JwtFilter 응답 커밋 충돌 및 예외 처리 로직 수정

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/auth/jwt/JwtFilter.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/jwt/JwtFilter.java
@@ -16,23 +16,44 @@ import java.io.IOException;
 @Slf4j
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
+
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
     protected void doFilterInternal(
-            @NonNull
-            HttpServletRequest request,
-            @NonNull
-            HttpServletResponse response,
-            @NonNull
-            FilterChain filterChain
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
     ) throws ServletException, IOException {
-        String token = jwtTokenProvider.resolveToken(request);
-        if (token != null && jwtTokenProvider.validateAccessToken(token)) {
-            Authentication authentication = jwtTokenProvider.getAuthentication(token);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-            log.debug("JWT 인증 성공: {}", authentication.getName());
+        try {
+            // request Cookie에서 JWT 토큰 추출
+            String token = jwtTokenProvider.resolveToken(request);
+
+            // 토큰 유효성 검증 및 인증 정보(Authentication) 설정
+            if (token != null && jwtTokenProvider.validateAccessToken(token)) {
+                Authentication authentication = jwtTokenProvider.getAuthentication(token);
+
+                // SecurityContext에 인증 객체 저장 (요청 처리 동안 유지)
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+                log.debug("JWT 인증 성공: {}", authentication.getName());
+            }
+
+            // 다음 필터로 요청 전달
+            filterChain.doFilter(request, response);
+
+        } catch (Exception e) {
+            // 응답이 이미 클라이언트로 전송 시작했는지 확인
+            if (response.isCommitted()) {
+                // 이미 커밋된 상태에서 다시 예외를 처리하려고 하면 'Response Committed' 에러가 발생
+                log.warn("응답이 이미 커밋되어 예외를 처리할 수 없습니다: {}", e.getMessage());
+                return;
+            }
+
+            // 발생한 예외를 Request 속성에 저장하여 EntryPoint 등에서 활용할 수 있게 함
+            request.setAttribute("exception", e);
+
+            // 예외 발생 시에도 필터 체인을 계속 진행하여 AuthenticationEntryPoint에서 처리하도록 유도
+            filterChain.doFilter(request, response);
         }
-        filterChain.doFilter(request, response);
     }
 }


### PR DESCRIPTION
## 연관 이슈
close #132 

## 🔄 변경 사항
- JwtFilter 내 try-catch 블록 추가로 런타임 예외 안정성 확보
- response.isCommitted() 체크를 통해 "Response already committed" 에러 방지
- 필터 발생 예외를 request attribute에 저장하여 EntryPoint 연동 강화

## 🧩 작업 사항
작업한 내용을 간략하게 설명해주세요.
- `JwtFilter` 파일 수정
- 연관 이슈 확인해주세요