### PR TITLE
[REFACTOR] batch로 가져오는 외부 데이터 이미지 S3 저장

### DIFF
--- a/mopl-batch/src/main/java/com/mopl/domain/contents/processor/MovieProcessor.java
+++ b/mopl-batch/src/main/java/com/mopl/domain/contents/processor/MovieProcessor.java
@@ -5,6 +5,9 @@ import com.mopl.domain.content.entity.Tag;
 import com.mopl.domain.content.enums.ContentType;
 import com.mopl.domain.content.repository.TagRepository;
 import com.mopl.domain.contents.openapi.TmdbClient;
+import com.mopl.global.s3.FileCategory;
+import com.mopl.global.s3.S3Manager;
+import com.mopl.global.util.ImageDownloadUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.annotation.BeforeStep;
@@ -25,6 +28,8 @@ public class MovieProcessor implements ItemProcessor<Long, Content> {
 
     private final TmdbClient tmdbClient;
     private final TagRepository tagRepository;
+    private final ImageDownloadUtil imageDownloadUtil;
+    private final S3Manager s3Manager;
 
     @BeforeStep
     public void beforeStep(StepExecution stepExecution) {
@@ -41,11 +46,18 @@ public class MovieProcessor implements ItemProcessor<Long, Content> {
             return tmdbClient.getMovieDetails(movieId)
                     .filter(movie -> movie.description() != null && !movie.description().isBlank())
                     .map(movie -> {
+
+                        // 웹에서 받은 이미지를 byte[]로 변환
+                        byte[] imageBytes = imageDownloadUtil
+                            .downloadImage("https://image.tmdb.org/t/p/w200" + movie.thumbnailUrl());
+                        String imageName = movie.thumbnailUrl();
+                        String thumbnailUrl = s3Manager.uploadByte(imageBytes, imageName, FileCategory.CONTENT_THUMBNAIL);
+
                         Content content = new Content(
                                 ContentType.movie,
                                 movie.title(),
                                 movie.description(),
-                                "https://image.tmdb.org/t/p/w200" + movie.thumbnailUrl()
+                                thumbnailUrl
                         );
 
                         // 태그 추가

--- a/mopl-batch/src/main/java/com/mopl/domain/contents/processor/SportProcessor.java
+++ b/mopl-batch/src/main/java/com/mopl/domain/contents/processor/SportProcessor.java
@@ -5,6 +5,9 @@ import com.mopl.domain.content.entity.Tag;
 import com.mopl.domain.content.enums.ContentType;
 import com.mopl.domain.content.repository.TagRepository;
 import com.mopl.domain.contents.dto.sportDb.SportDbDto;
+import com.mopl.global.s3.FileCategory;
+import com.mopl.global.s3.S3Manager;
+import com.mopl.global.util.ImageDownloadUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.annotation.BeforeStep;
@@ -24,6 +27,8 @@ import static com.mopl.domain.contents.dto.tmdb.KeywordDto.tagCache;
 public class SportProcessor implements ItemProcessor<SportDbDto, Content> {
 
     private final TagRepository tagRepository;
+    private final ImageDownloadUtil imageDownloadUtil;
+    private final S3Manager s3Manager;
 
     @BeforeStep
     public void beforeStep() {
@@ -37,11 +42,19 @@ public class SportProcessor implements ItemProcessor<SportDbDto, Content> {
     @Override
     public Content process(SportDbDto item) {
         try{
+            // 웹에서 받은 이미지를 byte[]로 변환
+            byte[] imageBytes = imageDownloadUtil.downloadImage(item.thumbnailUrl());
+            String imageName = item.thumbnailUrl()
+                .substring(item.thumbnailUrl().lastIndexOf("/") + 1);
+
+            // S3에 썸네일 저장
+            String thumbnailUrl = s3Manager.uploadByte(imageBytes, imageName, FileCategory.CONTENT_THUMBNAIL);
+
             Content content = new Content(
                 ContentType.sport,
                 item.title(),
                 item.description(),
-                item.thumbnailUrl()
+                    thumbnailUrl
             );
 
             // 1. SportDbDto에서 명시한 세 개의 필드만 추출

--- a/mopl-batch/src/main/java/com/mopl/domain/contents/processor/TvSeriesProcessor.java
+++ b/mopl-batch/src/main/java/com/mopl/domain/contents/processor/TvSeriesProcessor.java
@@ -6,6 +6,9 @@ import com.mopl.domain.content.enums.ContentType;
 import com.mopl.domain.content.repository.TagRepository;
 import com.mopl.domain.contents.dto.tmdb.TvSeriesDto;
 import com.mopl.domain.contents.openapi.TmdbClient;
+import com.mopl.global.s3.FileCategory;
+import com.mopl.global.s3.S3Manager;
+import com.mopl.global.util.ImageDownloadUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.annotation.BeforeStep;
@@ -25,6 +28,8 @@ public class TvSeriesProcessor implements ItemProcessor<TvSeriesDto, Content> {
 
     private final TmdbClient tmdbClient;
     private final TagRepository tagRepository;
+    private final ImageDownloadUtil imageDownloadUtil;
+    private final S3Manager s3Manager;
 
     @BeforeStep
     public void beforeStep() {
@@ -38,11 +43,18 @@ public class TvSeriesProcessor implements ItemProcessor<TvSeriesDto, Content> {
     @Override
     public Content process(TvSeriesDto item) throws Exception {
         try {
+            // 웹에서 받은 이미지를 byte[]로 변환
+            byte[] imageBytes = imageDownloadUtil
+                .downloadImage("https://image.tmdb.org/t/p/w200" + item.thumbnailUrl());
+            String imageName = item.thumbnailUrl();
+            // S3에 썸네일 저장
+            String thumbnailUrl = s3Manager.uploadByte(imageBytes, imageName, FileCategory.CONTENT_THUMBNAIL);
+
             Content content = new Content(
                     ContentType.tvSeries,
                     item.title(),
                     item.description(),
-                    "https://image.tmdb.org/t/p/w200" + item.thumbnailUrl()
+                    thumbnailUrl
             );
 
             // 2. 키워드(장르) 정보 가져오기 및 태그 매핑

--- a/mopl-batch/src/main/java/com/mopl/global/util/ImageDownloadUtil.java
+++ b/mopl-batch/src/main/java/com/mopl/global/util/ImageDownloadUtil.java
@@ -1,0 +1,27 @@
+package com.mopl.global.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.io.InputStream;
+import java.net.URL;
+
+@Slf4j
+@Component
+public class ImageDownloadUtil {
+
+    /**
+     * URL에서 이미지를 바이트 배열로 다운로드
+     * @param imageUrl 다운로드할 이미지 URL
+     * @return 이미지 바이트 배열
+     */
+    public byte[] downloadImage(String imageUrl) {
+        try (InputStream in = new URL(imageUrl).openStream()) {
+            return in.readAllBytes();
+        } catch (Exception e) {
+            log.error("이미지 다운로드 실패: {}", imageUrl, e);
+            throw new RuntimeException("이미지 다운로드 중 오류가 발생했습니다.", e);
+        }
+    }
+
+}

--- a/mopl-core/src/main/java/com/mopl/global/s3/S3Manager.java
+++ b/mopl-core/src/main/java/com/mopl/global/s3/S3Manager.java
@@ -57,6 +57,31 @@ public class S3Manager {
         }
     }
 
+    public String uploadByte(byte[] imageBytes, String imageName, FileCategory dirName) {
+        if (imageBytes == null || imageBytes.length == 0) {
+            throw new RuntimeException("업로드할 이미지 데이터가 비어있습니다.");
+        }
+
+        String fileName = dirName.getPath() + "/" + UUID.randomUUID() + imageName;
+
+        try {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(fileName)
+                    .contentType("image/jpeg")
+                    .contentLength((long) imageBytes.length)
+                    .build();
+
+            s3Client.putObject(putObjectRequest, RequestBody.fromBytes(imageBytes));
+
+            log.info("이미지 S3 업로드 완료: {}", fileName);
+            return fileName;
+        } catch (Exception e) {
+            log.error("이미지 S3 업로드 실패: {}", e.getMessage());
+            throw new RuntimeException("이미지 S3 업로드 중 오류가 발생했습니다.", e);
+        }
+    }
+
     /**
      * 파일 삭제
      * @param fileUrl 삭제할 파일의 전체 URL

--- a/mopl-core/src/main/java/com/mopl/global/s3/S3Manager.java
+++ b/mopl-core/src/main/java/com/mopl/global/s3/S3Manager.java
@@ -50,6 +50,7 @@ public class S3Manager {
             s3Client.putObject(putObjectRequest,
                     RequestBody.fromInputStream(inputStream, file.fileSize()));
 
+
             return getPublicUrl(fileName);
         } catch (Exception e) {
             log.error("S3 파일 업로드 실패: {}", e.getMessage());
@@ -74,8 +75,8 @@ public class S3Manager {
 
             s3Client.putObject(putObjectRequest, RequestBody.fromBytes(imageBytes));
 
-            log.info("이미지 S3 업로드 완료: {}", fileName);
-            return fileName;
+
+            return getPublicUrl(fileName);
         } catch (Exception e) {
             log.error("이미지 S3 업로드 실패: {}", e.getMessage());
             throw new RuntimeException("이미지 S3 업로드 중 오류가 발생했습니다.", e);
@@ -135,6 +136,7 @@ public class S3Manager {
 
     /** 고정 URL 생성 로직 (DB 저장용) */
     private String getPublicUrl(String fileName) {
+        log.info("이미지 S3 업로드 완료: {}", fileName);
         return s3Client.utilities().getUrl(GetUrlRequest.builder()
                 .bucket(bucket)
                 .key(fileName)


### PR DESCRIPTION
## 연관 이슈
close #168 

## 🔄 변경 사항
- 웹에서 가져오는 이미지를 byte[]로 변환
- 변환된 이미지 byte[]를 S3로 업로드 하는 로직 구현

## 🧩 작업 사항
작업한 내용을 간략하게 설명해주세요.
`mopl-batch/src/main/java/com/mopl/global/util/ImageDownloadUtil.java`
- 웹에서 가져온 이미지를 byte[] 로 변환하는 공통 유틸
- 공통 유틸을 사용해 외부 api에서 받아온 이미지를 byte[]로 변환
- S3Manager에 byte[]를 받아 S3로 업로드하는 로직 구현


## 📸 스크린샷
<img width="1661" height="977" alt="스크린샷 2026-01-14 오후 5 34 35" src="https://github.com/user-attachments/assets/a8c46af1-0c36-4725-8fba-869aa3bdac84" />
직접 등록한 콘텐츠와 외부에서 받아온 콘텐츠 썸네일 이미지 모두 정상적으로 보임