### PR TITLE
[FEAT] Auth -  csrf 토큰 조회 

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/auth/controller/AuthController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/controller/AuthController.java
@@ -9,6 +9,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -41,5 +42,10 @@ public class AuthController {
         JwtDto jwtDto = authService.refresh(refreshToken, response);
         return ResponseEntity.ok().body(jwtDto);
     }
+    @GetMapping("/csrf-token")
+    public CsrfToken getCsrfToken(CsrfToken token) {
+        return token;
+    }
+
 
 }

--- a/mopl-api/src/main/java/com/mopl/global/config/SecurityConfig.java
+++ b/mopl-api/src/main/java/com/mopl/global/config/SecurityConfig.java
@@ -57,7 +57,6 @@ public class SecurityConfig {
                                 "/api/auth/refresh",
                                 "/api/auth/csrf-token"
                         ).permitAll()
-                        .requestMatchers("/api/auth/**").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/users").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/mopl-api/src/main/java/com/mopl/global/config/SecurityConfig.java
+++ b/mopl-api/src/main/java/com/mopl/global/config/SecurityConfig.java
@@ -55,7 +55,7 @@ public class SecurityConfig {
                                 "/api/auth/sign-out",
                                 "/api/auth/reset-password",
                                 "/api/auth/refresh",
-                                "/api/auth/csrf-token"
+                                "/api/auth/csrf-token" // 로그아웃 후 호출
                         ).permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/users").permitAll()
                         .anyRequest().authenticated()
@@ -66,10 +66,9 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf
                         .ignoringRequestMatchers(
                                 "/api/auth/sign-in",
-                                "/api/auth/sign-out",
                                 "/api/auth/reset-password",
                                 "/api/auth/refresh",
-                                "/api/auth/csrf-token",
+                                "/api/auth/sign-out",
                                 "/api/users"
                         )
                         .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())

--- a/mopl-api/src/main/java/com/mopl/global/config/SecurityConfig.java
+++ b/mopl-api/src/main/java/com/mopl/global/config/SecurityConfig.java
@@ -54,7 +54,8 @@ public class SecurityConfig {
                                 "/api/auth/sign-in",
                                 "/api/auth/sign-out",
                                 "/api/auth/reset-password",
-                                "/api/auth/refresh"
+                                "/api/auth/refresh",
+                                "/api/auth/csrf-token"
                         ).permitAll()
                         .requestMatchers("/api/auth/**").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/users").permitAll()
@@ -65,9 +66,7 @@ public class SecurityConfig {
                 .addFilterBefore(new JwtFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
                 .csrf(csrf -> csrf
                         .ignoringRequestMatchers(
-                                "/api/auth/sign-in",
-                                "/api/auth/reset-password",
-                                "/api/auth/csrf-token",
+                                "/api/auth/**",
                                 "/api/users"
                         )
                         .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())

--- a/mopl-api/src/main/java/com/mopl/global/config/SecurityConfig.java
+++ b/mopl-api/src/main/java/com/mopl/global/config/SecurityConfig.java
@@ -16,6 +16,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 
 @Configuration
 @EnableWebSecurity
@@ -62,7 +63,15 @@ public class SecurityConfig {
                 .headers(headers -> headers
                         .frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
                 .addFilterBefore(new JwtFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
-                .csrf(AbstractHttpConfigurer::disable) // TODO : 나중/#78에 변경예정
+                .csrf(csrf -> csrf
+                        .ignoringRequestMatchers(
+                                "/api/auth/sign-in",
+                                "/api/auth/reset-password",
+                                "/api/auth/csrf-token",
+                                "/api/users"
+                        )
+                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                )
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint));
 

--- a/mopl-api/src/main/java/com/mopl/global/config/SecurityConfig.java
+++ b/mopl-api/src/main/java/com/mopl/global/config/SecurityConfig.java
@@ -65,7 +65,11 @@ public class SecurityConfig {
                 .addFilterBefore(new JwtFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
                 .csrf(csrf -> csrf
                         .ignoringRequestMatchers(
-                                "/api/auth/**",
+                                "/api/auth/sign-in",
+                                "/api/auth/sign-out",
+                                "/api/auth/reset-password",
+                                "/api/auth/refresh",
+                                "/api/auth/csrf-token",
                                 "/api/users"
                         )
                         .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())

--- a/mopl-core/src/main/resources/db/testdata.sql
+++ b/mopl-core/src/main/resources/db/testdata.sql
@@ -37,8 +37,8 @@ VALUES (1, '새로운 메시지 도착', '김철수님이 메시지를 보냈습
        (8, 'API 사용량 초과', '일일 API 호출 한도의 80%를 초과했습니다.', 'WARNING', '2026-01-10 13:45:00');
 -- 샘플 데이터 5개 삽입
 INSERT INTO contents (content_type, title, description, thumbnail_url, average_rating, review_count, created_at)
-VALUES ('MOVIE', '인터스텔라', '인류의 생존을 위해 우주로 떠나는 탐험가들의 이야기를 그린 SF 대작', 'https://example.com/interstellar.jpg', 4.8, 15234,'2026-01-10 10:00:00'),
-       ('MOVIE', '해리포터와 마법사의 돌', 'J.K. 롤링의 판타지 소설 시리즈 첫 번째 작품', 'https://example.com/harry-potter.jpg', 4.7, 28901,'2026-01-10 11:00:00'),
-       ('MOVIE', '젤다의 전설: 브레스 오브 더 와일드', '광활한 오픈 월드를 탐험하는 액션 어드벤처 게임', 'https://example.com/zelda.jpg', 4.9, 42156,'2026-01-10 12:00:00'),
-       ('MOVIE', 'Bohemian Rhapsody', '퀸의 대표곡으로 록 오페라 스타일의 명곡', 'https://example.com/bohemian.jpg', 4.9, 67823,'2026-01-10 13:00:00'),
-       ('MOVIE', '브레이킹 배드', '화학 교사가 마약 제조자로 변해가는 과정을 그린 범죄 드라마', 'https://example.com/breaking-bad.jpg', 4.8, 51290,'2026-01-10 14:00:00');
+VALUES ('movie', '인터스텔라', '인류의 생존을 위해 우주로 떠나는 탐험가들의 이야기를 그린 SF 대작', 'https://example.com/interstellar.jpg', 4.8, 15234,'2026-01-10 10:00:00'),
+       ('movie', '해리포터와 마법사의 돌', 'J.K. 롤링의 판타지 소설 시리즈 첫 번째 작품', 'https://example.com/harry-potter.jpg', 4.7, 28901,'2026-01-10 11:00:00'),
+       ('movie', '젤다의 전설: 브레스 오브 더 와일드', '광활한 오픈 월드를 탐험하는 액션 어드벤처 게임', 'https://example.com/zelda.jpg', 4.9, 42156,'2026-01-10 12:00:00'),
+       ('movie', 'Bohemian Rhapsody', '퀸의 대표곡으로 록 오페라 스타일의 명곡', 'https://example.com/bohemian.jpg', 4.9, 67823,'2026-01-10 13:00:00'),
+       ('movie', '브레이킹 배드', '화학 교사가 마약 제조자로 변해가는 과정을 그린 범죄 드라마', 'https://example.com/breaking-bad.jpg', 4.8, 51290,'2026-01-10 14:00:00');


### PR DESCRIPTION
## 연관 이슈
close #123 

## 🔄 변경 사항
사용자가 get 요청이 아닌 다른 요청일 때 ( post,patch 등 )XSRF-TOKEN 이라는 이름의 쿠키 안에 csrf토큰 생성 하고
프론트는 이를 X-XSRF-TOKEN에 넣어 csrf 공격에서 부터 페이지를 보호 한다 



## 🧩 작업 사항
작업한 내용을 간략하게 설명해주세요.
-SecurityConfig 
  프론트에서 로그아웃 후 /api/csrf-token을 호출을 하기 때문에 해당 경로를 requestMatchers에 추가했다 
- AuthController 추가 

-csrf 토큰 무시 경로
<img width="953" height="352" alt="image" src="https://github.com/user-attachments/assets/d80c27e7-f7bb-46f1-9313-f3308139bc4b" />

csrf 토큰: 자동으로 모든 요청에 쿠키가 붙기 때문에 csrf토큰으로 외부에서의 요청을 할 수 없게 막는 역할을 한다. 그래서 중요한 로직(결제 등)은 csrf로 보호하고 인증같은 경우는 토큰이 없을 때여서 추가하고 이미 충분히 httponly로 쿠키를 보호하고 있기 때문에 csrf 무시에 포함 시켜도 상관 없다 

## 📸 스크린샷
요청 헤더에 붙은거 확인 완료 했으나 다른 요청에 붙어있는지 추가로 확인 필요 함 (아직 구현과 오류가 덜 된 부분이 있어서 나중에 더 확인 해야 함)
<img width="636" height="62" alt="image" src="https://github.com/user-attachments/assets/1c760191-84b9-4d62-bc32-5fa6179a46aa" />
