### PR TITLE
[Feat] User refresh 토큰 redis에 저장 

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/auth/controller/AuthController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/controller/AuthController.java
@@ -3,12 +3,14 @@ package com.mopl.domain.auth.controller;
 import com.mopl.domain.auth.dto.JwtDto;
 import com.mopl.domain.auth.dto.ResetPasswordRequest;
 import com.mopl.domain.auth.dto.SignInRequest;
+import com.mopl.domain.auth.dto.UserPrincipal;
 import com.mopl.domain.auth.service.AuthService;
 import com.mopl.domain.auth.service.EmailService;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,8 +28,11 @@ public class AuthController {
     }
 
     @PostMapping("/sign-out")
-    public ResponseEntity<?> logout(HttpServletResponse response) {
-        authService.logout(response);
+    public ResponseEntity<?> logout(@AuthenticationPrincipal UserPrincipal userPrincipal,
+                                    HttpServletResponse response) {
+        Long myId = userPrincipal.getUserId();
+        authService.logout(myId, response);
+
         return ResponseEntity.ok().build();
     }
 

--- a/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
@@ -80,7 +80,9 @@ public class AuthService {
         return jwtDto;
     }
 
-    public void logout(HttpServletResponse response) {
+    public void logout(Long myId, HttpServletResponse response) {
+        //TODO http 관련은 controller 까지로 변경 예정
+        redisManager.delete(RedisNameSpace.AUTH_TOKEN, myId.toString());
         deleteCookie(response, "REFRESH_TOKEN");
     }
 
@@ -97,7 +99,6 @@ public class AuthService {
                 RedisNameSpace.AUTH_TOKEN,
                 userId.toString(),
                 String.class);
-        System.out.println(token);
 
         //refresh 값 불일치
         if(token.isEmpty() ||  !token.get().equals(refreshToken)){

--- a/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
@@ -70,6 +70,7 @@ public class AuthService {
         //TODO http는 controller로 분리 작업 필요
         String accessToken = jwtTokenProvider.createAccessToken(user);
         String refreshToken = jwtTokenProvider.createRefreshToken(user);
+        redisManager.save(RedisNameSpace.AUTH_TOKEN,user.getId().toString(),refreshToken);
 
         String thumbnailUrl = s3Manager.generatePresignedUrl(user.getProfileImageUrl());
         JwtDto jwtDto = new JwtDto(userMapper.toDto(user, thumbnailUrl), accessToken);
@@ -84,15 +85,28 @@ public class AuthService {
     }
 
     public JwtDto refresh(String refreshToken, HttpServletResponse response) {
-        if (!jwtTokenProvider.validateRefreshToken(refreshToken)) {
+        //jwt 유효 검증
+        if (!jwtTokenProvider.validateRefreshToken(refreshToken) ) {
             throw new AuthException(AuthErrorCode.REFRESH_TOKEN_INVALID);
         }
         Long userId = jwtTokenProvider.getUserIdFromRefreshToken(refreshToken);
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_EXIST));
+
+        Optional<String> token = redisManager.findByKey(
+                RedisNameSpace.AUTH_TOKEN,
+                userId.toString(),
+                String.class);
+        System.out.println(token);
+
+        //refresh 값 불일치
+        if(token.isEmpty() ||  !token.get().equals(refreshToken)){
+            throw new AuthException(AuthErrorCode.REFRESH_TOKEN_INVALID);
+        }
         String newAccessToken = jwtTokenProvider.createAccessToken(user);
         String newRefreshToken = jwtTokenProvider.createRefreshToken(user);
-
+        //새로운 refresh 토큰 redis에 저장
+        redisManager.save(RedisNameSpace.AUTH_TOKEN,userId.toString() ,newRefreshToken);
         String thumbnailUrl = s3Manager.generatePresignedUrl(user.getProfileImageUrl());
         JwtDto jwtDto = new JwtDto(userMapper.toDto(user, thumbnailUrl), newAccessToken);
 

--- a/mopl-api/src/main/java/com/mopl/domain/notification/service/NotificationService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/notification/service/NotificationService.java
@@ -66,7 +66,7 @@ public class NotificationService {
                 pageable
         );
 
-        Long totalCount = (long)fetched.size();
+        Long totalCount = notificationRepository.countByReceiverId(userId);
 
         boolean hasNext = fetched.size() > limit;
 

--- a/mopl-core/src/main/java/com/mopl/domain/notification/repository/NotificationRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/notification/repository/NotificationRepository.java
@@ -25,5 +25,12 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             @Param("idAfter") Long idAfter,
             Pageable pageable
     );
+
+    @Query("""
+        select count(n)
+        from Notification n
+        where n.receiverId = :userId
+        """)
+    Long countByReceiverId(@Param("userId")Long userId);
     Optional<Notification> findByIdAndReceiverId(Long notificationId, Long userId);
 }

--- a/mopl-core/src/main/java/com/mopl/domain/notification/repository/NotificationRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/notification/repository/NotificationRepository.java
@@ -24,4 +24,11 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             @Param("idAfter") Long idAfter,
             Pageable pageable
     );
+
+    @Query("""
+        select count(n)
+        from Notification n
+        where n.receiverId = :userId
+        """)
+    Long countByReceiverId(@Param("userId")Long userId);
 }


### PR DESCRIPTION
## 연관 이슈
close #196 

## 🔄 변경 사항
/login 서비스 - refresh 토큰 redis에 저장
/refresh서비스 - jwt 형식 인증
/refresh서비스 - refresh 값 과 redis의 refresh 토큰 값 비교
/refresh서비스 - 새로운 refresh redis에 저장
/logout서비스 - refresh 토큰 삭제

## 🧩 작업 사항
작업한 내용을 간략하게 설명해주세요.
- 서비스(/login, /logout, /refresh)에 refresh 토큰을 삭제, 저장 조회 함 

## 📸 스크린샷
