### PR TITLE
[FEAT] Follow - 팔로우 여부 확인 API 구현 및 테스트 환경 개선

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/follow/controller/FollowController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/follow/controller/FollowController.java
@@ -45,4 +45,15 @@ public class FollowController implements FollowControllerDocs {
 
         return ResponseEntity.noContent().build();
     }
+
+    // 특정 유저 팔로우 확인 조회 API
+    @Override
+    @GetMapping("/followed-by-me")
+    public ResponseEntity<Boolean> checkFollowStatus(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestParam Long followeeId) {
+
+        boolean result = followService.isFollowing(userPrincipal.getUserId(), followeeId);
+        return ResponseEntity.ok(result);
+    }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/follow/controller/docs/FollowControllerDocs.java
+++ b/mopl-api/src/main/java/com/mopl/domain/follow/controller/docs/FollowControllerDocs.java
@@ -47,4 +47,19 @@ public interface FollowControllerDocs {
             @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal user,
             @Parameter(description = "삭제할 팔로우 ID (PK)") @PathVariable Long followId
     );
+
+    // 특정 유저 팔로우 확인 조회 명세서
+    @Operation(summary = "팔로우 여부 확인", description = "로그인한 사용자가 특정 사용자(followeeId)를 현재 팔로우하고 있는지 여부를 조회합니다. (true: 팔로우 중, false: 미팔로우)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공 (true/false 반환)"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (파라미터 누락 또는 잘못된 형식)"),
+            @ApiResponse(responseCode = "401", description = "인증 오류 (로그인 필요)"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    @GetMapping("/followed-by-me")
+    ResponseEntity<Boolean> checkFollowStatus(
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal user,
+            @Parameter(description = "확인할 상대방 사용자 ID (PK)", required = true) @RequestParam Long followeeId
+    );
 }
+

--- a/mopl-api/src/main/java/com/mopl/domain/follow/service/FollowService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/follow/service/FollowService.java
@@ -71,8 +71,14 @@ public class FollowService {
         followRepository.delete(follow);
     }
 
+    // 특정 유저 팔로우 확인 조회 로직
+    public boolean isFollowing(Long followerId, Long followeeId) {
+        return followRepository.existsByFollowerIdAndFolloweeId(followerId, followeeId);
+    }
+
     private User getUserOrThrow(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new MoplException(ErrorCode.NOT_FOUND));
     }
+
 }

--- a/mopl-api/src/main/java/com/mopl/global/exception/GlobalExceptionHandler.java
+++ b/mopl-api/src/main/java/com/mopl/global/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -37,6 +38,17 @@ public class GlobalExceptionHandler {
         log.error("타입 불일치 오류 발생: {}", detail, e);
 
         return createErrorResponse(ErrorCode.INVALID_INPUT_VALUE, detail);
+    }
+
+    /** 필수 파라미터 누락 예외 (400) - ErrorCode.MISSING_INPUT_VALUE와 연결 */
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<@NonNull ProblemDetail> handleMissingParams(MissingServletRequestParameterException e) {
+
+        String detail = String.format("필수 파라미터 '%s'가 누락되었습니다.", e.getParameterName());
+
+        log.error("필수 파라미터 누락: {}", detail, e);
+
+        return createErrorResponse(ErrorCode.MISSING_INPUT_VALUE, detail);
     }
 
     /** 권한 부족 예외 (403) - ErrorCode.INSUFFICIENT_PERMISSIONS과 연결 */

--- a/mopl-api/src/test/java/com/mopl/domain/follow/controller/FollowApiTest.java
+++ b/mopl-api/src/test/java/com/mopl/domain/follow/controller/FollowApiTest.java
@@ -1,6 +1,11 @@
 package com.mopl.domain.follow.controller;
 
+import com.mopl.domain.auth.dto.UserPrincipal;
 import com.mopl.domain.follow.exception.FollowErrorCode;
+import com.mopl.domain.user.enums.Role;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
 import tools.jackson.databind.ObjectMapper;
 import com.mopl.domain.follow.dto.request.FollowRequest;
 import com.mopl.domain.follow.entity.Follow;
@@ -18,12 +23,15 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import java.util.Collections;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ActiveProfiles("test")
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
@@ -52,6 +60,20 @@ class FollowApiTest {
         user2 = userRepository.save(new User("you", "user2@test.com", "password"));
     }
 
+    // UserPrincipal을 포함한 인증 토큰 생성 헬퍼 메서드
+    private UsernamePasswordAuthenticationToken createAuthToken(User user) {
+
+        // 실제 컨트롤러가 사용하는 UserPrincipal 객체 생성
+        UserPrincipal principal = new UserPrincipal(user.getId(), user.getEmail(), Role.USER);
+
+        // SecurityContext에 들어갈 토큰 생성
+        return new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+    }
+
     // 1. 성공 케이스 (201)
     @Test
     @DisplayName("[201] 정상적인 팔로우 요청 시 성공한다")
@@ -63,7 +85,8 @@ class FollowApiTest {
         mockMvc.perform(post("/api/follows")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
-                        .with(user(String.valueOf(user1.getId())))) // 로그인
+                        .with(authentication(createAuthToken(user1)))
+                        .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.followerId").value(user1.getId()))
@@ -81,7 +104,8 @@ class FollowApiTest {
         mockMvc.perform(post("/api/follows")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
-                        .with(user(String.valueOf(user1.getId()))))
+                        .with(authentication(createAuthToken(user1)))
+                        .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.title").value(FollowErrorCode.CANNOT_FOLLOW_SELF.name()))
@@ -100,7 +124,8 @@ class FollowApiTest {
         mockMvc.perform(post("/api/follows")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
-                        .with(user(String.valueOf(user1.getId()))))
+                        .with(authentication(createAuthToken(user1)))
+                        .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.title").value(FollowErrorCode.ALREADY_FOLLOWING.name()))
@@ -117,7 +142,8 @@ class FollowApiTest {
         // When & Then
         mockMvc.perform(post("/api/follows")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.title").value(ErrorCode.UNAUTHORIZED.name()));
@@ -136,7 +162,8 @@ class FollowApiTest {
         mockMvc.perform(post("/api/follows")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
-                        .with(user(String.valueOf(user1.getId()))))
+                        .with(authentication(createAuthToken(user1)))
+                        .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.title").value(ErrorCode.NOT_FOUND.name()));

--- a/mopl-api/src/test/java/com/mopl/domain/follow/controller/FollowStatusApiTest.java
+++ b/mopl-api/src/test/java/com/mopl/domain/follow/controller/FollowStatusApiTest.java
@@ -1,0 +1,135 @@
+package com.mopl.domain.follow.controller;
+
+import com.mopl.domain.auth.dto.UserPrincipal;
+import com.mopl.domain.follow.entity.Follow;
+import com.mopl.domain.follow.repository.FollowRepository;
+import com.mopl.domain.user.entity.User;
+import com.mopl.domain.user.enums.Role;
+import com.mopl.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class FollowStatusApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private FollowRepository followRepository;
+
+    // 테스트용 유저
+    private User user1;
+    private User user2;
+
+    @BeforeEach
+    void setUp() {
+        // 유저 생성
+        user1 = userRepository.save(new User("me", "user1@test.com", "password"));
+        user2 = userRepository.save(new User("you", "user2@test.com", "password"));
+    }
+
+    // UserPrincipal을 포함한 인증 토큰 생성 헬퍼 메서드
+    private UsernamePasswordAuthenticationToken createAuthToken(User user) {
+
+        // 실제 컨트롤러가 사용하는 UserPrincipal 객체 생성
+        UserPrincipal principal = new UserPrincipal(user.getId(), user.getEmail(), Role.USER);
+
+        // SecurityContext에 들어갈 토큰 생성
+        return new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+    }
+
+    @Test
+    @DisplayName("[200] 팔로우 중일 경우 true를 반환한다")
+    void checkFollowStatus_True() throws Exception {
+        // Given: user1 -> user2 팔로우 관계 생성
+        followRepository.save(Follow.builder().follower(user1).followee(user2).build());
+
+        // When & Then: user1이 로그인한 상태로 user2 팔로우 여부 조회
+        mockMvc.perform(get("/api/follows/followed-by-me")
+                        .param("followeeId", String.valueOf(user2.getId()))
+                        .with(authentication(createAuthToken(user1))))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().string("true"));
+    }
+
+    @Test
+    @DisplayName("[200] 팔로우 중이 아닐 경우 false를 반환한다")
+    void checkFollowStatus_False() throws Exception {
+        // Given: 팔로우 관계 없음
+
+        // When & Then: user1이 로그인한 상태로 user2 팔로우 여부 조회
+        mockMvc.perform(get("/api/follows/followed-by-me")
+                        .param("followeeId", String.valueOf(user2.getId()))
+                        .with(authentication(createAuthToken(user1))))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().string("false"));
+    }
+
+    @Test
+    @DisplayName("[200] 존재하지 않는 유저 ID로 조회해도 false를 반환한다")
+    void checkFollowStatus_NotFoundUser_False() throws Exception {
+        // Given: 존재하지 않는 ID
+        long nonExistentUserId = 999999L;
+
+        // When & Then
+        mockMvc.perform(get("/api/follows/followed-by-me")
+                        .param("followeeId", String.valueOf(nonExistentUserId))
+                        .with(authentication(createAuthToken(user1))))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().string("false"));
+    }
+
+    @Test
+    @DisplayName("[401] 로그인하지 않고 조회하면 UNAUTHORIZED 에러 발생")
+    void checkFollowStatus_Unauthorized() throws Exception {
+        // Given
+        Long targetId = user2.getId();
+
+        // When & Then: .with(authentication(...)) 생략
+        mockMvc.perform(get("/api/follows/followed-by-me")
+                        .param("followeeId", String.valueOf(targetId)))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("[400] 필수 파라미터(followeeId)가 없으면 BAD_REQUEST 발생")
+    void checkFollowStatus_NoParam_Fail() throws Exception {
+        // When & Then
+        mockMvc.perform(get("/api/follows/followed-by-me")
+                        .with(authentication(createAuthToken(user1))))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/mopl-api/src/test/java/com/mopl/domain/follow/controller/UnFollowApiTest.java
+++ b/mopl-api/src/test/java/com/mopl/domain/follow/controller/UnFollowApiTest.java
@@ -12,15 +12,23 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
+import com.mopl.domain.auth.dto.UserPrincipal;
+import com.mopl.domain.user.enums.Role;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import java.util.Collections;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ActiveProfiles("test")
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
@@ -46,6 +54,20 @@ class UnFollowApiTest {
         user2 = userRepository.save(new User("you", "user2@test.com", "password"));
     }
 
+    // UserPrincipal을 포함한 인증 토큰 생성 헬퍼 메서드
+    private UsernamePasswordAuthenticationToken createAuthToken(User user) {
+
+        // 실제 컨트롤러가 사용하는 UserPrincipal 객체 생성
+        UserPrincipal principal = new UserPrincipal(user.getId(), user.getEmail(), Role.USER);
+
+        // SecurityContext에 들어갈 토큰 생성
+        return new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+    }
+
     // 1. 성공 케이스 (204)
     @Test
     @DisplayName("[204] 본인이 생성한 팔로우를 취소하면 성공한다")
@@ -56,7 +78,8 @@ class UnFollowApiTest {
 
         // When & Then
         mockMvc.perform(delete("/api/follows/{followId}", savedFollow.getId())
-                        .with(user(String.valueOf(user1.getId())))) // 작성자(user1)로 로그인
+                        .with(authentication(createAuthToken(user1))) // 작성자(user1)로 로그인
+                        .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isNoContent());
     }
@@ -67,7 +90,8 @@ class UnFollowApiTest {
     void unfollowUser_TypeMismatch_Fail() throws Exception {
         // When: 숫자가 들어가야 할 자리에 문자("abc") 입력
         mockMvc.perform(delete("/api/follows/abc")
-                        .with(user(String.valueOf(user1.getId()))))
+                        .with(authentication(createAuthToken(user1)))
+                        .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.title").value(ErrorCode.INVALID_INPUT_VALUE.name()));
@@ -83,7 +107,8 @@ class UnFollowApiTest {
 
         // When: user2가 user1의 팔로우를 삭제 시도
         mockMvc.perform(delete("/api/follows/{followId}", savedFollow.getId())
-                        .with(user(String.valueOf(user2.getId()))))
+                        .with(authentication(createAuthToken(user2)))
+                        .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.title").value(ErrorCode.FORBIDDEN.name()));
@@ -98,10 +123,10 @@ class UnFollowApiTest {
 
         // When & Then
         mockMvc.perform(delete("/api/follows/{followId}", invalidFollowId)
-                        .with(user(String.valueOf(user1.getId()))))
+                        .with(authentication(createAuthToken(user1)))
+                        .with(csrf()))
                 .andDo(print())
-                .andExpect(status().isNotFound()) // 404
+                .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.title").value(FollowErrorCode.FOLLOW_NOT_FOUND.name()));
     }
-
 }

--- a/mopl-api/src/test/resources/application-test.yml
+++ b/mopl-api/src/test/resources/application-test.yml
@@ -17,17 +17,18 @@ spring:
       hibernate:
         format_sql: true
 
+  # Redis 설정
   data:
     redis:
       host: localhost
       port: 6379
 
-  # [추가] 이메일 설정 가짜 값 (이게 없어서 에러 발생)
+  # 이메일 설정 가짜 값
   mail:
     host: smtp.gmail.com
     port: 587
-    username: "test@gmail.com"  # 가짜 값
-    password: "testpassword"    # 가짜 값
+    username: "test@gmail.com"
+    password: "testpassword"
     properties:
       mail:
         smtp:
@@ -35,7 +36,7 @@ spring:
           starttls:
             enable: true
 
-# [JWT 설정] (기존 내용 유지)
+# JWT 설정
 jwt:
   access-secret: "test_secret_key_for_access_token_must_be_32_bytes_long"
   refresh-secret: "test_secret_key_for_refresh_token_must_be_32_bytes_long"

--- a/mopl-api/src/test/resources/application-test.yml
+++ b/mopl-api/src/test/resources/application-test.yml
@@ -1,0 +1,50 @@
+spring:
+  config:
+    activate:
+      on-profile: test
+
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+  # [추가] 이메일 설정 가짜 값 (이게 없어서 에러 발생)
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: "test@gmail.com"  # 가짜 값
+    password: "testpassword"    # 가짜 값
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
+# [JWT 설정] (기존 내용 유지)
+jwt:
+  access-secret: "test_secret_key_for_access_token_must_be_32_bytes_long"
+  refresh-secret: "test_secret_key_for_refresh_token_must_be_32_bytes_long"
+  access-token-validity: 3600000
+  refresh-token-validity: 604800000
+  cookie:
+    secure: false
+    same-site: Lax
+
+logging:
+  level:
+    root: INFO

--- a/mopl-api/src/test/resources/application-test.yml
+++ b/mopl-api/src/test/resources/application-test.yml
@@ -17,12 +17,13 @@ spring:
       hibernate:
         format_sql: true
 
+  # Redis 설정
   data:
     redis:
       host: localhost
       port: 6379
 
-  # [추가] 이메일 설정 가짜 값 (이게 없어서 에러 발생)
+  # 이메일 설정 가짜 값
   mail:
     host: smtp.gmail.com
     port: 587
@@ -35,7 +36,7 @@ spring:
           starttls:
             enable: true
 
-# [JWT 설정] (기존 내용 유지)
+# JWT 설정
 jwt:
   access-secret: "test_secret_key_for_access_token_must_be_32_bytes_long"
   refresh-secret: "test_secret_key_for_refresh_token_must_be_32_bytes_long"

--- a/mopl-core/src/main/java/com/mopl/domain/follow/repository/FollowRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/follow/repository/FollowRepository.java
@@ -6,11 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FollowRepository extends JpaRepository<@NonNull Follow, @NonNull Long> {
 
-    // 중복 팔로우 체크
+    // 중복 팔로우 체크 및 특정 유저 팔로우 체크
     boolean existsByFollowerIdAndFolloweeId(Long followerId, Long followeeId);
-
-    // 언팔로우
-    void deleteByFollowerIdAndFolloweeId(Long followerId, Long followeeId);
 
     // 팔로워/팔로잉 수 카운트 (마이페이지에 쓰이는것)
     long countByFollowerId(Long followerId);

--- a/mopl-core/src/main/java/com/mopl/global/exception/ErrorCode.java
+++ b/mopl-core/src/main/java/com/mopl/global/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
 
     // 데이터 및 비즈니스 로직 관련
     INVALID_INPUT_VALUE("입력 값이 유효하지 않습니다.", 400),
+    MISSING_INPUT_VALUE("필수 입력 값이 누락되었습니다.", 400),
     DATA_INTEGRITY_VIOLATION("데이터 무결성 제약 조건이 위반되었습니다.", 400),
     DUPLICATE_RESOURCE("이미 존재하는 리소스입니다.", 409),
 


### PR DESCRIPTION
## 연관 이슈

close #85 

## 🔄 변경 사항

* **특정 유저 팔로우 여부 조회 API 추가**: `GET /api/follows/followed-by-me` 엔드포인트를 통해 내가 상대를 팔로우 중인지(`true/false`) 확인 가능
* **테스트 실행 환경 개선**: 테스트 전용 설정 파일(`application-test.yml`)을 도입하여 환경 변수 의존성 제거 및 CI 안정성 확보
* **예외 처리 강화**: API 요청 시 필수 파라미터(`@RequestParam`)가 누락될 경우 500 에러가 아닌 400 에러(`MISSING_INPUT_VALUE`)를 반환하도록 개선

## 🧩 작업 사항

**Backend Logic**

* `FollowRepository`: `existsByFollowerIdAndFolloweeId` 추가 및 미사용 `deleteBy...` 메서드 제거
* `FollowService`: `isFollowing` 메서드 구현 (예외 발생 없이 Boolean 상태 반환)
* `FollowController`: 팔로우 여부 확인 API 구현 및 `FollowControllerDocs` Swagger 명세 작성

**Exception Handling**

* `GlobalExceptionHandler`: `MissingServletRequestParameterException` 핸들러 추가
* `ErrorCode`: `MISSING_INPUT_VALUE("필수 입력 값이 누락되었습니다.", 400)` 코드 추가

**Test & Config**

* `FollowStatusApiTest`: 팔로우 여부 확인 통합 테스트 코드 신규 작성 (정상, 미인증, 파라미터 누락 등 시나리오 검증)
* `FollowApiTest`: `UserPrincipal` 인증 객체 주입 방식 리팩토링 및 `@ActiveProfiles("test")` 적용
* `UnFollowApiTest`: `UserPrincipal` 인증 객체 주입 방식 리팩토링 및 `@ActiveProfiles("test")` 적용
* `Test Config`: `mopl-api/src/test/resources/application-test.yml` 생성 (JWT, Mail 더미 데이터 주입)

## 📸 스크린샷
<img width="537" height="202" alt="image" src="https://github.com/user-attachments/assets/bb6bb722-845b-4ee2-a542-cd57121277e0" />

<img width="537" height="202" alt="image" src="https://github.com/user-attachments/assets/96f2db4f-2f93-4d6c-bcd8-f569e4889ab1" />

<img width="537" height="202" alt="image" src="https://github.com/user-attachments/assets/01c6c142-f756-4923-a7af-08dd74c4a2cf" />


