### PR TITLE
[CHORE] 개발용 AWS RDS 연결 설정

### DIFF
--- a/mopl-core/src/main/resources/application-core-dev.yml
+++ b/mopl-core/src/main/resources/application-core-dev.yml
@@ -1,25 +1,18 @@
 spring:
   datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:mopldb;MODE=MySQL;DB_CLOSE_DELAY=-1
-    username: sa
-    password:
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
-  sql:
-    init:
-      mode: always # 자동 실행하려면 always. 수동으로 제어하려면 never
-      schema-locations: classpath:db/schema.sql
-      data-locations: classpath:db/testdata.sql
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://mopl-mysql-dev.cd8oe2q2qsl0.ap-northeast-2.rds.amazonaws.com:3306/mopl_dev?useSSL=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${MYSQL_DEV_USER}
+    password: ${MYSQL_DEV_PASSWORD}
+
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     show-sql: false
     properties:
       hibernate:
         format_sql: true
+
   data:
     redis:
       host: localhost


### PR DESCRIPTION
## 연관 이슈
close #156 

## 🔄 변경 사항
개발용 RDS 설정
팀에서 다같이 공유할 AWS RDS 생성한 뒤 애플리케이션에서 연결을 했습니다.
 
### 🗂 개발용 / 운영용 RDS 분리 이유

RDS를 개발용과 운영용으로 분리하여 사용하는 이유는 다음과 같습니다.

* **데이터 보호**

  * 개발 환경에서는 스키마 변경, 데이터 초기화, 테스트용 데이터 삽입이 빈번하게 발생합니다.
  * 운영 DB와 분리함으로써 실수로 운영 데이터를 수정·삭제하는 사고를 방지합니다.

* **환경별 설정 차이**

  * 개발 환경에서는 디버깅과 테스트를 위해 `ddl-auto`, 로그 설정, 접속 방식 등이 운영 환경과 다릅니다.
  * `application-core-dev.yml`을 통해 개발 환경 전용 DB 설정을 명확히 분리했습니다.

* **팀 단위 개발 효율**

  * 팀원들이 동일한 개발용 RDS를 사용함으로써 로컬 환경 차이 없이 공통 데이터 기준으로 개발할 수 있습니다.
  * 로컬 H2 기반 개발에서 실제 MySQL 환경으로 전환하여 운영 환경과 최대한 유사한 조건에서 테스트할 수 있습니다.

* **운영 안정성 확보**

  * 운영용 RDS는 배포된 애플리케이션만 접근하도록 제한하고,
  * 개발용 RDS는 IP 기반 접근 제어를 통해 팀원 개발 환경에서만 사용하도록 분리했습니다.

이를 통해 **환경 간 책임과 역할을 명확히 하고, 운영 안정성과 개발 생산성을 동시에 확보**하는 것을 목표로 합니다.
