### PR TITLE
[FIX] S3 URL 파싱 로직 개선 및 파일 삭제 기능 안정화

### DIFF
--- a/mopl-core/src/main/java/com/mopl/global/s3/S3Manager.java
+++ b/mopl-core/src/main/java/com/mopl/global/s3/S3Manager.java
@@ -15,6 +15,7 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 
+import java.net.URI;
 import java.time.Duration;
 import java.util.UUID;
 
@@ -62,8 +63,8 @@ public class S3Manager {
      */
     public void delete(String fileUrl) {
         try {
-            // URL에서 S3 Key 추출 (.com/ 이후의 문자열)
-            String key = fileUrl.substring(fileUrl.lastIndexOf(".com/") + 5);
+            // URL에서 안전한 S3 Key 추출 메서드 사용
+            String key = extractKey(fileUrl);
 
             DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
                     .bucket(bucket)
@@ -86,10 +87,8 @@ public class S3Manager {
         if (fileUrl == null || fileUrl.isEmpty()) return null;
 
         try {
-            // URL에서 Key 추출 (기존 delete에서 쓴 로직 활용)
-            String key = fileUrl.contains(".com/")
-                    ? fileUrl.substring(fileUrl.lastIndexOf(".com/") + 5)
-                    : fileUrl;
+            // URL에서 안전한 S3 Key 추출 메서드 사용
+            String key = extractKey(fileUrl);
 
             GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                     .bucket(bucket)
@@ -115,5 +114,28 @@ public class S3Manager {
                 .bucket(bucket)
                 .key(fileName)
                 .build()).toString();
+    }
+
+    /** URL에서 S3 Key(파일 경로)를 안전하게 추출하는 메서드 */
+    private String extractKey(String fileUrl) {
+        try {
+            // 1. URL 형식이 아니면(이미 Key라면) 그대로 반환
+            if (!fileUrl.startsWith("http")) {
+                return fileUrl;
+            }
+
+            // 2. URI 파싱을 통해 Path만 추출 (/profile/abc.jpg)
+            URI uri = new URI(fileUrl);
+            String path = uri.getPath();
+
+            // 3. 맨 앞의 슬래시(/) 제거
+            if (path.startsWith("/")) {
+                return path.substring(1);
+            }
+            return path;
+        } catch (Exception e) {
+            log.error("S3 Key 추출 실패: url={}", fileUrl);
+            throw new RuntimeException("잘못된 파일 URL 형식입니다.");
+        }
     }
 }


### PR DESCRIPTION
## 🔄 변경 사항

* S3Manager의 URL 파싱 로직을 기존 `substring` 기반에서 `java.net.URI` 기반으로 변경하여 안정성을 강화했습니다.

## 🧩 작업 사항

* **S3 Key 추출 로직 개선 (`extractKey` 메서드 추가)**
* 기존에는 `.com/` 문자열을 기준으로 파싱하여 도메인 변경이나 버킷 이름에 취약했던 로직을 제거했습니다.
* `java.net.URI`를 활용해 URL에서 Path를 파싱하고 Key를 추출하도록 변경하여 도메인에 상관없이 동작하도록 개선했습니다.


* **`delete` 및 `generatePresignedUrl` 메서드 리팩토링**
* 개선된 `extractKey` 메서드를 적용하여 파일 삭제 및 Presigned URL 생성 시의 안정성을 확보했습니다.


* **예외 처리 강화**
잘못된 URL 형식이 들어올 경우에 대한 예외 처리 및 로깅을 추가했습니다.



## 📸 스크린샷
