### PR TITLE
[FEAT] AWS - S3 설정 및 파일 업로드, 조회, 삭제 구현 및 테스트

### DIFF
--- a/mopl-core/build.gradle
+++ b/mopl-core/build.gradle
@@ -37,4 +37,9 @@ dependencies {
     // MapStruct
     implementation 'org.mapstruct:mapstruct:1.6.3'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
+
+    // AWS S3
+    implementation platform("software.amazon.awssdk:bom:2.26.21")
+    implementation "software.amazon.awssdk:s3"
+    implementation "software.amazon.awssdk:sts"
 }

--- a/mopl-core/src/main/java/com/mopl/global/dto/UploadFileRequest.java
+++ b/mopl-core/src/main/java/com/mopl/global/dto/UploadFileRequest.java
@@ -1,0 +1,11 @@
+package com.mopl.global.dto;
+
+import java.io.InputStream;
+
+public record UploadFileRequest(
+        InputStream inputStream,
+        String originalFileName,
+        long fileSize,
+        String contentType
+) {
+}

--- a/mopl-core/src/main/java/com/mopl/global/s3/FileCategory.java
+++ b/mopl-core/src/main/java/com/mopl/global/s3/FileCategory.java
@@ -9,7 +9,8 @@ public enum FileCategory {
     CONTENT_THUMBNAIL("contents/thumbnails"),
     PROFILE_IMAGE("profiles"),
     CHAT_FILE("chats"),
-    BATCH_LOG("logs/batch");
+    BATCH_LOG("logs/batch"),
+    TEST("test");
 
     private final String path;
 }

--- a/mopl-core/src/main/java/com/mopl/global/s3/FileCategory.java
+++ b/mopl-core/src/main/java/com/mopl/global/s3/FileCategory.java
@@ -1,0 +1,15 @@
+package com.mopl.global.s3;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum FileCategory {
+    CONTENT_THUMBNAIL("contents/thumbnails"),
+    PROFILE_IMAGE("profiles"),
+    CHAT_FILE("chats"),
+    BATCH_LOG("logs/batch");
+
+    private final String path;
+}

--- a/mopl-core/src/main/java/com/mopl/global/s3/S3Config.java
+++ b/mopl-core/src/main/java/com/mopl/global/s3/S3Config.java
@@ -1,0 +1,48 @@
+package com.mopl.global.s3;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key:}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key:}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(getCredentialsProvider())
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(getCredentialsProvider())
+                .build();
+    }
+
+    private AwsCredentialsProvider getCredentialsProvider() {
+        if (accessKey != null && !accessKey.isEmpty() && secretKey != null && !secretKey.isEmpty()) {
+            return StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey));
+        }
+        return DefaultCredentialsProvider.create();
+    }
+}

--- a/mopl-core/src/main/java/com/mopl/global/s3/S3Manager.java
+++ b/mopl-core/src/main/java/com/mopl/global/s3/S3Manager.java
@@ -1,0 +1,119 @@
+package com.mopl.global.s3;
+
+import com.mopl.global.dto.UploadFileRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3Manager {
+
+    private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    /**
+     * 파일 업로드
+     * @param file 업로드할 파일
+     * @param dirName S3 내 폴더 경로 (예: "profile", "chat")
+     * @return 저장된 파일의 전체 URL
+     */
+    public String upload(UploadFileRequest file, FileCategory dirName) {
+        String fileName = dirName.getPath() + "/" + UUID.randomUUID() + "_" + file.originalFileName();
+
+        try(java.io.InputStream inputStream = file.inputStream()) {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(fileName)
+                    .contentType(file.contentType())
+                    .contentLength(file.fileSize()) // 중요: Content-Length 명시로 스트림 끝 알림
+                    .build();
+
+            s3Client.putObject(putObjectRequest,
+                    RequestBody.fromInputStream(inputStream, file.fileSize()));
+
+            return getPublicUrl(fileName);
+        } catch (Exception e) {
+            log.error("S3 파일 업로드 실패: {}", e.getMessage());
+            throw new RuntimeException("S3 파일 업로드 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    /**
+     * 파일 삭제
+     * @param fileUrl 삭제할 파일의 전체 URL
+     */
+    public void delete(String fileUrl) {
+        try {
+            // URL에서 S3 Key 추출 (.com/ 이후의 문자열)
+            String key = fileUrl.substring(fileUrl.lastIndexOf(".com/") + 5);
+
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build();
+
+            s3Client.deleteObject(deleteObjectRequest);
+            log.info("S3 파일 삭제 완료: {}", key);
+        } catch (Exception e) {
+            log.error("S3 파일 삭제 실패: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * 특정 시간 동안만 유효한 조회용 Presigned URL 생성
+     * @param fileUrl DB에 저장된 전체 URL 또는 Key
+     * @return 서명된 URL
+     */
+    public String generatePresignedUrl(String fileUrl) {
+        if (fileUrl == null || fileUrl.isEmpty()) return null;
+
+        try {
+            // URL에서 Key 추출 (기존 delete에서 쓴 로직 활용)
+            String key = fileUrl.contains(".com/")
+                    ? fileUrl.substring(fileUrl.lastIndexOf(".com/") + 5)
+                    : fileUrl;
+
+            GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build();
+
+            GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                    .signatureDuration(Duration.ofMinutes(10)) // 10분간 유효
+                    .getObjectRequest(getObjectRequest)
+                    .build();
+
+            PresignedGetObjectRequest presignedRequest = s3Presigner.presignGetObject(presignRequest);
+            return presignedRequest.url().toString();
+        } catch (Exception e) {
+            log.error("Presigned URL 생성 실패: {}", e.getMessage());
+            return fileUrl; // 실패 시 원본 반환 또는 에러 처리
+        }
+    }
+
+    /** 고정 URL 생성 로직 (DB 저장용) */
+    private String getPublicUrl(String fileName) {
+        return s3Client.utilities().getUrl(GetUrlRequest.builder()
+                .bucket(bucket)
+                .key(fileName)
+                .build()).toString();
+    }
+}

--- a/mopl-core/src/main/resources/application-core-dev.yml
+++ b/mopl-core/src/main/resources/application-core-dev.yml
@@ -25,6 +25,12 @@ spring:
       host: localhost
       port: 6379
 
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY_ID}
+      secret-key: ${AWS_SECRET_ACCESS_KEY}
+
 logging:
   level:
     root: INFO

--- a/mopl-core/src/main/resources/application-core-test.yml
+++ b/mopl-core/src/main/resources/application-core-test.yml
@@ -1,0 +1,15 @@
+spring:
+  config:
+    import: optional:file:.env[.properties], optional:file:../.env[.properties]
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY_ID}
+      secret-key: ${AWS_SECRET_ACCESS_KEY}
+    s3:
+      bucket: ${AWS_S3_BUCKET}
+    region:
+      static: ${AWS_REGION}
+    stack:
+      auto: false

--- a/mopl-core/src/main/resources/application-core.yml
+++ b/mopl-core/src/main/resources/application-core.yml
@@ -10,3 +10,11 @@ spring:
     redis:
       repositories:
         enabled: true
+cloud:
+  aws:
+    s3:
+      bucket: ${AWS_S3_BUCKET}
+    region:
+      static: ${AWS_REGION}
+    stack:
+      auto: false

--- a/mopl-core/src/test/java/com/mopl/global/s3/S3ManagerTest.java
+++ b/mopl-core/src/test/java/com/mopl/global/s3/S3ManagerTest.java
@@ -1,6 +1,7 @@
 package com.mopl.global.s3;
 
 import com.mopl.global.dto.UploadFileRequest;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,14 +14,15 @@ import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-@SpringBootTest(
-        classes = {S3Manager.class, S3Config.class}
-)
+// Test 할 땐 @Disabled 주석 처리 후 실행
+@Disabled("이 테스트는 실제 S3에 파일을 업로드 합니다. 로컬에서 수동으로만 테스트 해주세요.")
+@SpringBootTest(classes = {S3Manager.class, S3Config.class})
 @ActiveProfiles("core-test")
 class S3ManagerTest {
 
     @Autowired
     private S3Manager s3Manager;
+
 
     @Test
     @DisplayName("S3 파일 업로드 테스트")
@@ -37,12 +39,11 @@ class S3ManagerTest {
                 "text/plain"
         );
 
-        String savedUrl = s3Manager.upload(request, FileCategory.CONTENT_THUMBNAIL);
+        String savedUrl = s3Manager.upload(request, FileCategory.TEST);
         System.out.println("저장된 URL (DB 저장용): " + savedUrl);
 
         assertThat(savedUrl).contains("test-file.txt");
-        assertThat(savedUrl).contains(FileCategory.CONTENT_THUMBNAIL.getPath());
-
+        assertThat(savedUrl).contains(FileCategory.TEST.getPath());
     }
 
     @Test
@@ -57,7 +58,7 @@ class S3ManagerTest {
                 bytes.length,
                 "text/plain"
         );
-        String publicUrl = s3Manager.upload(request, FileCategory.CONTENT_THUMBNAIL);
+        String publicUrl = s3Manager.upload(request, FileCategory.TEST);
 
         // 2. Presigned URL 생성 호출
         String presignedUrl = s3Manager.generatePresignedUrl(publicUrl);

--- a/mopl-core/src/test/java/com/mopl/global/s3/S3ManagerTest.java
+++ b/mopl-core/src/test/java/com/mopl/global/s3/S3ManagerTest.java
@@ -1,0 +1,74 @@
+package com.mopl.global.s3;
+
+import com.mopl.global.dto.UploadFileRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest(
+        classes = {S3Manager.class, S3Config.class}
+)
+@ActiveProfiles("core-test")
+class S3ManagerTest {
+
+    @Autowired
+    private S3Manager s3Manager;
+
+    @Test
+    @DisplayName("S3 파일 업로드 테스트")
+    void testUpload() {
+
+        String content = "Hello, MOPL S3 Test!";
+        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+        InputStream inputStream = new ByteArrayInputStream(bytes);
+
+        UploadFileRequest request = new UploadFileRequest(
+                inputStream,
+                "test-file.txt",
+                bytes.length,
+                "text/plain"
+        );
+
+        String savedUrl = s3Manager.upload(request, FileCategory.CONTENT_THUMBNAIL);
+        System.out.println("저장된 URL (DB 저장용): " + savedUrl);
+
+        assertThat(savedUrl).contains("test-file.txt");
+        assertThat(savedUrl).contains(FileCategory.CONTENT_THUMBNAIL.getPath());
+
+    }
+
+    @Test
+    @DisplayName("Presigned URL 생성 테스트")
+    void testGeneratePresignedUrl() {
+        // 1. 테스트용 파일 먼저 업로드
+        String content = "Presigned URL Test Content";
+        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+        UploadFileRequest request = new UploadFileRequest(
+                new ByteArrayInputStream(bytes),
+                "presigned-test.txt",
+                bytes.length,
+                "text/plain"
+        );
+        String publicUrl = s3Manager.upload(request, FileCategory.CONTENT_THUMBNAIL);
+
+        // 2. Presigned URL 생성 호출
+        String presignedUrl = s3Manager.generatePresignedUrl(publicUrl);
+
+        // 3. 검증
+        System.out.println("원본 URL: " + publicUrl);
+        System.out.println("생성된 Presigned URL: " + presignedUrl);
+
+        assertThat(presignedUrl).isNotNull();
+        assertThat(presignedUrl).contains("X-Amz-Algorithm"); // AWS 서명 알고리즘 포함 여부
+        assertThat(presignedUrl).contains("X-Amz-Signature"); // 서명 값 포함 여부
+        assertThat(presignedUrl).contains("presigned-test.txt"); // 파일명 포함 여부
+    }
+}

--- a/mopl-core/src/test/java/com/mopl/global/s3/S3ManagerTest.java
+++ b/mopl-core/src/test/java/com/mopl/global/s3/S3ManagerTest.java
@@ -23,53 +23,50 @@ class S3ManagerTest {
     @Autowired
     private S3Manager s3Manager;
 
+    String content = "Hello, MOPL S3 Test!";
+    byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(bytes);
+
+    UploadFileRequest testFile = new UploadFileRequest(
+            inputStream,
+            "test-file.txt",
+            bytes.length,
+            "text/plain"
+    );
 
     @Test
-    @DisplayName("S3 파일 업로드 테스트")
+    @DisplayName("S3 파일 업로드 및 Presigned URL 조회")
     void testUpload() {
+        String testUrl = s3Manager.upload(testFile, FileCategory.TEST);
+        System.out.println("저장된 URL (DB 저장용): " + testUrl);
 
-        String content = "Hello, MOPL S3 Test!";
-        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
-        InputStream inputStream = new ByteArrayInputStream(bytes);
+        assertThat(testUrl).contains("test-file.txt");
+        assertThat(testUrl).contains(FileCategory.TEST.getPath());
 
-        UploadFileRequest request = new UploadFileRequest(
-                inputStream,
-                "test-file.txt",
-                bytes.length,
-                "text/plain"
-        );
+        String presignedUrl = s3Manager.generatePresignedUrl(testUrl);
 
-        String savedUrl = s3Manager.upload(request, FileCategory.TEST);
-        System.out.println("저장된 URL (DB 저장용): " + savedUrl);
-
-        assertThat(savedUrl).contains("test-file.txt");
-        assertThat(savedUrl).contains(FileCategory.TEST.getPath());
-    }
-
-    @Test
-    @DisplayName("Presigned URL 생성 테스트")
-    void testGeneratePresignedUrl() {
-        // 1. 테스트용 파일 먼저 업로드
-        String content = "Presigned URL Test Content";
-        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
-        UploadFileRequest request = new UploadFileRequest(
-                new ByteArrayInputStream(bytes),
-                "presigned-test.txt",
-                bytes.length,
-                "text/plain"
-        );
-        String publicUrl = s3Manager.upload(request, FileCategory.TEST);
-
-        // 2. Presigned URL 생성 호출
-        String presignedUrl = s3Manager.generatePresignedUrl(publicUrl);
-
-        // 3. 검증
-        System.out.println("원본 URL: " + publicUrl);
+        System.out.println("원본 URL: " + testUrl);
         System.out.println("생성된 Presigned URL: " + presignedUrl);
 
         assertThat(presignedUrl).isNotNull();
         assertThat(presignedUrl).contains("X-Amz-Algorithm"); // AWS 서명 알고리즘 포함 여부
         assertThat(presignedUrl).contains("X-Amz-Signature"); // 서명 값 포함 여부
-        assertThat(presignedUrl).contains("presigned-test.txt"); // 파일명 포함 여부
+        assertThat(presignedUrl).contains("test-file.txt"); // 파일명 포함 여부
+
+        s3Manager.delete(testUrl);
     }
+
+
+    @Test
+    @DisplayName("삭제 테스트")
+    void testDelete() {
+        String testUrl = s3Manager.upload(testFile, FileCategory.TEST);
+        System.out.println("저장된 URL (DB 저장용): " + testUrl);
+
+        assertThat(testUrl).contains("test-file.txt");
+        assertThat(testUrl).contains(FileCategory.TEST.getPath());
+
+        s3Manager.delete(testUrl);
+    }
+
 }


### PR DESCRIPTION
## 🔗 연관 이슈

close #154

## 🔄 변경 사항

* AWS S3 연동을 위한 공통 설정 및 매니저 구현
* core 모듈에 AWS S3 관련 의존성 추가
* 파일 업로드 / 삭제 / Presigned URL 조회 기능 구현
* 테스트 환경에서 실제 S3를 사용하는 통합 테스트 추가
* 환경별 설정(application-core.yml, dev/test yml) 및 `.env` 기반 AWS 자격 증명 연동


## 🧩 작업 사항

### `mopl-core/build.gradle`

* AWS SDK v2(S3, STS) 사용을 위해 BOM 기반 의존성 추가

### `UploadFileRequest.java`

* 파일 업로드 시 필요한 정보를 담는 공용 DTO 추가
  (InputStream, 원본 파일명, 파일 크기, Content-Type)

### `FileCategory.java`

* S3 내 파일 저장 경로 관리를 위한 Enum 도입
* 파일 유형별 디렉토리 경로를 명시적으로 관리하도록 설계
* 필요 시 카테고리 확장 가능

### `S3Config.java`

* `S3Client`, `S3Presigner` Bean 설정
* access-key / secret-key가 존재할 경우 `StaticCredentialsProvider` 사용
* 값이 없을 경우 `DefaultCredentialsProvider`를 사용해
  로컬/배포 환경 모두 대응 가능하도록 구성

### `S3Manager.java`

* S3 관련 공통 로직을 담당하는 유틸 컴포넌트 구현
* 주요 기능

  * 파일 업로드 (UUID 기반 파일명 생성, Content-Length 명시)
  * 파일 삭제 (URL 또는 Key 기반)
  * Presigned URL 생성 (10분 유효)
  * DB 저장용 고정 URL 생성 로직 분리
* 멀티 모듈 환경을 고려하여 Spring Web 의존 없이 파일 처리 가능하도록 설계

### 설정 파일

* `application-core.yml`

  * S3 bucket, region 설정 추가
* `application-core-dev.yml`, `application-core-test.yml`

  * `.env` 기반 AWS 자격 증명 연동
  * 테스트 환경에서도 실제 S3 접근 가능하도록 구성

### `S3ManagerTest.java`

* 실제 S3에 파일을 업로드하는 통합 테스트 작성
* 테스트 내용

  * 파일 업로드 정상 동작 여부
  * Presigned URL 생성 여부 및 서명 파라미터 검증
  * 파일 삭제 동작 검증
* 실제 리소스를 사용하므로 기본적으로 `@Disabled` 처리

## 📸 스크린샷
테스트시 실제 S3에 저장됩니다. 경로는 /test
<img width="1167" height="417" alt="image" src="https://github.com/user-attachments/assets/3b96655f-7cfe-481d-83db-a43fe043d2c6" />
presignedUrl 테스트 성공시 화면(url은 10분간 유효)
<img width="1192" height="734" alt="image" src="https://github.com/user-attachments/assets/6b006434-2677-48e4-b9ef-42ec0aa83973" />
<img width="1509" height="379" alt="image" src="https://github.com/user-attachments/assets/401c53d1-eafb-4575-9484-6de6f6288954" />