### PR TITLE
[FEAT] Batch - TvSeries, Sprot 데이터 배치 처리 추가 구현

### DIFF
--- a/mopl-batch/src/main/java/com/mopl/domain/contents/TestController.java
+++ b/mopl-batch/src/main/java/com/mopl/domain/contents/TestController.java
@@ -1,20 +1,16 @@
 package com.mopl.domain.contents;
 
-import com.mopl.domain.contents.dto.SportDbDto;
+import com.mopl.domain.contents.dto.sportDb.SportDbDto;
+import com.mopl.domain.contents.dto.tmdb.KeywordDto;
 import com.mopl.domain.contents.dto.tmdb.TmdbDetailDto;
+import com.mopl.domain.contents.dto.tmdb.TvSeriesDto;
 import com.mopl.domain.contents.openapi.SportDbClient;
 import com.mopl.domain.contents.openapi.TmdbClient;
 import lombok.RequiredArgsConstructor;
-import org.springframework.batch.core.job.Job;
-import org.springframework.batch.core.job.parameters.JobParameters;
-import org.springframework.batch.core.job.parameters.JobParametersBuilder;
-import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 //@Profile("local")
 @RequiredArgsConstructor
@@ -25,16 +21,23 @@ public class TestController {
     private final TmdbClient tmdbClient;
     private final SportDbClient sportDbClient;
 
-    private final JobLauncher jobLauncher;
-    private final Job tmdbJob;
-
-    @GetMapping("/tmdb")
+    @GetMapping("/tmdb/movie")
     public Mono<List<Long>> getPopularMovieIds(@RequestParam(name = "page", defaultValue = "1") int page) {
         return tmdbClient.getPopularMovieIdList(page);
     }
-    @GetMapping("/tmdb/{movieId}")
+    @GetMapping("/tmdb/movie/{movieId}")
     public Mono<TmdbDetailDto> getMovieDetails(@PathVariable Long movieId) {
         return tmdbClient.getMovieDetails(movieId);
+    }
+
+    @GetMapping("/tmdb/tvseries")
+    public Mono<List<TvSeriesDto>> getPopularTvSeriesIds(@RequestParam(name = "page", defaultValue = "1") int page) {
+        return tmdbClient.getPopularTvSeriesIdList(page);
+    }
+
+    @GetMapping("/tmdb/tvseries/{tvId}")
+    public Mono<List<KeywordDto>> getTvSeriesKeyword(@PathVariable Long tvId) {
+        return tmdbClient.getTvSeriesKeyword(tvId);
     }
 
     @GetMapping("/sport")
@@ -42,21 +45,4 @@ public class TestController {
         return sportDbClient.getSportsEventSeason();
     }
 
-    @GetMapping("/batch/tmdb")
-    public String runTmdbBatch() {
-        // 별도의 스레드에서 배치를 실행하여 WebFlux 루프 스레드가 차단되지 않도록 합니다.
-        CompletableFuture.runAsync(() -> {
-            try {
-                JobParameters jobParameters = new JobParametersBuilder()
-                        .addString("datetime", LocalDateTime.now().toString())
-                        .toJobParameters();
-
-                jobLauncher.run(tmdbJob, jobParameters);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        });
-
-        return "SUCCESS: TMDB Batch execution triggered in a background thread.";
-    }
 }

--- a/mopl-batch/src/main/java/com/mopl/domain/contents/controller/BatchController.java
+++ b/mopl-batch/src/main/java/com/mopl/domain/contents/controller/BatchController.java
@@ -1,0 +1,55 @@
+package com.mopl.domain.contents.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.CompletableFuture;
+
+//@Profile("local")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/batch")
+public class BatchController {
+
+    private final JobLauncher jobLauncher;
+    private final Job movieJob;
+    private final Job tvSeriesJob;
+    private final Job sportJob;
+
+    @GetMapping("/tmdb/movie")
+    public String runMovieBatch() {
+        return executeJob(movieJob, "Movie");
+    }
+
+    @GetMapping("/tmdb/tvseries")
+    public String runTvSeriesBatch() {
+        return executeJob(tvSeriesJob, "TV Series");
+    }
+
+    @GetMapping("/sport")
+    public String runSportBatch() {
+        return executeJob(sportJob, "Sport");
+    }
+
+    private String executeJob(Job job, String jobName) {
+        CompletableFuture.runAsync(() -> {
+            try {
+                JobParameters jobParameters = new JobParametersBuilder()
+                        .addString("datetime", LocalDateTime.now().toString())
+                        .toJobParameters();
+
+                jobLauncher.run(job, jobParameters);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+        return "SUCCESS: TMDB " + jobName + " Batch execution triggered.";
+    }
+}

--- a/mopl-batch/src/main/java/com/mopl/domain/contents/dto/sportDb/SportDbDto.java
+++ b/mopl-batch/src/main/java/com/mopl/domain/contents/dto/sportDb/SportDbDto.java
@@ -1,4 +1,4 @@
-package com.mopl.domain.contents.dto;
+package com.mopl.domain.contents.dto.sportDb;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -13,5 +13,7 @@ public record SportDbDto(
         String description,
         @JsonAlias("strThumb")
         @JsonProperty("thumbnailUrl")
-        String thumbnailUrl
+        String thumbnailUrl,
+        String strVenue,
+        String strSport
 ) {}

--- a/mopl-batch/src/main/java/com/mopl/domain/contents/dto/sportDb/SportDbResponse.java
+++ b/mopl-batch/src/main/java/com/mopl/domain/contents/dto/sportDb/SportDbResponse.java
@@ -1,4 +1,4 @@
-package com.mopl.domain.contents.dto;
+package com.mopl.domain.contents.dto.sportDb;
 
 import java.util.List;
 

--- a/mopl-batch/src/main/java/com/mopl/domain/contents/dto/tmdb/KeywordDto.java
+++ b/mopl-batch/src/main/java/com/mopl/domain/contents/dto/tmdb/KeywordDto.java
@@ -1,7 +1,20 @@
 package com.mopl.domain.contents.dto.tmdb;
 
+import com.mopl.domain.content.entity.Tag;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 public record KeywordDto(
-    Long id,
-    String name
+        Long id,
+        String name
 ) {
+
+    /**
+     * 태그 정보 중복 조회를 방지하기 위한 공유 캐시입니다.
+     * - 목적: API 응답 처리 중 반복되는 태그명에 대해 매번 DB 조회를 하지 않고 메모리에서 즉시 반환하여 성능 개선
+     * - static: 여러 DTO 인스턴스 및 배치 스텝 간에 캐시를 공유하기 위해 사용
+     * - ConcurrentHashMap: 멀티스레드 배치 환경(Parallel Steps)에서도 데이터 안정성을 보장하기 위해 사용
+     */
+    public static final Map<String, Tag> tagCache = new ConcurrentHashMap<>();
 }

--- a/mopl-batch/src/main/java/com/mopl/domain/contents/dto/tmdb/TmdbResponse.java
+++ b/mopl-batch/src/main/java/com/mopl/domain/contents/dto/tmdb/TmdbResponse.java
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
-public record TmdbResponse(
+public record TmdbResponse<T>(
         int page,
-        List<TmdbDto> results,
+        List<T> results,
         @JsonProperty("total_pages") int totalPages,
         @JsonProperty("total_results") int totalResults
 ) {

--- a/mopl-batch/src/main/java/com/mopl/domain/contents/dto/tmdb/TvSeriesDto.java
+++ b/mopl-batch/src/main/java/com/mopl/domain/contents/dto/tmdb/TvSeriesDto.java
@@ -1,0 +1,14 @@
+package com.mopl.domain.contents.dto.tmdb;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+
+public record TvSeriesDto(
+        Long id,
+        @JsonAlias("name")
+        String title,
+        @JsonAlias("overview")
+        String description,
+        @JsonAlias("poster_path")
+        String thumbnailUrl
+) {
+}

--- a/mopl-batch/src/main/java/com/mopl/domain/contents/dto/tmdb/TvSeriesKeyword.java
+++ b/mopl-batch/src/main/java/com/mopl/domain/contents/dto/tmdb/TvSeriesKeyword.java
@@ -1,0 +1,8 @@
+package com.mopl.domain.contents.dto.tmdb;
+
+import java.util.List;
+
+public record TvSeriesKeyword(
+        List<KeywordDto> genres
+) {
+}

--- a/mopl-batch/src/main/java/com/mopl/domain/contents/openapi/SportDbClient.java
+++ b/mopl-batch/src/main/java/com/mopl/domain/contents/openapi/SportDbClient.java
@@ -1,7 +1,7 @@
 package com.mopl.domain.contents.openapi;
 
-import com.mopl.domain.contents.dto.SportDbDto;
-import com.mopl.domain.contents.dto.SportDbResponse;
+import com.mopl.domain.contents.dto.sportDb.SportDbDto;
+import com.mopl.domain.contents.dto.sportDb.SportDbResponse;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;

--- a/mopl-batch/src/main/java/com/mopl/domain/contents/openapi/TmdbClient.java
+++ b/mopl-batch/src/main/java/com/mopl/domain/contents/openapi/TmdbClient.java
@@ -1,9 +1,8 @@
 package com.mopl.domain.contents.openapi;
 
-import com.mopl.domain.contents.dto.tmdb.TmdbDetailDto;
-import com.mopl.domain.contents.dto.tmdb.TmdbDto;
-import com.mopl.domain.contents.dto.tmdb.TmdbResponse;
+import com.mopl.domain.contents.dto.tmdb.*;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -29,7 +28,7 @@ public class TmdbClient {
                         .queryParam("language", "ko-KR")
                         .build())
                 .retrieve()
-                .bodyToMono(TmdbResponse.class)
+                .bodyToMono(new ParameterizedTypeReference<TmdbResponse<TmdbDto>>() {})
                 .map(response -> response.results().stream()
                         .map(TmdbDto::id)
                         .toList()
@@ -46,6 +45,38 @@ public class TmdbClient {
                         .build(movieId))
                 .retrieve()
                 .bodyToMono(TmdbDetailDto.class)
+                .retryWhen(Retry.backoff(3, Duration.ofSeconds(1)));
+    }
+
+    /** Open API에서 인기 있는 TV 시리즈 목록을 가져옵니다. */
+    public Mono<List<TvSeriesDto>> getPopularTvSeriesIdList(int page) {
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/tv/popular")
+                        .queryParam("page", page)
+                        .queryParam("language", "ko-KR")
+                        .build())
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<TmdbResponse<TvSeriesDto>>() {})
+                .map(response -> response.results().stream()
+                        .map(result-> {
+                            return new TvSeriesDto(result.id(), result.title(), result.description(), result.thumbnailUrl());
+                        })
+                        .toList()
+                )
+                .retryWhen(Retry.backoff(3, Duration.ofSeconds(2)));
+    }
+
+    public Mono<List<KeywordDto>> getTvSeriesKeyword(Long tvSeriesId) {
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/tv/{tvSeriesId}")
+                        .queryParam("append_to_response", "keywords")
+                        .queryParam("language", "ko-KR")
+                        .build(tvSeriesId))
+                .retrieve()
+                .bodyToMono(TvSeriesKeyword.class)
+                .map(TvSeriesKeyword::genres)
                 .retryWhen(Retry.backoff(3, Duration.ofSeconds(1)));
     }
 }

--- a/mopl-batch/src/main/java/com/mopl/domain/contents/processor/MovieProcessor.java
+++ b/mopl-batch/src/main/java/com/mopl/domain/contents/processor/MovieProcessor.java
@@ -13,26 +13,24 @@ import org.springframework.batch.core.step.StepExecution;
 import org.springframework.batch.infrastructure.item.ItemProcessor;
 import org.springframework.stereotype.Component;
 
-import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.List;
+
+import static com.mopl.domain.contents.dto.tmdb.KeywordDto.tagCache;
 
 @Slf4j
 @Component
 @StepScope
 @RequiredArgsConstructor
-public class TmdbProcessor implements ItemProcessor<Long, Content> {
+public class MovieProcessor implements ItemProcessor<Long, Content> {
 
     private final TmdbClient tmdbClient;
     private final TagRepository tagRepository;
 
-    // 키를 미리 담아놓을 메모리 캐시 key - 장르이름, value - Tag 객체
-    private Map<String, Tag> tagCache;
-
     @BeforeStep
     public void beforeStep(StepExecution stepExecution) {
-        if (tagCache == null) {
-            tagCache = tagRepository.findAll().stream()
-                    .collect(Collectors.toMap(Tag::getTag, tag -> tag));
+        if (tagCache.isEmpty()) {
+            List<Tag> allTags = tagRepository.findAll();
+            allTags.forEach(tag -> tagCache.put(tag.getTag(), tag));
             log.info("태그 {}개를 캐시에 로드했습니다.", tagCache.size());
         }
     }

--- a/mopl-batch/src/main/java/com/mopl/domain/contents/processor/SportProcessor.java
+++ b/mopl-batch/src/main/java/com/mopl/domain/contents/processor/SportProcessor.java
@@ -4,7 +4,7 @@ import com.mopl.domain.content.entity.Content;
 import com.mopl.domain.content.entity.Tag;
 import com.mopl.domain.content.enums.ContentType;
 import com.mopl.domain.content.repository.TagRepository;
-import com.mopl.domain.contents.dto.SportDbDto;
+import com.mopl.domain.contents.dto.sportDb.SportDbDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.annotation.BeforeStep;

--- a/mopl-batch/src/main/java/com/mopl/domain/contents/processor/SportProcessor.java
+++ b/mopl-batch/src/main/java/com/mopl/domain/contents/processor/SportProcessor.java
@@ -1,0 +1,69 @@
+package com.mopl.domain.contents.processor;
+
+import com.mopl.domain.content.entity.Content;
+import com.mopl.domain.content.entity.Tag;
+import com.mopl.domain.content.enums.ContentType;
+import com.mopl.domain.content.repository.TagRepository;
+import com.mopl.domain.contents.dto.SportDbDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.annotation.BeforeStep;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.infrastructure.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static com.mopl.domain.contents.dto.tmdb.KeywordDto.tagCache;
+
+@Slf4j
+@Component
+@StepScope
+@RequiredArgsConstructor
+public class SportProcessor implements ItemProcessor<SportDbDto, Content> {
+
+    private final TagRepository tagRepository;
+
+    @BeforeStep
+    public void beforeStep() {
+        if (tagCache.isEmpty()) {
+            List<Tag> allTags = tagRepository.findAll();
+            allTags.forEach(tag -> tagCache.put(tag.getTag(), tag));
+            log.info("TV 시리즈 배치를 위해 태그 {}개를 캐시에 로드했습니다.", tagCache.size());
+        }
+    }
+
+    @Override
+    public Content process(SportDbDto item) {
+        try{
+            Content content = new Content(
+                ContentType.sport,
+                item.title(),
+                item.description(),
+                item.thumbnailUrl()
+            );
+
+            // 1. SportDbDto에서 명시한 세 개의 필드만 추출
+            List<String> tagNames = Stream.of(item.strVenue(), item.strSport())
+                    .filter(name -> name != null && !name.isBlank())
+                    .distinct()
+                    .toList();
+
+            // 추출한 태그들을 순회하며 등록
+            tagNames.forEach(tagName -> {
+                Tag tag = tagCache.computeIfAbsent(tagName, name ->
+                        tagRepository.findByTag(name)
+                                .orElseGet(() -> tagRepository.save(new Tag(name)))
+                );
+                content.addTag(tag);
+            });
+
+            return content;
+
+        } catch (Exception e) {
+            log.error("TV 시리즈 상세 정보 처리 실패 - ID: {}, 사유: {}", item.id(), e.getMessage());
+            return null; // 에러 발생 시 해당 아이템은 건너뜀
+        }
+    }
+}

--- a/mopl-batch/src/main/java/com/mopl/domain/contents/processor/TvSeriesProcessor.java
+++ b/mopl-batch/src/main/java/com/mopl/domain/contents/processor/TvSeriesProcessor.java
@@ -1,0 +1,67 @@
+package com.mopl.domain.contents.processor;
+
+import com.mopl.domain.content.entity.Content;
+import com.mopl.domain.content.entity.Tag;
+import com.mopl.domain.content.enums.ContentType;
+import com.mopl.domain.content.repository.TagRepository;
+import com.mopl.domain.contents.dto.tmdb.TvSeriesDto;
+import com.mopl.domain.contents.openapi.TmdbClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.annotation.BeforeStep;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.infrastructure.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static com.mopl.domain.contents.dto.tmdb.KeywordDto.tagCache;
+
+@Slf4j
+@Component
+@StepScope
+@RequiredArgsConstructor
+public class TvSeriesProcessor implements ItemProcessor<TvSeriesDto, Content> {
+
+    private final TmdbClient tmdbClient;
+    private final TagRepository tagRepository;
+
+    @BeforeStep
+    public void beforeStep() {
+        if (tagCache.isEmpty()) {
+            List<Tag> allTags = tagRepository.findAll();
+            allTags.forEach(tag -> tagCache.put(tag.getTag(), tag));
+            log.info("TV 시리즈 배치를 위해 태그 {}개를 캐시에 로드했습니다.", tagCache.size());
+        }
+    }
+
+    @Override
+    public Content process(TvSeriesDto item) throws Exception {
+        try {
+            Content content = new Content(
+                    ContentType.tvSeries,
+                    item.title(),
+                    item.description(),
+                    "https://image.tmdb.org/t/p/w200" + item.thumbnailUrl()
+            );
+
+            // 2. 키워드(장르) 정보 가져오기 및 태그 매핑
+            return tmdbClient.getTvSeriesKeyword(item.id())
+                    .map(genreList -> {
+                        genreList.forEach(genre -> {
+                            Tag tag = tagCache.computeIfAbsent(genre.name(), name -> {
+                                Tag newTag = new Tag(name);
+                                return tagRepository.save(newTag);
+                            });
+                            content.addTag(tag);
+                        });
+                        return content;
+                    })
+                    .block(); // 동기 처리를 위해 block 사용
+
+        } catch (Exception e) {
+            log.error("TV 시리즈 상세 정보 처리 실패 - ID: {}, 사유: {}", item.id(), e.getMessage());
+            return null; // 에러 발생 시 해당 아이템은 건너뜀
+        }
+    }
+}

--- a/mopl-batch/src/main/java/com/mopl/domain/contents/reader/MovieReader.java
+++ b/mopl-batch/src/main/java/com/mopl/domain/contents/reader/MovieReader.java
@@ -15,7 +15,7 @@ import java.util.List;
 @Component
 @StepScope
 @RequiredArgsConstructor
-public class TmdbReader implements ItemReader<Long> {
+public class MovieReader implements ItemReader<Long> {
 
     private final TmdbClient tmdbClient;
     private Iterator<Long> itemIterator;

--- a/mopl-batch/src/main/java/com/mopl/domain/contents/reader/SportReader.java
+++ b/mopl-batch/src/main/java/com/mopl/domain/contents/reader/SportReader.java
@@ -1,6 +1,6 @@
 package com.mopl.domain.contents.reader;
 
-import com.mopl.domain.contents.dto.SportDbDto;
+import com.mopl.domain.contents.dto.sportDb.SportDbDto;
 import com.mopl.domain.contents.openapi.SportDbClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/mopl-batch/src/main/java/com/mopl/domain/contents/reader/SportReader.java
+++ b/mopl-batch/src/main/java/com/mopl/domain/contents/reader/SportReader.java
@@ -1,0 +1,48 @@
+package com.mopl.domain.contents.reader;
+
+import com.mopl.domain.contents.dto.SportDbDto;
+import com.mopl.domain.contents.openapi.SportDbClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.infrastructure.item.ItemReader;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+@Slf4j
+@Component
+@StepScope
+@RequiredArgsConstructor
+public class SportReader implements ItemReader<SportDbDto> {
+
+    private final SportDbClient sportDbClient;
+    private Iterator<SportDbDto> itemIterator;
+
+    private int page = 1;
+    private final int maxPage = 20;
+
+    @Override
+    public SportDbDto read() throws IOException {
+        if (itemIterator == null || !itemIterator.hasNext()) {
+
+            if (page > maxPage) {
+                log.info("TMDB Reader: 최대 페이지 제한({})에 도달하여 읽기를 종료합니다.", maxPage);
+                return null;
+            }
+
+            log.debug("TMDB API 호출 중... page: {}", page);
+            List<SportDbDto> tvSeriesList = sportDbClient.getSportsEventSeason().block();
+
+            // 더 이상 데이터 없으면 배치 종료
+            if (tvSeriesList == null || tvSeriesList.isEmpty()) return null;
+
+            this.itemIterator = tvSeriesList.iterator();
+            this.page++;
+
+        }
+        return itemIterator.next();
+    }
+}

--- a/mopl-batch/src/main/java/com/mopl/domain/contents/reader/TvSeriesReader.java
+++ b/mopl-batch/src/main/java/com/mopl/domain/contents/reader/TvSeriesReader.java
@@ -1,0 +1,48 @@
+package com.mopl.domain.contents.reader;
+
+import com.mopl.domain.contents.dto.tmdb.TvSeriesDto;
+import com.mopl.domain.contents.openapi.TmdbClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.infrastructure.item.ItemReader;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+
+@Slf4j
+@Component
+@StepScope
+@RequiredArgsConstructor
+public class TvSeriesReader implements ItemReader<TvSeriesDto> {
+
+    private final TmdbClient tmdbClient;
+    private Iterator<TvSeriesDto> itemIterator;
+
+    private int page = 1;
+    private final int maxPage = 20;
+
+    @Override
+    public TvSeriesDto read() throws IOException {
+        if (itemIterator == null || !itemIterator.hasNext()) {
+
+            if (page > maxPage) {
+                log.info("TMDB Reader: 최대 페이지 제한({})에 도달하여 읽기를 종료합니다.", maxPage);
+                return null;
+            }
+
+            log.debug("TMDB API 호출 중... page: {}", page);
+            List<TvSeriesDto> tvSeriesList = tmdbClient.getPopularTvSeriesIdList(page).block();
+
+            // 더 이상 데이터 없으면 배치 종료
+            if (tvSeriesList == null || tvSeriesList.isEmpty()) return null;
+
+            this.itemIterator = tvSeriesList.iterator();
+            this.page++;
+
+        }
+        return itemIterator.next();
+    }
+}

--- a/mopl-batch/src/main/java/com/mopl/job/MovieBatchJob.java
+++ b/mopl-batch/src/main/java/com/mopl/job/MovieBatchJob.java
@@ -1,8 +1,8 @@
 package com.mopl.job;
 
 import com.mopl.domain.content.entity.Content;
-import com.mopl.domain.contents.processor.TmdbProcessor;
-import com.mopl.domain.contents.reader.TmdbReader;
+import com.mopl.domain.contents.processor.MovieProcessor;
+import com.mopl.domain.contents.reader.MovieReader;
 import com.mopl.domain.contents.writer.TmdbWriter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.job.Job;
@@ -16,25 +16,25 @@ import org.springframework.transaction.PlatformTransactionManager;
 
 @Configuration
 @RequiredArgsConstructor
-public class TmdbBatchConfig {
+public class MovieBatchJob {
 
     private final JobRepository jobRepository;
     private final PlatformTransactionManager transactionManager;
 
-    private final TmdbReader tmdbReader;
-    private final TmdbProcessor tmdbProcessor;
+    private final MovieReader tmdbReader;
+    private final MovieProcessor tmdbProcessor;
     private final TmdbWriter tmdbWriter;
 
     @Bean
-    public Job tmdbJob() {
-        return new JobBuilder("tmdbJob", jobRepository)
-                .start(tmdbStep())
+    public Job movieJob() {
+        return new JobBuilder("movieJob", jobRepository)
+                .start(movieStep())
                 .build();
     }
 
     @Bean
-    public Step tmdbStep() {
-        return new StepBuilder("tmdbDataMigrationStep", jobRepository)
+    public Step movieStep() {
+        return new StepBuilder("movieStep", jobRepository)
                 .<Long, Content>chunk(10)
                 .reader(tmdbReader)
                 .processor(tmdbProcessor)

--- a/mopl-batch/src/main/java/com/mopl/job/SportBatchJob.java
+++ b/mopl-batch/src/main/java/com/mopl/job/SportBatchJob.java
@@ -1,7 +1,7 @@
 package com.mopl.job;
 
 import com.mopl.domain.content.entity.Content;
-import com.mopl.domain.contents.dto.SportDbDto;
+import com.mopl.domain.contents.dto.sportDb.SportDbDto;
 import com.mopl.domain.contents.processor.SportProcessor;
 import com.mopl.domain.contents.reader.SportReader;
 import com.mopl.domain.contents.writer.TmdbWriter;

--- a/mopl-batch/src/main/java/com/mopl/job/SportBatchJob.java
+++ b/mopl-batch/src/main/java/com/mopl/job/SportBatchJob.java
@@ -1,0 +1,46 @@
+package com.mopl.job;
+
+import com.mopl.domain.content.entity.Content;
+import com.mopl.domain.contents.dto.SportDbDto;
+import com.mopl.domain.contents.processor.SportProcessor;
+import com.mopl.domain.contents.reader.SportReader;
+import com.mopl.domain.contents.writer.TmdbWriter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.Step;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class SportBatchJob {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+
+    private final SportReader sportReader;
+    private final SportProcessor sportProcessor;
+    private final TmdbWriter tmdbWriter;
+
+    @Bean
+    public Job sportJob() {
+        return new JobBuilder("sportJob", jobRepository)
+                .start(sportStep())
+                .build();
+    }
+
+    @Bean
+    public Step sportStep() {
+        return new StepBuilder("tvSeriesStep", jobRepository)
+                .<SportDbDto, Content>chunk(10)
+                .reader(sportReader)
+                .processor(sportProcessor)
+                .writer(tmdbWriter)
+                .transactionManager(transactionManager)
+                .build();
+    }
+}

--- a/mopl-batch/src/main/java/com/mopl/job/TvSeriesBatchJob.java
+++ b/mopl-batch/src/main/java/com/mopl/job/TvSeriesBatchJob.java
@@ -1,0 +1,46 @@
+package com.mopl.job;
+
+import com.mopl.domain.content.entity.Content;
+import com.mopl.domain.contents.dto.tmdb.TvSeriesDto;
+import com.mopl.domain.contents.processor.TvSeriesProcessor;
+import com.mopl.domain.contents.reader.TvSeriesReader;
+import com.mopl.domain.contents.writer.TmdbWriter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.Step;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class TvSeriesBatchJob {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+
+    private final TvSeriesReader tvSeriesReader;
+    private final TvSeriesProcessor tvSeriesProcessor;
+    private final TmdbWriter tmdbWriter;
+
+    @Bean
+    public Job tvSeriesJob() {
+        return new JobBuilder("tvSeriesJob", jobRepository)
+                .start(tvSeriesStep())
+                .build();
+    }
+
+    @Bean
+    public Step tvSeriesStep() {
+        return new StepBuilder("tvSeriesStep", jobRepository)
+                .<TvSeriesDto, Content>chunk(10)
+                .reader(tvSeriesReader)
+                .processor(tvSeriesProcessor)
+                .writer(tmdbWriter)
+                .transactionManager(transactionManager)
+                .build();
+    }
+}


### PR DESCRIPTION
## 연관 이슈
close #144 

## 🔄 변경 사항
TMDB 기반 배치 구조를 영화(Movie) / TV 시리즈 / 스포츠 콘텐츠로 분리하고, 배치 실행용 컨트롤러 및 DTO 구조를 정비했습니다.
또한 태그 중복 조회를 줄이기 위해 공용 캐시를 도입하여 배치 성능을 개선했습니다.

## 🧩 작업 사항
- TMDB 배치 구조 리팩토링
- 기존 TmdbProcessor, TmdbBatchConfig를 Movie 기준으로 명확히 분리
- MovieProcessor, MovieBatchJob로 명명 규칙 정리
- TV 시리즈 배치 기능 추가
- TvSeriesDto, TvSeriesKeyword, TvSeriesProcessor, TvSeriesBatchJob 신규 구현
- TMDB 인기 TV 시리즈 및 키워드 조회 로직 추가
- 스포츠 배치 기능 추가
- SportProcessor, SportBatchJob 신규 구현
- SportDB DTO 패키지 구조 분리 (dto.sportDb)
- 배치 실행용 컨트롤러 분리
- 기존 테스트 컨트롤러에서 배치 실행 로직 제거
- /batch 전용 BatchController 신규 추가
- 태그 캐싱 구조 개선
- KeywordDto에 static ConcurrentHashMap 기반 태그 캐시 도입
- Movie / TV Series / Sport 배치 간 태그 캐시 공유
- OpenAPI 클라이언트 개선
- TmdbResponse<T> 제네릭 적용
- TV 시리즈 관련 API 호출 로직 추가 및 타입 안정성 개선
- 패키지 및 import 구조 정리
- DTO, Processor, Reader, Job 역할별 구조 명확화
- 파일 이동에 따른 참조 수정

## 📸 스크린샷
- 테스트 결과나 로그 결과가 있다면 첨부