### PR TITLE
[refactor] Auth 서비스의 HTTP 의존성 제거

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/auth/controller/AuthController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/controller/AuthController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
+
     private final AuthService authService;
     private final EmailService emailService;
 
@@ -30,10 +31,10 @@ public class AuthController {
     private static final int REFRESH_TOKEN_MAX_AGE = 60 * 60 * 24 * 14; // 2주
 
     @PostMapping("/sign-in")
-    public ResponseEntity<JwtDto> login(@ModelAttribute SignInRequest req, HttpServletResponse response) {
+    public ResponseEntity<JwtDto> login(@ModelAttribute SignInRequest req,
+                                        HttpServletResponse response) {
         TokenResultDto tokenDto = authService.login(req.username(), req.password());
-        //refresh 토큰 저장
-        addTokenCookie(response, "REFRESH_TOKEN", tokenDto.refreshToken(), REFRESH_TOKEN_MAX_AGE); //2주
+        addTokenCookie(response, "REFRESH_TOKEN", tokenDto.refreshToken(), REFRESH_TOKEN_MAX_AGE);
         return ResponseEntity.ok(tokenDto.jwtDto());
     }
 
@@ -42,23 +43,24 @@ public class AuthController {
                                     HttpServletResponse response) {
         Long myId = userPrincipal.getUserId();
         authService.logout(myId);
-        //refresh 토큰 삭제
         deleteCookie(response, "REFRESH_TOKEN");
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/reset-password")
-    public ResponseEntity<Void> resetPassword(@Valid @RequestBody ResetPasswordRequest req) {
+    public ResponseEntity<Void> resetPassword(@RequestBody @Valid ResetPasswordRequest req) {
         emailService.resetPassword(req.email());
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/refresh")
-    public ResponseEntity<JwtDto> refresh(@CookieValue("REFRESH_TOKEN") String refreshToken, HttpServletResponse response) {
+    public ResponseEntity<JwtDto> refresh(@CookieValue("REFRESH_TOKEN") String refreshToken,
+                                          HttpServletResponse response) {
         TokenResultDto tokenDto = authService.refresh(refreshToken);
         addTokenCookie(response, "REFRESH_TOKEN", tokenDto.refreshToken(), REFRESH_TOKEN_MAX_AGE);
         return ResponseEntity.ok().body(tokenDto.jwtDto());
     }
+
     @GetMapping("/csrf-token")
     public CsrfToken getCsrfToken(CsrfToken token) {
         return token;

--- a/mopl-api/src/main/java/com/mopl/domain/auth/controller/AuthController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/controller/AuthController.java
@@ -1,14 +1,14 @@
 package com.mopl.domain.auth.controller;
 
-import com.mopl.domain.auth.dto.JwtDto;
-import com.mopl.domain.auth.dto.ResetPasswordRequest;
-import com.mopl.domain.auth.dto.SignInRequest;
-import com.mopl.domain.auth.dto.UserPrincipal;
+import com.mopl.domain.auth.dto.*;
 import com.mopl.domain.auth.service.AuthService;
 import com.mopl.domain.auth.service.EmailService;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.web.csrf.CsrfToken;
@@ -21,18 +21,29 @@ public class AuthController {
     private final AuthService authService;
     private final EmailService emailService;
 
+    @Value("${jwt.cookie.secure}")
+    private boolean cookieSecure;
+
+    @Value("${jwt.cookie.same-site:Lax}")  // 기본값 Lax
+    private String cookieSameSite;
+
+    private static final int REFRESH_TOKEN_MAX_AGE = 60 * 60 * 24 * 14; // 2주
+
     @PostMapping("/sign-in")
     public ResponseEntity<JwtDto> login(@ModelAttribute SignInRequest req, HttpServletResponse response) {
-        JwtDto jwtDto = authService.login(req.username(), req.password(), response);
-        return ResponseEntity.ok(jwtDto);
+        TokenResultDto tokenDto = authService.login(req.username(), req.password());
+        //refresh 토큰 저장
+        addTokenCookie(response, "REFRESH_TOKEN", tokenDto.refreshToken(), REFRESH_TOKEN_MAX_AGE); //2주
+        return ResponseEntity.ok(tokenDto.jwtDto());
     }
 
     @PostMapping("/sign-out")
     public ResponseEntity<?> logout(@AuthenticationPrincipal UserPrincipal userPrincipal,
                                     HttpServletResponse response) {
         Long myId = userPrincipal.getUserId();
-        authService.logout(myId, response);
-
+        authService.logout(myId);
+        //refresh 토큰 삭제
+        deleteCookie(response, "REFRESH_TOKEN");
         return ResponseEntity.ok().build();
     }
 
@@ -44,13 +55,34 @@ public class AuthController {
 
     @PostMapping("/refresh")
     public ResponseEntity<JwtDto> refresh(@CookieValue("REFRESH_TOKEN") String refreshToken, HttpServletResponse response) {
-        JwtDto jwtDto = authService.refresh(refreshToken, response);
-        return ResponseEntity.ok().body(jwtDto);
+        TokenResultDto tokenDto = authService.refresh(refreshToken);
+        addTokenCookie(response, "REFRESH_TOKEN", tokenDto.refreshToken(), REFRESH_TOKEN_MAX_AGE);
+        return ResponseEntity.ok().body(tokenDto.jwtDto());
     }
     @GetMapping("/csrf-token")
     public CsrfToken getCsrfToken(CsrfToken token) {
         return token;
     }
 
+    private void addTokenCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .path("/")
+                .maxAge(maxAge)
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .sameSite(cookieSameSite)
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
 
+    private void deleteCookie(HttpServletResponse response, String name) {
+        ResponseCookie cookie = ResponseCookie.from(name, "")
+                .path("/")
+                .maxAge(0)// 즉시 만료
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .sameSite(cookieSameSite)
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/auth/dto/TokenResultDto.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/dto/TokenResultDto.java
@@ -1,0 +1,7 @@
+package com.mopl.domain.auth.dto;
+
+public record TokenResultDto(
+        JwtDto jwtDto,
+        String refreshToken
+) {
+}

--- a/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
@@ -32,14 +32,17 @@ public class AuthService {
     private final S3Manager s3Manager;
     private final RedisManager redisManager;
 
+    /**
+     * 로그인
+     * DB 비밀번호 또는 임시 비밀번호(Redis)로 인증합니다.
+     */
     public TokenResultDto login(String username, String password) {
         User user = userRepository.findByEmailAndLockedFalse(username)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_EXIST));
-        //DB 비밀번호 일치
         if (passwordEncoder.matches(password, user.getPassword())) {
             return generateToken(user);
         }
-        //임시 비밀번호 일치
+
         if (redisManager.hasKey(RedisNameSpace.TEMP_PASSWORD, username)) {
             Optional<String> tempPassword = redisManager.findByKey(
                     RedisNameSpace.TEMP_PASSWORD,
@@ -50,16 +53,15 @@ public class AuthService {
                 return generateToken(user);
             }
         }
-        //둘다 틀린 경우
         throw new UserException(UserErrorCode.PASSWORD_NOT_CORRECT);
     }
 
+    //로그인 성공 후 토큰 생성
     private TokenResultDto generateToken(User user) {
-        String accessToken = jwtTokenProvider.createAccessToken(user);
-
         String refreshToken = jwtTokenProvider.createRefreshToken(user);
         redisManager.save(RedisNameSpace.AUTH_TOKEN, user.getId().toString(), refreshToken);
 
+        String accessToken = jwtTokenProvider.createAccessToken(user);
         String thumbnailUrl = s3Manager.generatePresignedUrl(user.getProfileImageUrl());
         JwtDto jwtDto = new JwtDto(userMapper.toDto(user, thumbnailUrl), accessToken);
 
@@ -70,30 +72,30 @@ public class AuthService {
         redisManager.delete(RedisNameSpace.AUTH_TOKEN, myId.toString());
     }
 
+    /**
+     * Refresh Token을 검증하고 새로운 Access/Refresh Token을 발급합니다.
+     * Redis에 저장된 토큰과 비교하여 탈취된 토큰 사용을 방지합니다.
+     */
     public TokenResultDto refresh(String refreshToken) {
-        //jwt 유효 검증
         if (!jwtTokenProvider.validateRefreshToken(refreshToken)) {
             throw new AuthException(AuthErrorCode.REFRESH_TOKEN_INVALID);
         }
 
         Long userId = jwtTokenProvider.getUserIdFromRefreshToken(refreshToken);
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_EXIST));
-
         Optional<String> token = redisManager.findByKey(
                 RedisNameSpace.AUTH_TOKEN,
                 userId.toString(),
                 String.class);
-        //refresh 값 불일치
         if (token.isEmpty() || !token.get().equals(refreshToken)) {
             throw new AuthException(AuthErrorCode.REFRESH_TOKEN_INVALID);
         }
 
-        String newAccessToken = jwtTokenProvider.createAccessToken(user);
-        //새로운 refresh 토큰 redis에 저장
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_EXIST));
         String newRefreshToken = jwtTokenProvider.createRefreshToken(user);
         redisManager.save(RedisNameSpace.AUTH_TOKEN, userId.toString(), newRefreshToken);
 
+        String newAccessToken = jwtTokenProvider.createAccessToken(user);
         String thumbnailUrl = s3Manager.generatePresignedUrl(user.getProfileImageUrl());
         JwtDto jwtDto = new JwtDto(userMapper.toDto(user, thumbnailUrl), newAccessToken);
 

--- a/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.mopl.domain.auth.service;
 
 import com.mopl.domain.auth.dto.JwtDto;
+import com.mopl.domain.auth.dto.TokenResultDto;
 import com.mopl.domain.auth.exception.AuthErrorCode;
 import com.mopl.domain.auth.exception.AuthException;
 import com.mopl.domain.auth.jwt.JwtTokenProvider;
@@ -12,12 +13,8 @@ import com.mopl.domain.user.repository.UserRepository;
 import com.mopl.global.redis.RedisManager;
 import com.mopl.global.redis.RedisNameSpace;
 import com.mopl.global.s3.S3Manager;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -35,19 +32,13 @@ public class AuthService {
     private final S3Manager s3Manager;
     private final RedisManager redisManager;
 
-    @Value("${jwt.cookie.secure}")
-    private boolean cookieSecure;
-
-    @Value("${jwt.cookie.same-site:Lax}")  // 기본값 Lax
-    private String cookieSameSite;
-
-    public JwtDto login(String username, String password, HttpServletResponse response) {
+    public TokenResultDto login(String username, String password) {
         User user = userRepository.findByEmailAndLockedFalse(username)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_EXIST));
 
         //DB 비밀번호 일치
         if (passwordEncoder.matches(password, user.getPassword())) {
-            return generateToken(user, response);
+            return generateToken(user);
         }
 
         //임시 비밀번호 일치
@@ -59,14 +50,14 @@ public class AuthService {
 
             if (tempPassword.isPresent() && tempPassword.get().equals(password)) {
                 redisManager.delete(RedisNameSpace.TEMP_PASSWORD, username);
-                return generateToken(user, response);
+                return generateToken(user);
             }
         }
         //둘다 틀린 경우
         throw new UserException(UserErrorCode.PASSWORD_NOT_CORRECT);
     }
 
-    private JwtDto generateToken(User user, HttpServletResponse response) {
+    private TokenResultDto generateToken(User user) {
         //TODO http는 controller로 분리 작업 필요
         String accessToken = jwtTokenProvider.createAccessToken(user);
         String refreshToken = jwtTokenProvider.createRefreshToken(user);
@@ -75,18 +66,14 @@ public class AuthService {
         String thumbnailUrl = s3Manager.generatePresignedUrl(user.getProfileImageUrl());
         JwtDto jwtDto = new JwtDto(userMapper.toDto(user, thumbnailUrl), accessToken);
 
-        addTokenCookie(response, "REFRESH_TOKEN", refreshToken, 60 * 60 * 24 * 14); //2주
-
-        return jwtDto;
+        return new TokenResultDto(jwtDto, refreshToken);
     }
 
-    public void logout(Long myId, HttpServletResponse response) {
-        //TODO http 관련은 controller 까지로 변경 예정
+    public void logout(Long myId) {
         redisManager.delete(RedisNameSpace.AUTH_TOKEN, myId.toString());
-        deleteCookie(response, "REFRESH_TOKEN");
     }
 
-    public JwtDto refresh(String refreshToken, HttpServletResponse response) {
+    public TokenResultDto refresh(String refreshToken) {
         //jwt 유효 검증
         if (!jwtTokenProvider.validateRefreshToken(refreshToken) ) {
             throw new AuthException(AuthErrorCode.REFRESH_TOKEN_INVALID);
@@ -111,30 +98,8 @@ public class AuthService {
         String thumbnailUrl = s3Manager.generatePresignedUrl(user.getProfileImageUrl());
         JwtDto jwtDto = new JwtDto(userMapper.toDto(user, thumbnailUrl), newAccessToken);
 
-        addTokenCookie(response, "REFRESH_TOKEN", newRefreshToken, 60 * 60 * 24 * 14);
 
-        return jwtDto;
-    }
 
-    private void addTokenCookie(HttpServletResponse response, String name, String value, int maxAge) {
-        ResponseCookie cookie = ResponseCookie.from(name, value)
-                .path("/")
-                .maxAge(maxAge)
-                .httpOnly(true)
-                .secure(cookieSecure)
-                .sameSite(cookieSameSite)
-                .build();
-        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
-    }
-
-    private void deleteCookie(HttpServletResponse response, String name) {
-        ResponseCookie cookie = ResponseCookie.from(name, "")
-                .path("/")
-                .maxAge(0)// 즉시 만료
-                .httpOnly(true)
-                .secure(cookieSecure)
-                .sameSite(cookieSameSite)
-                .build();
-        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        return new TokenResultDto(jwtDto, newRefreshToken);
     }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
@@ -39,9 +39,7 @@ public class AuthService {
     public TokenResultDto login(String username, String password) {
         User user = userRepository.findByEmailAndLockedFalse(username)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_EXIST));
-        if (passwordEncoder.matches(password, user.getPassword())) {
-            return generateToken(user);
-        }
+        if (passwordEncoder.matches(password, user.getPassword())) return generateToken(user);
 
         if (redisManager.hasKey(RedisNameSpace.TEMP_PASSWORD, username)) {
             Optional<String> tempPassword = redisManager.findByKey(

--- a/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/service/AuthService.java
@@ -35,19 +35,16 @@ public class AuthService {
     public TokenResultDto login(String username, String password) {
         User user = userRepository.findByEmailAndLockedFalse(username)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_EXIST));
-
         //DB 비밀번호 일치
         if (passwordEncoder.matches(password, user.getPassword())) {
             return generateToken(user);
         }
-
         //임시 비밀번호 일치
         if (redisManager.hasKey(RedisNameSpace.TEMP_PASSWORD, username)) {
             Optional<String> tempPassword = redisManager.findByKey(
                     RedisNameSpace.TEMP_PASSWORD,
                     username,
                     String.class);
-
             if (tempPassword.isPresent() && tempPassword.get().equals(password)) {
                 redisManager.delete(RedisNameSpace.TEMP_PASSWORD, username);
                 return generateToken(user);
@@ -58,10 +55,10 @@ public class AuthService {
     }
 
     private TokenResultDto generateToken(User user) {
-        //TODO http는 controller로 분리 작업 필요
         String accessToken = jwtTokenProvider.createAccessToken(user);
+
         String refreshToken = jwtTokenProvider.createRefreshToken(user);
-        redisManager.save(RedisNameSpace.AUTH_TOKEN,user.getId().toString(),refreshToken);
+        redisManager.save(RedisNameSpace.AUTH_TOKEN, user.getId().toString(), refreshToken);
 
         String thumbnailUrl = s3Manager.generatePresignedUrl(user.getProfileImageUrl());
         JwtDto jwtDto = new JwtDto(userMapper.toDto(user, thumbnailUrl), accessToken);
@@ -75,9 +72,10 @@ public class AuthService {
 
     public TokenResultDto refresh(String refreshToken) {
         //jwt 유효 검증
-        if (!jwtTokenProvider.validateRefreshToken(refreshToken) ) {
+        if (!jwtTokenProvider.validateRefreshToken(refreshToken)) {
             throw new AuthException(AuthErrorCode.REFRESH_TOKEN_INVALID);
         }
+
         Long userId = jwtTokenProvider.getUserIdFromRefreshToken(refreshToken);
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_EXIST));
@@ -86,19 +84,18 @@ public class AuthService {
                 RedisNameSpace.AUTH_TOKEN,
                 userId.toString(),
                 String.class);
-
         //refresh 값 불일치
-        if(token.isEmpty() ||  !token.get().equals(refreshToken)){
+        if (token.isEmpty() || !token.get().equals(refreshToken)) {
             throw new AuthException(AuthErrorCode.REFRESH_TOKEN_INVALID);
         }
+
         String newAccessToken = jwtTokenProvider.createAccessToken(user);
-        String newRefreshToken = jwtTokenProvider.createRefreshToken(user);
         //새로운 refresh 토큰 redis에 저장
-        redisManager.save(RedisNameSpace.AUTH_TOKEN,userId.toString() ,newRefreshToken);
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(user);
+        redisManager.save(RedisNameSpace.AUTH_TOKEN, userId.toString(), newRefreshToken);
+
         String thumbnailUrl = s3Manager.generatePresignedUrl(user.getProfileImageUrl());
         JwtDto jwtDto = new JwtDto(userMapper.toDto(user, thumbnailUrl), newAccessToken);
-
-
 
         return new TokenResultDto(jwtDto, newRefreshToken);
     }


### PR DESCRIPTION
## 연관 이슈
close #209 

## 🔄 변경 사항
HTTP 응답 처리는 컨트롤러의 책임이므로 레이어 분리 필요

## 🧩 작업 사항
작업한 내용을 간략하게 설명해주세요.
새로운 TokenResultDto 추가 : 
응답에 필요한 jwt dto와 쿠키 저장을 위한 refresh를 가져오기 위해 
기존 swagger(jwtDto를 통해 accesstoken만 있음)에 없었던 dto 추가 

<img width="490" height="260" alt="image" src="https://github.com/user-attachments/assets/3d49a9cf-617e-4502-9426-a536b82ecc26" />

JwtDto(응답)와 Refresh Token을 함께 반환
jwtDto는 응답 본문(Response Body)으로 반환
refreshToken은 controller에서 쿠키에 저장

컨트롤러 추가
addRefreshTokenCookie(): Refresh Token 쿠키 생성
deleteRefreshTokenCookie(): Refresh Token 쿠키 삭제
파라미터는 같지만 하는 역할이 다르기 때문에 가독성을 위해 분리 

## 📸 스크린샷
<img width="1209" height="235" alt="image" src="https://github.com/user-attachments/assets/2a92b7d3-8d8a-42af-a410-f8857c2d6534" />