### PR TITLE
[refactor] Review 중복 리뷰 발생으로 인한 유니크 키 처리

### DIFF
--- a/mopl-core/src/main/resources/db/schema.sql
+++ b/mopl-core/src/main/resources/db/schema.sql
@@ -54,7 +54,8 @@ CREATE TABLE reviews
     rating     DOUBLE       NOT NULL,
     updated_at DATETIME     NOT NULL,
     created_at DATETIME     NOT NULL,
-    PRIMARY KEY (id)
+    PRIMARY KEY (id),
+    UNIQUE KEY  uk_reviews_user_content  (user_id, content_id)
 );
 
 CREATE TABLE playlists


### PR DESCRIPTION
## 연관 이슈
close #182

## 🔄 변경 사항
리뷰 스키마 UNIQUE KEY 추가

## 🧩 작업 사항
- [x] reviews 테이블에 (user_id, content_id) 조합의 UNIQUE KEY(uk_reviews_user_content) 를 추가
      - 동일 유저의 동일 콘텐츠 중복 리뷰 생성이 불가능하도록 DB 레벨에서 제약을 적용

## 📸 스크린샷
<img width="989" height="623" alt="image" src="https://github.com/user-attachments/assets/1b8b87d9-4575-4e1c-ba9d-a44c93638dc5" />
<img width="995" height="637" alt="image" src="https://github.com/user-attachments/assets/d7937324-8656-46f0-a74e-5a86b04b1c25" />
<img width="638" height="360" alt="image" src="https://github.com/user-attachments/assets/9dda397a-8798-459e-9015-a7ea50e5bde5" />
