### PR TITLE
[feat] Notification 알림 읽음 처리(알림 삭제)

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/notification/controller/NotificationController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/notification/controller/NotificationController.java
@@ -39,6 +39,6 @@ public class NotificationController {
                                        @PathVariable Long notificationId) {
         Long userId = userPrincipal.getUserId();
         notificationService.deleteNotification(userId,notificationId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/notification/controller/NotificationController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/notification/controller/NotificationController.java
@@ -10,10 +10,7 @@ import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/notifications")
@@ -35,5 +32,13 @@ public class NotificationController {
         return ResponseEntity.ok(notificationService.findAll(
                 cursor, idAfter, limit, sortDirection, sortBy, userId
         ));
+    }
+
+    @DeleteMapping("/{notificationId}")
+    public ResponseEntity<Void> deleteNotification(@AuthenticationPrincipal UserPrincipal userPrincipal,
+                                       @PathVariable Long notificationId) {
+        Long userId = userPrincipal.getUserId();
+        notificationService.deleteNotification(userId,notificationId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/notification/exception/NotificationErrorCode.java
+++ b/mopl-api/src/main/java/com/mopl/domain/notification/exception/NotificationErrorCode.java
@@ -1,0 +1,18 @@
+package com.mopl.domain.notification.exception;
+
+import com.mopl.global.exception.DomainErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationErrorCode implements DomainErrorCode {
+
+    NOTIFICATION_NOT_EXIST("N001", "알림을 찾을 수 없습니다", HttpStatus.NOT_FOUND),
+    ;
+
+    private final String errorCode;
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/mopl-api/src/main/java/com/mopl/domain/notification/exception/NotificationException.java
+++ b/mopl-api/src/main/java/com/mopl/domain/notification/exception/NotificationException.java
@@ -1,0 +1,12 @@
+package com.mopl.domain.notification.exception;
+
+import com.mopl.global.exception.DomainException;
+import lombok.Getter;
+
+@Getter
+public class NotificationException extends DomainException {
+
+    public NotificationException(NotificationErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/mopl-api/src/main/java/com/mopl/domain/notification/service/NotificationService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/notification/service/NotificationService.java
@@ -4,6 +4,8 @@ package com.mopl.domain.notification.service;
 import com.mopl.domain.notification.dto.NotificationDto;
 import com.mopl.domain.notification.entity.Notification;
 import com.mopl.domain.notification.enums.Level;
+import com.mopl.domain.notification.exception.NotificationErrorCode;
+import com.mopl.domain.notification.exception.NotificationException;
 import com.mopl.domain.notification.repository.NotificationRepository;
 import com.mopl.global.dto.PageResponse;
 import com.mopl.global.enums.SortDirection;
@@ -44,6 +46,14 @@ public class NotificationService {
                 "notification",
                 notificationDto
         );
+    }
+
+    @Transactional
+    public void deleteNotification(Long userId, Long  notificationId){
+        Notification  notification = notificationRepository
+                .findByIdAndReceiverId(notificationId, userId)
+                .orElseThrow(()-> new NotificationException(NotificationErrorCode.NOTIFICATION_NOT_EXIST));
+        notificationRepository.delete(notification);
     }
 
     @Transactional(readOnly = true)

--- a/mopl-core/src/main/java/com/mopl/domain/notification/repository/NotificationRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/notification/repository/NotificationRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     @Query("""
@@ -24,4 +25,5 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             @Param("idAfter") Long idAfter,
             Pageable pageable
     );
+    Optional<Notification> findByIdAndReceiverId(Long notificationId, Long userId);
 }


### PR DESCRIPTION
## 연관 이슈
close #152 

## 🔄 변경 사항
swagger 에 deleteMapping으로 진행이 되어 있고 erd를 수정하여 deleteAt으로 하기에 늦었다는 판단하에 삭제로 구현 
현재 본인의 userId와 알림 id에 있는 receiverId가 일치할 경우에만 삭제 진행
## 🧩 작업 사항
작업한 내용을 간략하게 설명해주세요.
- noticifation 서비스 기능 추가 - 본인의 userId와 알림 id에 있는 receiverId가 일치할 경우에만 삭제
- 전용 exception 추가 - 해당 알람이 없을시 에러 메시지 

## 📸 스크린샷
<img width="557" height="250" alt="image" src="https://github.com/user-attachments/assets/4dc9b424-592f-45a2-93ed-2e012853f769" />
