### PR TITLE
[fix] DirectMessageDto 응답 dto의 id 타입 String으로 수정

### DIFF
--- a/mopl-core/src/main/java/com/mopl/domain/conversation/dto/response/DirectMessageDto.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/dto/response/DirectMessageDto.java
@@ -7,9 +7,13 @@ import tools.jackson.databind.ser.std.ToStringSerializer;
 import java.time.LocalDateTime;
 
 public record DirectMessageDto(
+
         @JsonSerialize(using = ToStringSerializer.class)
         Long id,
+
+        @JsonSerialize(using = ToStringSerializer.class)
         Long conversationId,
+
         LocalDateTime createdAt,
         UserSummaryDto sender,
         UserSummaryDto receiver,


### PR DESCRIPTION
## 🔄 변경 사항
DirectMessageDto 응답 dto의 id 타입 Long을 json 파싱할 때 String으로 변경
- 프론트엔드와 호환을 위해 타입 수정