### PR TITLE
[feat] 대용량 데이터 조회 성능 최적화 및 인덱스 적용

### DIFF
--- a/mopl-core/src/main/java/com/mopl/domain/conversation/entity/DirectMessage.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/entity/DirectMessage.java
@@ -9,7 +9,9 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "direct_messages")
+@Table(name = "direct_messages", indexes = {
+        @Index(name = "idx_dm_conv_created", columnList = "conversation_id, created_at DESC")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DirectMessage extends BaseCreatedEntity {
 

--- a/mopl-core/src/main/java/com/mopl/domain/notification/entity/Notification.java
+++ b/mopl-core/src/main/java/com/mopl/domain/notification/entity/Notification.java
@@ -9,7 +9,9 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "notifications")
+@Table(name = "notifications", indexes = {
+        @Index(name = "idx_noti_receiver_created", columnList = "receiver_id, created_at DESC")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notification extends BaseCreatedEntity {
 

--- a/mopl-core/src/main/java/com/mopl/domain/playlist/entity/Playlist.java
+++ b/mopl-core/src/main/java/com/mopl/domain/playlist/entity/Playlist.java
@@ -7,7 +7,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "playlists")
+@Table(name = "playlists", indexes = {
+        @Index(name = "idx_playlist_user_created", columnList = "user_id, created_at DESC")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Playlist extends BaseTimeEntity {

--- a/mopl-core/src/main/java/com/mopl/domain/review/entity/Review.java
+++ b/mopl-core/src/main/java/com/mopl/domain/review/entity/Review.java
@@ -7,7 +7,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "reviews")
+@Table(name = "reviews", indexes = {
+        @Index(name = "idx_review_content_created", columnList = "content_id, created_at DESC")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Review extends BaseTimeEntity {

--- a/mopl-core/src/main/resources/db/schema.sql
+++ b/mopl-core/src/main/resources/db/schema.sql
@@ -24,7 +24,7 @@ CREATE TABLE contents
     thumbnail_url  VARCHAR(255) NOT NULL,
     average_rating DOUBLE DEFAULT 0.0,
     review_count   INT    DEFAULT 0,
-    created_at        DATETIME     NOT NULL,
+    created_at     DATETIME     NOT NULL,
     PRIMARY KEY (id)
 );
 
@@ -55,7 +55,9 @@ CREATE TABLE reviews
     updated_at DATETIME     NOT NULL,
     created_at DATETIME     NOT NULL,
     PRIMARY KEY (id),
-    UNIQUE KEY  uk_reviews_user_content  (user_id, content_id)
+    UNIQUE KEY uk_reviews_user_content (user_id, content_id),
+    -- 콘텐츠별 최신 리뷰 조회를 위한 인덱스
+    INDEX idx_review_content_created (content_id, created_at DESC)
 );
 
 CREATE TABLE playlists
@@ -67,7 +69,9 @@ CREATE TABLE playlists
     subscriber_count BIGINT       NOT NULL DEFAULT 0,
     updated_at       DATETIME     NOT NULL,
     created_at       DATETIME     NOT NULL,
-    PRIMARY KEY (id)
+    PRIMARY KEY (id),
+    -- 유저별 플레이리스트 최신순 조회를 위한 인덱스
+    INDEX idx_playlist_user_created (user_id, created_at DESC)
 );
 
 CREATE TABLE playlist_subscribes
@@ -112,7 +116,9 @@ CREATE TABLE direct_messages
     author_id       BIGINT       NOT NULL,
     content         VARCHAR(255) NOT NULL,
     created_at      DATETIME     NOT NULL,
-    PRIMARY KEY (id)
+    PRIMARY KEY (id),
+    -- 대화방별 메시지 최신순 조회를 위한 인덱스
+    INDEX idx_dm_conv_created (conversation_id, created_at DESC)
 );
 
 CREATE TABLE notifications
@@ -123,7 +129,9 @@ CREATE TABLE notifications
     content     VARCHAR(255) NOT NULL,
     level       VARCHAR(255) NOT NULL,
     created_at  DATETIME     NOT NULL,
-    PRIMARY KEY (id)
+    PRIMARY KEY (id),
+    -- 유저별 알림 최신순 조회를 위한 인덱스
+    INDEX idx_noti_receiver_created (receiver_id, created_at DESC)
 );
 
 CREATE TABLE follows

--- a/scripts/dummyDataSetup.sql
+++ b/scripts/dummyDataSetup.sql
@@ -1,0 +1,98 @@
+CREATE DATABASE IF NOT EXISTS mopl_local;
+USE mopl_local;
+
+-- 1. 기초 데이터 초기화 (외래 키 제약 조건 잠시 해제 후 청소)
+SET FOREIGN_KEY_CHECKS = 0;
+TRUNCATE TABLE users;
+TRUNCATE TABLE contents;
+TRUNCATE TABLE conversations;
+TRUNCATE TABLE direct_messages;
+TRUNCATE TABLE notifications;
+TRUNCATE TABLE reviews;
+TRUNCATE TABLE playlists;
+SET FOREIGN_KEY_CHECKS = 1;
+
+-- 2. 필수 부모 데이터 생성
+INSERT INTO users (id, name, email, role, locked, updated_at, created_at)
+VALUES (1, '테스터', 'test@mopl.io', 'USER', false, NOW(), NOW());
+
+INSERT INTO contents (id, content_type, title, description, thumbnail_url, created_at)
+VALUES (1, 'movie', '인터스텔라', '우주 SF 영화', 'http://image.com', NOW());
+
+INSERT INTO conversations (id, created_at)
+VALUES (1, NOW());
+
+-- 3. 데이터 삽입 프로시저 정의 (* 데이터 갯수는 늘려서 해주세요 코드잇에서 빌린 맥북 성능이 별로라 멈추네요)
+
+-- ① DM 더미 데이터 (1만 건)
+DROP PROCEDURE IF EXISTS insert_dm_data;
+DELIMITER $$
+CREATE PROCEDURE insert_dm_data()
+BEGIN
+    DECLARE i INT DEFAULT 1;
+    WHILE i <= 10000 DO
+            INSERT INTO direct_messages (conversation_id, author_id, content, created_at)
+            VALUES (1, 1, CONCAT('DM 메시지입니다 - ', i), DATE_ADD('2026-01-01 00:00:00', INTERVAL i SECOND));
+            SET i = i + 1;
+        END WHILE;
+END$$
+DELIMITER ;
+
+-- ② 알림 더미 데이터 (1만 건)
+DROP PROCEDURE IF EXISTS insert_notification_data;
+DELIMITER $$
+CREATE PROCEDURE insert_notification_data()
+BEGIN
+    DECLARE i INT DEFAULT 1;
+    WHILE i <= 10000 DO
+            INSERT INTO notifications (receiver_id, title, content, level, created_at)
+            VALUES (1, '알림 제목', '알림 내용입니다.', 'INFO', DATE_ADD('2026-01-01 00:00:00', INTERVAL i SECOND));
+            SET i = i + 1;
+        END WHILE;
+END$$
+DELIMITER ;
+
+-- ③ 리뷰 더미 데이터 (5천 건)
+DROP PROCEDURE IF EXISTS insert_review_data;
+DELIMITER $$
+CREATE PROCEDURE insert_review_data()
+BEGIN
+    DECLARE i INT DEFAULT 1;
+    WHILE i <= 5000 DO
+            INSERT INTO reviews (user_id, content_id, texts, rating, updated_at, created_at)
+            VALUES (i, 1, CONCAT('리뷰 텍스트 - ', i), 4.0, NOW(), DATE_ADD('2026-01-01 00:00:00', INTERVAL i MINUTE));
+            SET i = i + 1;
+        END WHILE;
+END$$
+DELIMITER ;
+
+-- ④ 플레이리스트 더미 데이터 (3천 건)
+DROP PROCEDURE IF EXISTS insert_playlist_data;
+DELIMITER $$
+CREATE PROCEDURE insert_playlist_data()
+BEGIN
+    DECLARE i INT DEFAULT 1;
+    WHILE i <= 3000 DO
+            INSERT INTO playlists (user_id, title, description, subscriber_count, updated_at, created_at)
+            VALUES (1, CONCAT('플레이리스트 ', i), '설명', 0, NOW(), NOW());
+            SET i = i + 1;
+        END WHILE;
+END$$
+DELIMITER ;
+
+-- 4. 프로시저 실행 (실제 데이터 생성)
+SELECT 'DM 데이터 삽입 시작...' AS msg;
+CALL insert_dm_data();
+
+SELECT '알림 데이터 삽입 시작...' AS msg;
+CALL insert_notification_data();
+
+SELECT '리뷰 데이터 삽입 시작...' AS msg;
+CALL insert_review_data();
+
+SELECT '플레이리스트 데이터 삽입 시작...' AS msg;
+CALL insert_playlist_data();
+
+SELECT '모든 더미 데이터 생성이 완료되었습니다.' AS msg;
+
+SHOW TABLES;

--- a/scripts/indexTestReport.sql
+++ b/scripts/indexTestReport.sql
@@ -1,0 +1,53 @@
+USE mopl_local;
+
+-- 1. Direct Messages (DM) 성능 테스트
+-- [BEFORE]
+EXPLAIN SELECT * FROM direct_messages WHERE conversation_id = 1 ORDER BY created_at DESC LIMIT 20;
+
+-- [INDEX 생성]
+CREATE INDEX idx_dm_conv_created ON direct_messages (conversation_id, created_at DESC);
+
+-- [AFTER]
+EXPLAIN SELECT * FROM direct_messages WHERE conversation_id = 1 ORDER BY created_at DESC LIMIT 20;
+
+
+-- 2. Notifications (알림) 성능 테스트
+-- [BEFORE]
+EXPLAIN SELECT * FROM notifications WHERE receiver_id = 1 ORDER BY created_at DESC LIMIT 20;
+
+-- [INDEX 생성]
+CREATE INDEX idx_noti_receiver_created ON notifications (receiver_id, created_at DESC);
+
+-- [AFTER]
+EXPLAIN SELECT * FROM notifications WHERE receiver_id = 1 ORDER BY created_at DESC LIMIT 20;
+
+
+-- 3. Reviews (리뷰) 성능 테스트
+-- [BEFORE]
+EXPLAIN SELECT * FROM reviews WHERE content_id = 1 ORDER BY created_at DESC LIMIT 20;
+
+-- [INDEX 생성]
+CREATE INDEX idx_review_content_created ON reviews (content_id, created_at DESC);
+
+-- [AFTER]
+EXPLAIN SELECT * FROM reviews WHERE content_id = 1 ORDER BY created_at DESC LIMIT 20;
+
+
+-- 4. Playlists (플레이리스트) 성능 테스트
+-- [BEFORE]
+EXPLAIN SELECT * FROM playlists WHERE user_id = 1 ORDER BY created_at DESC LIMIT 20;
+
+-- [INDEX 생성]
+CREATE INDEX idx_playlist_user_created ON playlists (user_id, created_at DESC);
+
+-- [AFTER]
+EXPLAIN SELECT * FROM playlists WHERE user_id = 1 ORDER BY created_at DESC LIMIT 20;
+
+SHOW TABLES;
+
+
+-- 인덱스 삭제가 필요할 때 (초기화)
+-- DROP INDEX idx_dm_conv_created ON direct_messages;
+-- DROP INDEX idx_noti_receiver_created ON notifications;
+-- DROP INDEX idx_review_content_created ON reviews;
+-- DROP INDEX idx_playlist_user_created ON playlists;

--- a/scripts/schemaLocalTest.sql
+++ b/scripts/schemaLocalTest.sql
@@ -1,0 +1,142 @@
+DROP DATABASE IF EXISTS mopl_local;
+CREATE DATABASE mopl_local;
+USE mopl_local;
+
+CREATE TABLE users
+(
+    id                BIGINT       NOT NULL AUTO_INCREMENT,
+    name              VARCHAR(255) NOT NULL,
+    email             VARCHAR(255) NOT NULL,
+    password          VARCHAR(255) NULL,
+    role              VARCHAR(10)  NOT NULL,
+    locked            BOOLEAN      NOT NULL DEFAULT FALSE,
+    profile_image_url VARCHAR(255) NULL,
+    provider          VARCHAR(255) NULL,
+    provider_id       VARCHAR(255) NULL,
+    updated_at        DATETIME     NOT NULL,
+    created_at        DATETIME     NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_users_email (email)
+);
+
+CREATE TABLE contents
+(
+    id             BIGINT       NOT NULL AUTO_INCREMENT,
+    content_type   VARCHAR(255) NOT NULL,
+    title          VARCHAR(255) NOT NULL,
+    description    TEXT         NOT NULL,
+    thumbnail_url  VARCHAR(255) NOT NULL,
+    average_rating DOUBLE DEFAULT 0.0,
+    review_count   INT    DEFAULT 0,
+    created_at        DATETIME     NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE tags
+(
+    id  BIGINT       NOT NULL AUTO_INCREMENT,
+    tag VARCHAR(255) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_tags_tag (tag)
+);
+
+CREATE TABLE content_tags
+(
+    id         BIGINT NOT NULL AUTO_INCREMENT,
+    content_id BIGINT NOT NULL,
+    tag_id     BIGINT NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_content_tag (content_id, tag_id)
+);
+
+CREATE TABLE reviews
+(
+    id         BIGINT       NOT NULL AUTO_INCREMENT,
+    user_id    BIGINT       NOT NULL,
+    content_id BIGINT       NOT NULL,
+    texts      VARCHAR(255) NOT NULL,
+    rating     DOUBLE       NOT NULL,
+    updated_at DATETIME     NOT NULL,
+    created_at DATETIME     NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY  uk_reviews_user_content  (user_id, content_id)
+);
+
+CREATE TABLE playlists
+(
+    id               BIGINT       NOT NULL AUTO_INCREMENT,
+    user_id          BIGINT       NOT NULL,
+    title            VARCHAR(255) NOT NULL,
+    description      VARCHAR(255) NOT NULL,
+    subscriber_count BIGINT       NOT NULL DEFAULT 0,
+    updated_at       DATETIME     NOT NULL,
+    created_at       DATETIME     NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE playlist_subscribes
+(
+    id          BIGINT NOT NULL AUTO_INCREMENT,
+    user_id     BIGINT NOT NULL,
+    playlist_id BIGINT NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_playlist_subscribes (user_id, playlist_id)
+);
+
+CREATE TABLE playlist_contents
+(
+    id          BIGINT NOT NULL AUTO_INCREMENT,
+    playlist_id BIGINT NOT NULL,
+    content_id  BIGINT NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_playlist_contents (playlist_id, content_id)
+);
+
+CREATE TABLE conversations
+(
+    id              BIGINT   NOT NULL AUTO_INCREMENT,
+    created_at      DATETIME NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE read_status
+(
+    id              BIGINT NOT NULL AUTO_INCREMENT,
+    conversation_id BIGINT NOT NULL,
+    user_id         BIGINT NOT NULL,
+    last_message_id BIGINT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_read_status_conversation_user (conversation_id, user_id)
+);
+
+CREATE TABLE direct_messages
+(
+    id              BIGINT       NOT NULL AUTO_INCREMENT,
+    conversation_id BIGINT       NOT NULL,
+    author_id       BIGINT       NOT NULL,
+    content         VARCHAR(255) NOT NULL,
+    created_at      DATETIME     NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE notifications
+(
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    receiver_id BIGINT       NOT NULL,
+    title       VARCHAR(255) NOT NULL,
+    content     VARCHAR(255) NOT NULL,
+    level       VARCHAR(255) NOT NULL,
+    created_at  DATETIME     NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE follows
+(
+    id          BIGINT NOT NULL AUTO_INCREMENT,
+    follower_id BIGINT NOT NULL,
+    followee_id BIGINT NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_follows_relation (follower_id, followee_id)
+);
+
+SHOW TABLES;


### PR DESCRIPTION
## 연관 이슈

close #208 

## 🔄 변경 사항

* 대량 데이터 환경에서의 쿼리 성능 저하를 방지하기 위해 주요 테이블에 대한 인덱스 전략 반영하였습니다.
* `mopl-core` 모듈의 `schema.sql`과 JPA 엔티티 클래스에 복합 인덱스(Composite Index) 설정을 추가하였습니다.

## 🧩 작업 사항

* `schemaLocalTest.sql`: 로컬 MariaDB 환경 구축을 위한 전체 테이블 DDL 정의
* `dummyDataSetup.sql`: 성능 검증을 위한 데이터 삽입 프로시저 및 더미 데이터(약 3만 건) 생성
* `indexTestReport.sql`: 인덱스 적용 전후 `EXPLAIN` 분석을 통한 실행 계획 검증
* `DirectMessage`, `Notification`, `Review`, `Playlist` 엔티티에 `@Index` 어노테이션 반영
* `schema.sql`: 실제 운영 및 초기화 시 적용될 복합 인덱스 구문 추가

## 📸 스크린샷

### 1. 더미 데이터 추가 (dummyDataSetup.sql에서 건수 수정해도 됩니다.)

* DM: 10,000건

* 알림: 10,000건

* 리뷰: 5,000건

* 플레이리스트: 3,000건

### 2. EXPLAIN 결과 비교


테이블명 | 인덱스 적용 전 (Before) | 인덱스 적용 후 (After) | 개선율
-- | -- | -- | --
Notifications | 10 ms | 4 ms | 60% 단축
Reviews | 10 ms | 5 ms | 50% 단축
Playlists | 7 ms | 4 ms | 약 43% 단축
Direct Messages | 6 ms | 7 ms | 유사 수준

</body></html>

---