### PR TITLE
[FEAT] Follow - 사용자 팔로워 및 팔로잉 수 카운트 조회 API 구현

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/follow/controller/FollowController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/follow/controller/FollowController.java
@@ -3,6 +3,7 @@ package com.mopl.domain.follow.controller;
 import com.mopl.domain.auth.dto.UserPrincipal;
 import com.mopl.domain.follow.controller.docs.FollowControllerDocs;
 import com.mopl.domain.follow.dto.request.FollowRequest;
+import com.mopl.domain.follow.dto.response.FollowCountResponse;
 import com.mopl.domain.follow.dto.response.FollowResponse;
 import com.mopl.domain.follow.service.FollowService;
 import lombok.RequiredArgsConstructor;
@@ -55,5 +56,15 @@ public class FollowController implements FollowControllerDocs {
 
         boolean result = followService.isFollowing(userPrincipal.getUserId(), followeeId);
         return ResponseEntity.ok(result);
+    }
+
+    // 팔로워/팔로잉 수 카운트 조회 API
+    @Override
+    @GetMapping("/count")
+    public ResponseEntity<FollowCountResponse> getFollowCounts(@RequestParam Long targetId) {
+
+        FollowCountResponse response = followService.getFollowCounts(targetId);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/follow/controller/FollowController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/follow/controller/FollowController.java
@@ -45,4 +45,15 @@ public class FollowController implements FollowControllerDocs {
 
         return ResponseEntity.noContent().build();
     }
+
+    // 특정 유저 팔로우 확인 조회 API
+    @Override
+    @GetMapping("/followed-by-me")
+    public ResponseEntity<Boolean> checkFollowStatus(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestParam Long followeeId) {
+
+        boolean result = followService.isFollowing(userPrincipal.getUserId(), followeeId);
+        return ResponseEntity.ok(result);
+    }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/follow/controller/docs/FollowControllerDocs.java
+++ b/mopl-api/src/main/java/com/mopl/domain/follow/controller/docs/FollowControllerDocs.java
@@ -47,4 +47,19 @@ public interface FollowControllerDocs {
             @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal user,
             @Parameter(description = "삭제할 팔로우 ID (PK)") @PathVariable Long followId
     );
+
+    // 특정 유저 팔로우 확인 조회 명세서
+    @Operation(summary = "팔로우 여부 확인", description = "로그인한 사용자가 특정 사용자(followeeId)를 현재 팔로우하고 있는지 여부를 조회합니다. (true: 팔로우 중, false: 미팔로우)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공 (true/false 반환)"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (파라미터 누락 또는 잘못된 형식)"),
+            @ApiResponse(responseCode = "401", description = "인증 오류 (로그인 필요)"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    @GetMapping("/followed-by-me")
+    ResponseEntity<Boolean> checkFollowStatus(
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal user,
+            @Parameter(description = "확인할 상대방 사용자 ID (PK)", required = true) @RequestParam Long followeeId
+    );
 }
+

--- a/mopl-api/src/main/java/com/mopl/domain/follow/controller/docs/FollowControllerDocs.java
+++ b/mopl-api/src/main/java/com/mopl/domain/follow/controller/docs/FollowControllerDocs.java
@@ -2,6 +2,7 @@ package com.mopl.domain.follow.controller.docs;
 
 import com.mopl.domain.auth.dto.UserPrincipal;
 import com.mopl.domain.follow.dto.request.FollowRequest;
+import com.mopl.domain.follow.dto.response.FollowCountResponse;
 import com.mopl.domain.follow.dto.response.FollowResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -61,5 +62,22 @@ public interface FollowControllerDocs {
             @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal user,
             @Parameter(description = "확인할 상대방 사용자 ID (PK)", required = true) @RequestParam Long followeeId
     );
+
+    // 팔로워/팔로잉 수 조회 명세서
+    @Operation(summary = "팔로워/팔로잉 수 조회", description = "특정 사용자(targetId)의 팔로워 수(나를 구독)와 팔로잉 수(내가 구독)를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (파라미터 누락 등)"),
+            @ApiResponse(responseCode = "401", description = "인증 오류(로그인 필요)"),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    @GetMapping("/count")
+    ResponseEntity<FollowCountResponse> getFollowCounts(
+            @Parameter(description = "조회할 대상 사용자 ID (PK)", required = true) @RequestParam Long targetId
+    );
+
+
+
 }
 

--- a/mopl-api/src/main/java/com/mopl/domain/follow/dto/response/FollowCountResponse.java
+++ b/mopl-api/src/main/java/com/mopl/domain/follow/dto/response/FollowCountResponse.java
@@ -1,0 +1,16 @@
+package com.mopl.domain.follow.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "유저 팔로우/팔로잉 카운트 정보")
+public record FollowCountResponse(
+        @Schema(description = "팔로워 수 (나를 구독하는 사람)", example = "10")
+        long followerCount,
+
+        @Schema(description = "팔로잉 수 (내가 구독하는 사람)", example = "5")
+        long followingCount
+) {
+    public static FollowCountResponse of(long followerCount, long followingCount) {
+        return new FollowCountResponse(followerCount, followingCount);
+    }
+}

--- a/mopl-api/src/main/java/com/mopl/domain/follow/exception/FollowErrorCode.java
+++ b/mopl-api/src/main/java/com/mopl/domain/follow/exception/FollowErrorCode.java
@@ -11,7 +11,8 @@ public enum FollowErrorCode implements DomainErrorCode {
 
     CANNOT_FOLLOW_SELF("F001", "자기 자신을 팔로우할 수 없습니다.", HttpStatus.BAD_REQUEST), // 400
     ALREADY_FOLLOWING("F002", "이미 팔로우 중인 사용자입니다.", HttpStatus.BAD_REQUEST), // 400
-    FOLLOW_NOT_FOUND("F003", "팔로우 관계가 존재하지 않습니다.", HttpStatus.NOT_FOUND) // 404
+    NOT_YOUR_FOLLOW("F003", "본인의 팔로우만 취소할 수 있습니다.", HttpStatus.FORBIDDEN), //403
+    FOLLOW_NOT_FOUND("F004", "팔로우 관계가 존재하지 않습니다.", HttpStatus.NOT_FOUND) // 404
     ;
 
     private final String errorCode;

--- a/mopl-api/src/main/java/com/mopl/domain/follow/service/FollowService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/follow/service/FollowService.java
@@ -71,8 +71,14 @@ public class FollowService {
         followRepository.delete(follow);
     }
 
+    // 특정 유저 팔로우 확인 조회 로직
+    public boolean isFollowing(Long followerId, Long followeeId) {
+        return followRepository.existsByFollowerIdAndFolloweeId(followerId, followeeId);
+    }
+
     private User getUserOrThrow(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new MoplException(ErrorCode.NOT_FOUND));
     }
+
 }

--- a/mopl-api/src/main/java/com/mopl/domain/follow/service/FollowService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/follow/service/FollowService.java
@@ -1,6 +1,7 @@
 package com.mopl.domain.follow.service;
 
 import com.mopl.domain.follow.dto.request.FollowRequest;
+import com.mopl.domain.follow.dto.response.FollowCountResponse;
 import com.mopl.domain.follow.dto.response.FollowResponse;
 import com.mopl.domain.follow.entity.Follow;
 import com.mopl.domain.follow.exception.FollowErrorCode;
@@ -64,7 +65,7 @@ public class FollowService {
 
         // 2. 언팔로우 권한 확인 (403)
         if (!follow.getFollower().getId().equals(myId)) {
-            throw new MoplException(ErrorCode.FORBIDDEN);
+            throw new FollowException(FollowErrorCode.NOT_YOUR_FOLLOW);
         }
 
         // 3. 언팔로우
@@ -76,9 +77,25 @@ public class FollowService {
         return followRepository.existsByFollowerIdAndFolloweeId(followerId, followeeId);
     }
 
+    // 팔로워/팔로잉 수 조회 로직
+    public FollowCountResponse getFollowCounts(Long targetId) {
+
+        // 1. 유저 존재 확인 (404)
+        if (!userRepository.existsById(targetId)) {
+            throw new MoplException(ErrorCode.NOT_FOUND);
+        }
+
+        // 나를 팔로우 하는 사람 카운트 조회 (Follower)
+        long followerCount = followRepository.countByFolloweeId(targetId);
+
+        // 내가 팔로우 하는 사람 카운트 조회 (Following)
+        long followingCount = followRepository.countByFollowerId(targetId);
+
+        return FollowCountResponse.of(followerCount, followingCount);
+    }
+
     private User getUserOrThrow(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new MoplException(ErrorCode.NOT_FOUND));
     }
-
 }

--- a/mopl-api/src/main/java/com/mopl/global/exception/GlobalExceptionHandler.java
+++ b/mopl-api/src/main/java/com/mopl/global/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -37,6 +38,17 @@ public class GlobalExceptionHandler {
         log.error("타입 불일치 오류 발생: {}", detail, e);
 
         return createErrorResponse(ErrorCode.INVALID_INPUT_VALUE, detail);
+    }
+
+    /** 필수 파라미터 누락 예외 (400) - ErrorCode.MISSING_INPUT_VALUE와 연결 */
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<@NonNull ProblemDetail> handleMissingParams(MissingServletRequestParameterException e) {
+
+        String detail = String.format("필수 파라미터 '%s'가 누락되었습니다.", e.getParameterName());
+
+        log.error("필수 파라미터 누락: {}", detail, e);
+
+        return createErrorResponse(ErrorCode.MISSING_INPUT_VALUE, detail);
     }
 
     /** 권한 부족 예외 (403) - ErrorCode.INSUFFICIENT_PERMISSIONS과 연결 */

--- a/mopl-api/src/test/java/com/mopl/domain/follow/controller/FollowApiTest.java
+++ b/mopl-api/src/test/java/com/mopl/domain/follow/controller/FollowApiTest.java
@@ -1,6 +1,11 @@
 package com.mopl.domain.follow.controller;
 
+import com.mopl.domain.auth.dto.UserPrincipal;
 import com.mopl.domain.follow.exception.FollowErrorCode;
+import com.mopl.domain.user.enums.Role;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
 import tools.jackson.databind.ObjectMapper;
 import com.mopl.domain.follow.dto.request.FollowRequest;
 import com.mopl.domain.follow.entity.Follow;
@@ -18,12 +23,15 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import java.util.Collections;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ActiveProfiles("test")
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
@@ -52,6 +60,20 @@ class FollowApiTest {
         user2 = userRepository.save(new User("you", "user2@test.com", "password"));
     }
 
+    // UserPrincipal을 포함한 인증 토큰 생성 헬퍼 메서드
+    private UsernamePasswordAuthenticationToken createAuthToken(User user) {
+
+        // 실제 컨트롤러가 사용하는 UserPrincipal 객체 생성
+        UserPrincipal principal = new UserPrincipal(user.getId(), user.getEmail(), Role.USER);
+
+        // SecurityContext에 들어갈 토큰 생성
+        return new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+    }
+
     // 1. 성공 케이스 (201)
     @Test
     @DisplayName("[201] 정상적인 팔로우 요청 시 성공한다")
@@ -63,7 +85,8 @@ class FollowApiTest {
         mockMvc.perform(post("/api/follows")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
-                        .with(user(String.valueOf(user1.getId())))) // 로그인
+                        .with(authentication(createAuthToken(user1)))
+                        .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.followerId").value(user1.getId()))
@@ -81,7 +104,8 @@ class FollowApiTest {
         mockMvc.perform(post("/api/follows")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
-                        .with(user(String.valueOf(user1.getId()))))
+                        .with(authentication(createAuthToken(user1)))
+                        .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.title").value(FollowErrorCode.CANNOT_FOLLOW_SELF.name()))
@@ -100,7 +124,8 @@ class FollowApiTest {
         mockMvc.perform(post("/api/follows")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
-                        .with(user(String.valueOf(user1.getId()))))
+                        .with(authentication(createAuthToken(user1)))
+                        .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.title").value(FollowErrorCode.ALREADY_FOLLOWING.name()))
@@ -117,7 +142,8 @@ class FollowApiTest {
         // When & Then
         mockMvc.perform(post("/api/follows")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.title").value(ErrorCode.UNAUTHORIZED.name()));
@@ -136,7 +162,8 @@ class FollowApiTest {
         mockMvc.perform(post("/api/follows")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
-                        .with(user(String.valueOf(user1.getId()))))
+                        .with(authentication(createAuthToken(user1)))
+                        .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.title").value(ErrorCode.NOT_FOUND.name()));

--- a/mopl-api/src/test/java/com/mopl/domain/follow/controller/FollowCountApiTest.java
+++ b/mopl-api/src/test/java/com/mopl/domain/follow/controller/FollowCountApiTest.java
@@ -1,0 +1,146 @@
+package com.mopl.domain.follow.controller;
+
+import com.mopl.domain.auth.dto.UserPrincipal;
+import com.mopl.domain.follow.entity.Follow;
+import com.mopl.domain.follow.repository.FollowRepository;
+import com.mopl.domain.user.entity.User;
+import com.mopl.domain.user.enums.Role;
+import com.mopl.domain.user.repository.UserRepository;
+import com.mopl.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class FollowCountApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private FollowRepository followRepository;
+
+    // 테스트용 유저
+    private User targetUser;
+    private User fan1, fan2;
+
+    @BeforeEach
+    void setUp() {
+        // 유저 생성
+        targetUser = userRepository.save(new User("star", "star@test.com", "password"));
+        fan1 = userRepository.save(new User("fan1", "fan1@test.com", "password"));
+        fan2 = userRepository.save(new User("fan2", "fan2@test.com", "password"));
+    }
+
+    // UserPrincipal을 포함한 인증 토큰 생성 헬퍼 메서드
+    private UsernamePasswordAuthenticationToken createAuthToken(User user) {
+
+        // 실제 컨트롤러가 사용하는 UserPrincipal 객체 생성
+        UserPrincipal principal = new UserPrincipal(user.getId(), user.getEmail(), Role.USER);
+
+        // SecurityContext에 들어갈 토큰 생성
+        return new UsernamePasswordAuthenticationToken(
+                principal, null, Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+    }
+
+    // 1. 성공 케이스 - 데이터 있음 (200)
+    @Test
+    @DisplayName("[200] 팔로워/팔로잉이 있는 경우 정확한 카운트를 반환한다")
+    void getFollowCounts_Success() throws Exception {
+        // Given
+        // targetUser를 2명이 팔로우 (팔로워 = 2)
+        followRepository.save(Follow.builder().follower(fan1).followee(targetUser).build());
+        followRepository.save(Follow.builder().follower(fan2).followee(targetUser).build());
+
+        // targetUser가 1명을 팔로우 (팔로잉 = 1)
+        followRepository.save(Follow.builder().follower(targetUser).followee(fan1).build());
+
+        // When & Then
+        mockMvc.perform(get("/api/follows/count")
+                        .param("targetId", String.valueOf(targetUser.getId()))
+                        .with(authentication(createAuthToken(fan1)))) // 로그인 상태
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.followerCount").value(2))
+                .andExpect(jsonPath("$.followingCount").value(1));
+    }
+
+    // 2. 성공 케이스 - 데이터 없음 (200)
+    @Test
+    @DisplayName("[200] 팔로워/팔로잉이 없으면 0을 반환한다")
+    void getFollowCounts_Zero() throws Exception {
+        // Given: 아무 관계 없음
+
+        // When & Then
+        mockMvc.perform(get("/api/follows/count")
+                        .param("targetId", String.valueOf(targetUser.getId()))
+                        .with(authentication(createAuthToken(fan1))))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.followerCount").value(0))
+                .andExpect(jsonPath("$.followingCount").value(0));
+    }
+
+    // 3. 비즈니스 예외 케이스 (400)
+    @Test
+    @DisplayName("[400] 필수 파라미터(targetId) 누락 시 에러 발생")
+    void getFollowCounts_MissingParam() throws Exception {
+        // When & Then (targetId 파라미터 없이 요청)
+        mockMvc.perform(get("/api/follows/count")
+                        .with(authentication(createAuthToken(fan1))))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value(ErrorCode.MISSING_INPUT_VALUE.name()));
+    }
+
+    // 4. 인증 예외 케이스 (401)
+    @Test
+    @DisplayName("[401] 로그인하지 않고 요청하면 인증 에러 발생")
+    void getFollowCounts_Unauthorized() throws Exception {
+        // When & Then (인증 정보 없이 요청 -> Security Filter에서 차단)
+        mockMvc.perform(get("/api/follows/count")
+                        .param("targetId", String.valueOf(targetUser.getId())))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    // 5. 비즈니스 예외 케이스 (404)
+    @Test
+    @DisplayName("[404] 존재하지 않는 유저를 조회하면 NOT_FOUND 에러 발생")
+    void getFollowCounts_NotFound() throws Exception {
+        // Given
+        long nonExistentId = 999999L;
+
+        // When & Then
+        mockMvc.perform(get("/api/follows/count")
+                        .param("targetId", String.valueOf(nonExistentId))
+                        .with(authentication(createAuthToken(fan1))))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.title").value(ErrorCode.NOT_FOUND.name()));
+    }
+
+}

--- a/mopl-api/src/test/java/com/mopl/domain/follow/controller/FollowStatusApiTest.java
+++ b/mopl-api/src/test/java/com/mopl/domain/follow/controller/FollowStatusApiTest.java
@@ -1,0 +1,135 @@
+package com.mopl.domain.follow.controller;
+
+import com.mopl.domain.auth.dto.UserPrincipal;
+import com.mopl.domain.follow.entity.Follow;
+import com.mopl.domain.follow.repository.FollowRepository;
+import com.mopl.domain.user.entity.User;
+import com.mopl.domain.user.enums.Role;
+import com.mopl.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class FollowStatusApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private FollowRepository followRepository;
+
+    // 테스트용 유저
+    private User user1;
+    private User user2;
+
+    @BeforeEach
+    void setUp() {
+        // 유저 생성
+        user1 = userRepository.save(new User("me", "user1@test.com", "password"));
+        user2 = userRepository.save(new User("you", "user2@test.com", "password"));
+    }
+
+    // UserPrincipal을 포함한 인증 토큰 생성 헬퍼 메서드
+    private UsernamePasswordAuthenticationToken createAuthToken(User user) {
+
+        // 실제 컨트롤러가 사용하는 UserPrincipal 객체 생성
+        UserPrincipal principal = new UserPrincipal(user.getId(), user.getEmail(), Role.USER);
+
+        // SecurityContext에 들어갈 토큰 생성
+        return new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+    }
+
+    @Test
+    @DisplayName("[200] 팔로우 중일 경우 true를 반환한다")
+    void checkFollowStatus_True() throws Exception {
+        // Given: user1 -> user2 팔로우 관계 생성
+        followRepository.save(Follow.builder().follower(user1).followee(user2).build());
+
+        // When & Then: user1이 로그인한 상태로 user2 팔로우 여부 조회
+        mockMvc.perform(get("/api/follows/followed-by-me")
+                        .param("followeeId", String.valueOf(user2.getId()))
+                        .with(authentication(createAuthToken(user1))))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().string("true"));
+    }
+
+    @Test
+    @DisplayName("[200] 팔로우 중이 아닐 경우 false를 반환한다")
+    void checkFollowStatus_False() throws Exception {
+        // Given: 팔로우 관계 없음
+
+        // When & Then: user1이 로그인한 상태로 user2 팔로우 여부 조회
+        mockMvc.perform(get("/api/follows/followed-by-me")
+                        .param("followeeId", String.valueOf(user2.getId()))
+                        .with(authentication(createAuthToken(user1))))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().string("false"));
+    }
+
+    @Test
+    @DisplayName("[200] 존재하지 않는 유저 ID로 조회해도 false를 반환한다")
+    void checkFollowStatus_NotFoundUser_False() throws Exception {
+        // Given: 존재하지 않는 ID
+        long nonExistentUserId = 999999L;
+
+        // When & Then
+        mockMvc.perform(get("/api/follows/followed-by-me")
+                        .param("followeeId", String.valueOf(nonExistentUserId))
+                        .with(authentication(createAuthToken(user1))))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().string("false"));
+    }
+
+    @Test
+    @DisplayName("[401] 로그인하지 않고 조회하면 UNAUTHORIZED 에러 발생")
+    void checkFollowStatus_Unauthorized() throws Exception {
+        // Given
+        Long targetId = user2.getId();
+
+        // When & Then: .with(authentication(...)) 생략
+        mockMvc.perform(get("/api/follows/followed-by-me")
+                        .param("followeeId", String.valueOf(targetId)))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("[400] 필수 파라미터(followeeId)가 없으면 BAD_REQUEST 발생")
+    void checkFollowStatus_NoParam_Fail() throws Exception {
+        // When & Then
+        mockMvc.perform(get("/api/follows/followed-by-me")
+                        .with(authentication(createAuthToken(user1))))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/mopl-api/src/test/java/com/mopl/domain/follow/controller/FollowStatusApiTest.java
+++ b/mopl-api/src/test/java/com/mopl/domain/follow/controller/FollowStatusApiTest.java
@@ -6,12 +6,14 @@ import com.mopl.domain.follow.repository.FollowRepository;
 import com.mopl.domain.user.entity.User;
 import com.mopl.domain.user.enums.Role;
 import com.mopl.domain.user.repository.UserRepository;
+import com.mopl.global.exception.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+// [요청하신 경로 적용]
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.ActiveProfiles;
@@ -23,8 +25,7 @@ import java.util.Collections;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -54,18 +55,13 @@ class FollowStatusApiTest {
 
     // UserPrincipal을 포함한 인증 토큰 생성 헬퍼 메서드
     private UsernamePasswordAuthenticationToken createAuthToken(User user) {
-
-        // 실제 컨트롤러가 사용하는 UserPrincipal 객체 생성
         UserPrincipal principal = new UserPrincipal(user.getId(), user.getEmail(), Role.USER);
-
-        // SecurityContext에 들어갈 토큰 생성
         return new UsernamePasswordAuthenticationToken(
-                principal,
-                null,
-                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+                principal, null, Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
         );
     }
 
+    // 1. 성공 케이스 - 팔로우 중 (200)
     @Test
     @DisplayName("[200] 팔로우 중일 경우 true를 반환한다")
     void checkFollowStatus_True() throws Exception {
@@ -81,6 +77,7 @@ class FollowStatusApiTest {
                 .andExpect(content().string("true"));
     }
 
+    // 2. 성공 케이스 - 팔로우 중 아님 (200)
     @Test
     @DisplayName("[200] 팔로우 중이 아닐 경우 false를 반환한다")
     void checkFollowStatus_False() throws Exception {
@@ -95,6 +92,8 @@ class FollowStatusApiTest {
                 .andExpect(content().string("false"));
     }
 
+    // 3. 성공 케이스 - 존재하지 않는 유저 조회 (200)
+    // (Service 로직상 예외를 던지지 않고 false를 반환함)
     @Test
     @DisplayName("[200] 존재하지 않는 유저 ID로 조회해도 false를 반환한다")
     void checkFollowStatus_NotFoundUser_False() throws Exception {
@@ -110,26 +109,30 @@ class FollowStatusApiTest {
                 .andExpect(content().string("false"));
     }
 
+    // 4. 비즈니스 예외 케이스 (400)
+    @Test
+    @DisplayName("[400] 필수 파라미터(followeeId)가 없으면 BAD_REQUEST 발생")
+    void checkFollowStatus_NoParam_Fail() throws Exception {
+        // When & Then: 파라미터 누락
+        mockMvc.perform(get("/api/follows/followed-by-me")
+                        .with(authentication(createAuthToken(user1))))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value(ErrorCode.MISSING_INPUT_VALUE.name()));
+    }
+
+    // 5. 인증 예외 케이스 (401)
     @Test
     @DisplayName("[401] 로그인하지 않고 조회하면 UNAUTHORIZED 에러 발생")
     void checkFollowStatus_Unauthorized() throws Exception {
         // Given
         Long targetId = user2.getId();
 
-        // When & Then: .with(authentication(...)) 생략
+        // When & Then: .with(authentication(...)) 생략 로그인하지 않음 -> 401
         mockMvc.perform(get("/api/follows/followed-by-me")
                         .param("followeeId", String.valueOf(targetId)))
                 .andDo(print())
                 .andExpect(status().isUnauthorized());
     }
 
-    @Test
-    @DisplayName("[400] 필수 파라미터(followeeId)가 없으면 BAD_REQUEST 발생")
-    void checkFollowStatus_NoParam_Fail() throws Exception {
-        // When & Then
-        mockMvc.perform(get("/api/follows/followed-by-me")
-                        .with(authentication(createAuthToken(user1))))
-                .andDo(print())
-                .andExpect(status().isBadRequest());
-    }
 }

--- a/mopl-api/src/test/java/com/mopl/domain/follow/controller/UnFollowApiTest.java
+++ b/mopl-api/src/test/java/com/mopl/domain/follow/controller/UnFollowApiTest.java
@@ -111,7 +111,7 @@ class UnFollowApiTest {
                         .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.title").value(ErrorCode.FORBIDDEN.name()));
+                .andExpect(jsonPath("$.title").value(FollowErrorCode.NOT_YOUR_FOLLOW.name()));
     }
 
     // 4. 리소스 없음 (404)

--- a/mopl-api/src/test/java/com/mopl/domain/follow/controller/UnFollowApiTest.java
+++ b/mopl-api/src/test/java/com/mopl/domain/follow/controller/UnFollowApiTest.java
@@ -12,15 +12,23 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
+import com.mopl.domain.auth.dto.UserPrincipal;
+import com.mopl.domain.user.enums.Role;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import java.util.Collections;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ActiveProfiles("test")
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
@@ -46,6 +54,20 @@ class UnFollowApiTest {
         user2 = userRepository.save(new User("you", "user2@test.com", "password"));
     }
 
+    // UserPrincipal을 포함한 인증 토큰 생성 헬퍼 메서드
+    private UsernamePasswordAuthenticationToken createAuthToken(User user) {
+
+        // 실제 컨트롤러가 사용하는 UserPrincipal 객체 생성
+        UserPrincipal principal = new UserPrincipal(user.getId(), user.getEmail(), Role.USER);
+
+        // SecurityContext에 들어갈 토큰 생성
+        return new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+    }
+
     // 1. 성공 케이스 (204)
     @Test
     @DisplayName("[204] 본인이 생성한 팔로우를 취소하면 성공한다")
@@ -56,7 +78,8 @@ class UnFollowApiTest {
 
         // When & Then
         mockMvc.perform(delete("/api/follows/{followId}", savedFollow.getId())
-                        .with(user(String.valueOf(user1.getId())))) // 작성자(user1)로 로그인
+                        .with(authentication(createAuthToken(user1))) // 작성자(user1)로 로그인
+                        .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isNoContent());
     }
@@ -67,7 +90,8 @@ class UnFollowApiTest {
     void unfollowUser_TypeMismatch_Fail() throws Exception {
         // When: 숫자가 들어가야 할 자리에 문자("abc") 입력
         mockMvc.perform(delete("/api/follows/abc")
-                        .with(user(String.valueOf(user1.getId()))))
+                        .with(authentication(createAuthToken(user1)))
+                        .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.title").value(ErrorCode.INVALID_INPUT_VALUE.name()));
@@ -83,7 +107,8 @@ class UnFollowApiTest {
 
         // When: user2가 user1의 팔로우를 삭제 시도
         mockMvc.perform(delete("/api/follows/{followId}", savedFollow.getId())
-                        .with(user(String.valueOf(user2.getId()))))
+                        .with(authentication(createAuthToken(user2)))
+                        .with(csrf()))
                 .andDo(print())
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.title").value(ErrorCode.FORBIDDEN.name()));
@@ -98,10 +123,10 @@ class UnFollowApiTest {
 
         // When & Then
         mockMvc.perform(delete("/api/follows/{followId}", invalidFollowId)
-                        .with(user(String.valueOf(user1.getId()))))
+                        .with(authentication(createAuthToken(user1)))
+                        .with(csrf()))
                 .andDo(print())
-                .andExpect(status().isNotFound()) // 404
+                .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.title").value(FollowErrorCode.FOLLOW_NOT_FOUND.name()));
     }
-
 }

--- a/mopl-api/src/test/resources/application-test.yml
+++ b/mopl-api/src/test/resources/application-test.yml
@@ -17,17 +17,18 @@ spring:
       hibernate:
         format_sql: true
 
+  # Redis 설정
   data:
     redis:
       host: localhost
       port: 6379
 
-  # [추가] 이메일 설정 가짜 값 (이게 없어서 에러 발생)
+  # 이메일 설정 가짜 값
   mail:
     host: smtp.gmail.com
     port: 587
-    username: "test@gmail.com"  # 가짜 값
-    password: "testpassword"    # 가짜 값
+    username: "test@gmail.com"
+    password: "testpassword"
     properties:
       mail:
         smtp:
@@ -35,7 +36,7 @@ spring:
           starttls:
             enable: true
 
-# [JWT 설정] (기존 내용 유지)
+# JWT 설정
 jwt:
   access-secret: "test_secret_key_for_access_token_must_be_32_bytes_long"
   refresh-secret: "test_secret_key_for_refresh_token_must_be_32_bytes_long"

--- a/mopl-api/src/test/resources/application-test.yml
+++ b/mopl-api/src/test/resources/application-test.yml
@@ -1,0 +1,50 @@
+spring:
+  config:
+    activate:
+      on-profile: test
+
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+  # [추가] 이메일 설정 가짜 값 (이게 없어서 에러 발생)
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: "test@gmail.com"  # 가짜 값
+    password: "testpassword"    # 가짜 값
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
+# [JWT 설정] (기존 내용 유지)
+jwt:
+  access-secret: "test_secret_key_for_access_token_must_be_32_bytes_long"
+  refresh-secret: "test_secret_key_for_refresh_token_must_be_32_bytes_long"
+  access-token-validity: 3600000
+  refresh-token-validity: 604800000
+  cookie:
+    secure: false
+    same-site: Lax
+
+logging:
+  level:
+    root: INFO

--- a/mopl-api/src/test/resources/application-test.yml
+++ b/mopl-api/src/test/resources/application-test.yml
@@ -17,12 +17,13 @@ spring:
       hibernate:
         format_sql: true
 
+  # Redis 설정
   data:
     redis:
       host: localhost
       port: 6379
 
-  # [추가] 이메일 설정 가짜 값 (이게 없어서 에러 발생)
+  # 이메일 설정 가짜 값
   mail:
     host: smtp.gmail.com
     port: 587
@@ -35,7 +36,7 @@ spring:
           starttls:
             enable: true
 
-# [JWT 설정] (기존 내용 유지)
+# JWT 설정
 jwt:
   access-secret: "test_secret_key_for_access_token_must_be_32_bytes_long"
   refresh-secret: "test_secret_key_for_refresh_token_must_be_32_bytes_long"

--- a/mopl-core/src/main/java/com/mopl/domain/follow/repository/FollowRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/follow/repository/FollowRepository.java
@@ -6,11 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FollowRepository extends JpaRepository<@NonNull Follow, @NonNull Long> {
 
-    // 중복 팔로우 체크
+    // 중복 팔로우 체크 및 특정 유저 팔로우 체크
     boolean existsByFollowerIdAndFolloweeId(Long followerId, Long followeeId);
-
-    // 언팔로우
-    void deleteByFollowerIdAndFolloweeId(Long followerId, Long followeeId);
 
     // 팔로워/팔로잉 수 카운트 (마이페이지에 쓰이는것)
     long countByFollowerId(Long followerId);

--- a/mopl-core/src/main/java/com/mopl/global/exception/ErrorCode.java
+++ b/mopl-core/src/main/java/com/mopl/global/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
 
     // 데이터 및 비즈니스 로직 관련
     INVALID_INPUT_VALUE("입력 값이 유효하지 않습니다.", 400),
+    MISSING_INPUT_VALUE("필수 입력 값이 누락되었습니다.", 400),
     DATA_INTEGRITY_VIOLATION("데이터 무결성 제약 조건이 위반되었습니다.", 400),
     DUPLICATE_RESOURCE("이미 존재하는 리소스입니다.", 409),
 


### PR DESCRIPTION
## 연관 이슈

close #143

## 🔄 변경 사항

* **API 추가**: `GET /api/follows/count` 엔드포인트가 추가되었습니다. (특정 유저의 팔로워/팔로잉 수 조회)
* **에러 응답 개선**: 언팔로우 시 권한 오류가 `FORBIDDEN`에서 `NOT_YOUR_FOLLOW`("본인의 팔로우만 취소할 수 있습니다.")로 구체화되었습니다.

## 🧩 작업 사항

* `FollowCountResponse` DTO (Record) 생성
* `FollowService` 비즈니스 로직 구현
* 대상 유저 존재 여부 검증 (`existsById`) 추가
* 언팔로우 예외 처리 리팩토링 (`FollowErrorCode.NOT_YOUR_FOLLOW` 적용)

* `FollowController` 및 `FollowControllerDocs` 구현 (Swagger 명세 적용)
* 통합 테스트 작성 및 리팩토링
* `FollowCountApiTest` (신규 작성 - 5가지 케이스 검증)
* `UnFollowApiTest` (수정 - 주석 및 테스트 순서 변경)
* `FollowStatusApiTest` (수정 - 주석 및 테스트 순서 변경)



## 📸 스크린샷
<img width="1074" height="404" alt="image" src="https://github.com/user-attachments/assets/f26a7c2a-18f2-4a40-a01a-ac48716516d2" />

