### PR TITLE
[fix] Long id 응답을 문자열로 직렬화 수정

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/playlist/dto/response/PlaylistDto.java
+++ b/mopl-api/src/main/java/com/mopl/domain/playlist/dto/response/PlaylistDto.java
@@ -1,9 +1,13 @@
 package com.mopl.domain.playlist.dto.response;
 
+import tools.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.databind.ser.std.ToStringSerializer;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
 public record PlaylistDto(
+        @JsonSerialize(using = ToStringSerializer.class)
         Long id,
         Owner owner,
         String title,
@@ -15,6 +19,7 @@ public record PlaylistDto(
 ) {
 
     public record Owner(
+            @JsonSerialize(using = ToStringSerializer.class)
             Long userId,
             String name,
             String profileImageUrl
@@ -22,6 +27,7 @@ public record PlaylistDto(
     }
 
     public record Content(
+            @JsonSerialize(using = ToStringSerializer.class)
             Long id,
             String type,
             String title,

--- a/mopl-api/src/main/java/com/mopl/domain/review/dto/response/ReviewAuthorDto.java
+++ b/mopl-api/src/main/java/com/mopl/domain/review/dto/response/ReviewAuthorDto.java
@@ -1,6 +1,10 @@
 package com.mopl.domain.review.dto.response;
 
+import tools.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.databind.ser.std.ToStringSerializer;
+
 public record ReviewAuthorDto(
+        @JsonSerialize(using = ToStringSerializer.class)
         Long userId,
         String name,
         String profileImageUrl

--- a/mopl-api/src/main/java/com/mopl/domain/review/dto/response/ReviewDto.java
+++ b/mopl-api/src/main/java/com/mopl/domain/review/dto/response/ReviewDto.java
@@ -6,6 +6,7 @@ import tools.jackson.databind.ser.std.ToStringSerializer;
 public record ReviewDto(
         @JsonSerialize(using = ToStringSerializer.class)
         Long id,
+        @JsonSerialize(using = ToStringSerializer.class)
         Long contentId,
         ReviewAuthorDto author,
         String text,

--- a/mopl-api/src/main/java/com/mopl/domain/review/dto/response/ReviewDto.java
+++ b/mopl-api/src/main/java/com/mopl/domain/review/dto/response/ReviewDto.java
@@ -1,6 +1,10 @@
 package com.mopl.domain.review.dto.response;
 
+import tools.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.databind.ser.std.ToStringSerializer;
+
 public record ReviewDto(
+        @JsonSerialize(using = ToStringSerializer.class)
         Long id,
         Long contentId,
         ReviewAuthorDto author,


### PR DESCRIPTION
## 연관 이슈
close #178

## 🔄 변경 사항
API 응답 DTO의 Long ID 필드를 ToStringSerializer로 문자열 직렬화하도록 수정 (프론트 정밀도 이슈 방지)

## 🧩 작업 사항

- 리뷰dto - @JsonSerialize(using = ToStringSerializer.class)
- 플레이리스트dto - @JsonSerialize(using = ToStringSerializer.class)

## 📸 스크린샷
<img width="948" height="633" alt="image" src="https://github.com/user-attachments/assets/d725906f-f713-4779-8a7b-261f7db4678b" />
<img width="1578" height="747" alt="image" src="https://github.com/user-attachments/assets/b541433d-c994-4b89-94c2-3a4578be0682" />
