### PR TITLE
[feat] User -  비밀번호 변경 

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
@@ -56,7 +56,6 @@ public class AuthService {
                     RedisNameSpace.TEMP_PASSWORD,
                     username,
                     String.class);
-            System.out.println(tempPassword);
 
             if (tempPassword.isPresent() && tempPassword.get().equals(password)) {
                 redisManager.delete(RedisNameSpace.TEMP_PASSWORD, username);

--- a/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
@@ -72,7 +72,8 @@ public class AuthService {
         String accessToken = jwtTokenProvider.createAccessToken(user);
         String refreshToken = jwtTokenProvider.createRefreshToken(user);
 
-        JwtDto jwtDto = new JwtDto(userMapper.toDto(user), accessToken);
+        String thumbnailUrl = s3Manager.generatePresignedUrl(user.getProfileImageUrl());
+        JwtDto jwtDto = new JwtDto(userMapper.toDto(user, thumbnailUrl), accessToken);
 
         addTokenCookie(response, "REFRESH_TOKEN", refreshToken, 60 * 60 * 24 * 14); //2주
 

--- a/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
@@ -9,6 +9,8 @@ import com.mopl.domain.user.exception.UserErrorCode;
 import com.mopl.domain.user.exception.UserException;
 import com.mopl.domain.user.mapper.UserMapper;
 import com.mopl.domain.user.repository.UserRepository;
+import com.mopl.global.redis.RedisManager;
+import com.mopl.global.redis.RedisNameSpace;
 import com.mopl.global.s3.S3Manager;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -29,6 +33,7 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final UserMapper userMapper;
     private final S3Manager s3Manager;
+    private final RedisManager redisManager;
 
     @Value("${jwt.cookie.secure}")
     private boolean cookieSecure;
@@ -40,9 +45,30 @@ public class AuthService {
         User user = userRepository.findByEmailAndLockedFalse(username)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_EXIST));
 
-        if (!passwordEncoder.matches(password, user.getPassword()))
-            throw new UserException(UserErrorCode.PASSWORD_NOT_CORRECT);
+        //DB 비밀번호 일치
+        if (passwordEncoder.matches(password, user.getPassword())) {
+            return generateToken(user, response);
+        }
 
+        //임시 비밀번호 일치
+        if (redisManager.hasKey(RedisNameSpace.TEMP_PASSWORD, username)) {
+            Optional<String> tempPassword = redisManager.findByKey(
+                    RedisNameSpace.TEMP_PASSWORD,
+                    username,
+                    String.class);
+            System.out.println(tempPassword);
+
+            if (tempPassword.isPresent() && tempPassword.get().equals(password)) {
+                redisManager.delete(RedisNameSpace.TEMP_PASSWORD, username);
+                return generateToken(user, response);
+            }
+        }
+        //둘다 틀린 경우
+        throw new UserException(UserErrorCode.PASSWORD_NOT_CORRECT);
+    }
+
+    private JwtDto generateToken(User user, HttpServletResponse response) {
+        //TODO http는 controller로 분리 작업 필요
         String accessToken = jwtTokenProvider.createAccessToken(user);
         String refreshToken = jwtTokenProvider.createRefreshToken(user);
 
@@ -68,7 +94,7 @@ public class AuthService {
         String newRefreshToken = jwtTokenProvider.createRefreshToken(user);
 
         String thumbnailUrl = s3Manager.generatePresignedUrl(user.getProfileImageUrl());
-        JwtDto jwtDto = new JwtDto(userMapper.toDto(user,thumbnailUrl), newAccessToken);
+        JwtDto jwtDto = new JwtDto(userMapper.toDto(user, thumbnailUrl), newAccessToken);
 
         addTokenCookie(response, "REFRESH_TOKEN", newRefreshToken, 60 * 60 * 24 * 14);
 

--- a/mopl-api/src/main/java/com/mopl/domain/auth/service/EmailService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/service/EmailService.java
@@ -33,7 +33,6 @@ public class EmailService {
     public void resetPassword(String email) {
         emailValid(email);
         String temporaryPassword = createTemporaryPassword(10);
-        System.out.println(temporaryPassword);
         redisManager.save(RedisNameSpace.TEMP_PASSWORD, email, temporaryPassword);
         sendEmail(email, temporaryPassword);
     }

--- a/mopl-api/src/main/java/com/mopl/domain/auth/service/EmailService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/service/EmailService.java
@@ -3,6 +3,8 @@ package com.mopl.domain.auth.service;
 import com.mopl.domain.user.exception.UserErrorCode;
 import com.mopl.domain.user.exception.UserException;
 import com.mopl.domain.user.repository.UserRepository;
+import com.mopl.global.redis.RedisManager;
+import com.mopl.global.redis.RedisNameSpace;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,6 +25,7 @@ public class EmailService {
     private final SecureRandom random = new SecureRandom();
     private final SpringTemplateEngine templateEngine;
     private final UserRepository userRepository;
+    private final RedisManager redisManager;
 
     @Value("${spring.mail.username}")
     private String moplEmail;
@@ -30,7 +33,8 @@ public class EmailService {
     public void resetPassword(String email) {
         emailValid(email);
         String temporaryPassword = createTemporaryPassword(10);
-        // TODO: Redis에 저장
+        System.out.println(temporaryPassword);
+        redisManager.save(RedisNameSpace.TEMP_PASSWORD, email, temporaryPassword);
         sendEmail(email, temporaryPassword);
     }
 

--- a/mopl-api/src/main/java/com/mopl/domain/follow/controller/FollowController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/follow/controller/FollowController.java
@@ -10,7 +10,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -61,9 +63,9 @@ public class FollowController implements FollowControllerDocs {
     // 팔로워/팔로잉 수 카운트 조회 API
     @Override
     @GetMapping("/count")
-    public ResponseEntity<FollowCountResponse> getFollowCounts(@RequestParam Long targetId) {
+    public ResponseEntity<FollowCountResponse> getFollowCounts(@RequestParam Long followeeId) {
 
-        FollowCountResponse response = followService.getFollowCounts(targetId);
+        FollowCountResponse response = followService.getFollowCounts(followeeId);
 
         return ResponseEntity.ok(response);
     }

--- a/mopl-api/src/main/java/com/mopl/domain/user/controller/UserController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/user/controller/UserController.java
@@ -60,4 +60,12 @@ public class UserController {
         UserDto updatedImage = userService.updateImage(userId, request.name(), image);
         return ResponseEntity.ok().body(updatedImage);
     }
+
+    @PreAuthorize("principal.userId == #userId")
+    @PatchMapping("/{userId}/password")
+    public ResponseEntity<Void> updatePassword(@PathVariable Long userId,
+                                               @Valid @RequestBody ChangePasswordRequest request){
+        userService.updatePassword(userId, request.password());
+        return ResponseEntity.ok().build();
+    }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/user/controller/UserController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/user/controller/UserController.java
@@ -54,7 +54,7 @@ public class UserController {
 
     @PreAuthorize("principal.userId == #userId")
     @PatchMapping(value = "/{userId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<UserDto> updateImage(@PathVariable long userId,
+    public ResponseEntity<UserDto> updateImage(@PathVariable Long userId,
                                                @RequestPart(value = "request", required = true) UserUpdateRequest request,
                                                @RequestPart(value = "image", required = false) MultipartFile image){
         UserDto updatedImage = userService.updateImage(userId, request.name(), image);

--- a/mopl-api/src/main/java/com/mopl/domain/user/dto/ChangePasswordRequest.java
+++ b/mopl-api/src/main/java/com/mopl/domain/user/dto/ChangePasswordRequest.java
@@ -1,0 +1,9 @@
+package com.mopl.domain.user.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ChangePasswordRequest (
+        @NotNull(message = "비밀번호는 필수 입력값입니다.")
+        String password
+){
+}

--- a/mopl-api/src/main/java/com/mopl/domain/user/service/UserService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/user/service/UserService.java
@@ -108,6 +108,15 @@ public class UserService {
         user.updateLocked(newLocked);
     }
 
+    @Transactional
+    public void updatePassword(Long userId, String Password) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_EXIST));
+        String newPassword = passwordEncoder.encode(Password);
+        user.updatePassword(newPassword);
+
+    }
+
     public PageResponse<UserDto> findAllUsers(UserSearchCondition searchCondition) {
         String keywordLike = searchCondition.emailLike();
         Role roleEqual = searchCondition.roleEqual();

--- a/mopl-api/src/main/java/com/mopl/global/config/SecurityConfig.java
+++ b/mopl-api/src/main/java/com/mopl/global/config/SecurityConfig.java
@@ -21,7 +21,7 @@ import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 
 @Configuration
 @EnableWebSecurity
-@EnableMethodSecurity
+@EnableMethodSecurity(prePostEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/mopl-core/src/main/java/com/mopl/domain/user/entity/User.java
+++ b/mopl-core/src/main/java/com/mopl/domain/user/entity/User.java
@@ -63,4 +63,7 @@ public class User extends BaseTimeEntity {
     public void updateProfileImageUrl(String profileImageUrl){
         this.profileImageUrl = profileImageUrl;
     }
+    public void updatePassword(String password){
+        this.password = password;
+    }
 }


### PR DESCRIPTION
## 연관 이슈
close #173 

## 🔄 변경 사항
비밀번호 찾기 -> 이메일로 비밀번호 초기화 -> *임시 비밀번호 로그인 -> 새 비밀번호로 변경 
*가 붙은 부분은 아직 구현이 덜 됨( redis에 저장 예정)
(현재) 임시 비밀번호가 발급만 되지 기존의 비밀번호를 그대로 사용하고 있음
기존 비밀번호로 로그인을 하고 새 비밀번호 변경 시도 후 성공 
## 🧩 작업 사항
작업한 내용을 간략하게 설명해주세요.
- dto - 값인증 
- 엔티티 - 비밀번호 업데이트 메서드 추가
- 서비스 - User 객체 확인 , 비밀번호 암호화 후 저장 
- 컨트롤러 - 본인 인증

## 📸 스크린샷
새 비밀번호로  로그인 성공 