### PR TITLE
[Feat] User 비밀번호 변경 

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/auth/service/EmailService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/service/EmailService.java
@@ -30,6 +30,7 @@ public class EmailService {
     public void resetPassword(String email) {
         emailValid(email);
         String temporaryPassword = createTemporaryPassword(10);
+        System.out.println(temporaryPassword);
         // TODO: Redis에 저장
         sendEmail(email, temporaryPassword);
     }

--- a/mopl-api/src/main/java/com/mopl/domain/auth/service/EmailService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/service/EmailService.java
@@ -30,7 +30,6 @@ public class EmailService {
     public void resetPassword(String email) {
         emailValid(email);
         String temporaryPassword = createTemporaryPassword(10);
-        System.out.println(temporaryPassword);
         // TODO: Redis에 저장
         sendEmail(email, temporaryPassword);
     }

--- a/mopl-api/src/main/java/com/mopl/domain/user/controller/UserController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/user/controller/UserController.java
@@ -49,4 +49,12 @@ public class UserController {
         UserDto userDto = userService.detail(userId);
         return ResponseEntity.ok().body(userDto);
     }
+
+    @PreAuthorize("principal.userId == #userId")
+    @PatchMapping("/{userId}/password")
+    public ResponseEntity<Void> updatePassword(@PathVariable Long userId,
+                                               @Valid @RequestBody ChangePasswordRequest request){
+        userService.updatePassword(userId, request.password());
+        return ResponseEntity.ok().build();
+    }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/user/dto/ChangePasswordRequest.java
+++ b/mopl-api/src/main/java/com/mopl/domain/user/dto/ChangePasswordRequest.java
@@ -1,0 +1,9 @@
+package com.mopl.domain.user.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ChangePasswordRequest (
+        @NotNull(message = "비밀번호는 필수 입력값입니다.")
+        String password
+){
+}

--- a/mopl-api/src/main/java/com/mopl/domain/user/service/UserService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/user/service/UserService.java
@@ -64,6 +64,15 @@ public class UserService {
         user.updateLocked(newLocked);
     }
 
+    @Transactional
+    public void updatePassword(Long userId, String Password) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_EXIST));
+        String newPassword = passwordEncoder.encode(Password);
+        user.updatePassword(newPassword);
+
+    }
+
     public PageResponse<UserDto> findAllUsers(UserSearchCondition searchCondition) {
         String keywordLike = searchCondition.emailLike();
         Role roleEqual = searchCondition.roleEqual();

--- a/mopl-core/src/main/java/com/mopl/domain/user/entity/User.java
+++ b/mopl-core/src/main/java/com/mopl/domain/user/entity/User.java
@@ -57,4 +57,6 @@ public class User extends BaseTimeEntity {
     public void updateLocked(Boolean locked){
         this.locked = locked;
     }
+
+    public void updatePassword(String password){this.password = password;}
 }


### PR DESCRIPTION
## 연관 이슈
close #173 

## 🔄 변경 사항
비밀번호 찾기 -> 이메일로 비밀번호 초기화 -> *임시 비밀번호 로그인 -> 새 비밀번호로 변경 
*가 붙은 부분은 아직 구현이 덜 됨( redis에 저장 예정)
(현재) 임시 비밀번호가 발급만 되지 기존의 비밀번호를 그대로 사용하고 있음
기존 비밀번호로 로그인을 하고 새 비밀번호 변경 시도 후 성공 
## 🧩 작업 사항
작업한 내용을 간략하게 설명해주세요.
- dto - 값인증 
- 엔티티 - 비밀번호 업데이트 메서드 추가
- 서비스 - User 객체 확인 , 비밀번호 암호화 후 저장 
- 컨트롤러 - 본인 인증

## 📸 스크린샷
새 비밀번호로  로그인 성공 