### PR TITLE
[feat] 비활성화 채팅방 DM 수신 및 메시지 유실 복구 시스템 구현 (Kafka, SSE, Redis)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  kafka:
+    image: apache/kafka:latest
+    container_name: kafka
+    ports: # 호스트:컨테이너
+      - "9092:9092"
+    environment:
+      # 카프카 서버의 ID 지정
+      KAFKA_NODE_ID: 1
+
+      # 역할 지정: broker, controller(클러스터를 관리하는 매니저. 예전 주키퍼 역할)
+      # 실제 운영 환경에서는 Controller 3개, broker 3개 총 6개의 컨테이너를 띄워 사용해야 함
+      KAFKA_PROCESS_ROLES: broker, controller
+
+      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092 # TODO 운영 환경에서는 PLAINTEXT://kafka:9092 로 수정
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+
+      # 복사본 설정
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+
+      # 파티션 개수
+      KAFKA_NUM_PARTITIONS: 3
+
+    volumes:
+      - kafka_data:/var/lib/kafka/data
+volumes:
+  kafka_data:

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/service/DirectMessageService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/service/DirectMessageService.java
@@ -17,7 +17,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.mopl.domain.conversation.exception.ConversationErrorCode.CONVERSATION_ID_MISMATCH;
 import static com.mopl.domain.conversation.exception.ConversationErrorCode.CONVERSATION_NOT_FOUND;
@@ -90,8 +92,10 @@ public class DirectMessageService {
 
         UserSummaryDto mySummaryDto = new UserSummaryDto(userId, "me", null);
 
+        Map<Long, String> urlCache = new HashMap<>(); // key: authorId, value: presignedUrl
+
         return messages.stream()
-                .map(msg -> convertToMissedDto(msg, mySummaryDto))
+                .map(msg -> convertToMissedDto(msg, mySummaryDto, urlCache))
                 .toList();
     }
 
@@ -113,10 +117,13 @@ public class DirectMessageService {
     }
 
     // 받는 사람이 무조건 본인
-    private DirectMessageDto convertToMissedDto(DirectMessage message, UserSummaryDto mySummaryDto) {
+    private DirectMessageDto convertToMissedDto(DirectMessage message, UserSummaryDto mySummaryDto, Map<Long, String> urlCache) {
         User author = message.getAuthor();
 
-        String presignedUrl = s3Manager.generatePresignedUrl(author.getProfileImageUrl());
+        String presignedUrl = urlCache.computeIfAbsent(
+                author.getId(),
+                authorId -> s3Manager.generatePresignedUrl(author.getProfileImageUrl())
+        );
 
         // 보낸 사람 (상대방)
         UserSummaryDto senderDto = new UserSummaryDto(

--- a/mopl-api/src/main/java/com/mopl/domain/conversation/service/DirectMessageService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/service/DirectMessageService.java
@@ -9,11 +9,14 @@ import com.mopl.domain.conversation.repository.ReadStatusRepository;
 import com.mopl.domain.user.dto.response.UserSummaryDto;
 import com.mopl.domain.user.entity.User;
 import com.mopl.global.dto.PageResponse;
+import com.mopl.global.s3.S3Manager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 import static com.mopl.domain.conversation.exception.ConversationErrorCode.CONVERSATION_ID_MISMATCH;
@@ -26,6 +29,7 @@ public class DirectMessageService {
 
     private final DirectMessageRepository directMessageRepository;
     private final ReadStatusRepository readStatusRepository;
+    private final S3Manager s3Manager;
 
     // 로그인한 사용자의 대화방 메시지 전체 조회
     public PageResponse<DirectMessageDto> findMessages(DMCursorRequest cursorRequest, Long myId, Long conversationId) {
@@ -53,7 +57,8 @@ public class DirectMessageService {
         }
 
         UserSummaryDto mySummaryDto = new UserSummaryDto(myId, "me", null);
-        UserSummaryDto withUserDto = new UserSummaryDto(targetUser.getId(), targetUser.getName(), targetUser.getProfileImageUrl());
+        String presignedUrl = s3Manager.generatePresignedUrl(targetUser.getProfileImageUrl());
+        UserSummaryDto withUserDto = new UserSummaryDto(targetUser.getId(), targetUser.getName(), presignedUrl);
 
         List<DirectMessageDto> messageDtos = messages.stream()
                 .map(message -> convertToDto(myId, conversationId, message, mySummaryDto, withUserDto))
@@ -78,6 +83,18 @@ public class DirectMessageService {
                 .build();
     }
 
+    public List<DirectMessageDto> findMissedMessages(Long userId, long lastTimestamp, Long lastId) {
+        LocalDateTime lastTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(lastTimestamp), ZoneId.systemDefault());
+
+        List<DirectMessage> messages = directMessageRepository.findMissedMessages(userId, lastTime, lastId);
+
+        UserSummaryDto mySummaryDto = new UserSummaryDto(userId, "me", null);
+
+        return messages.stream()
+                .map(msg -> convertToMissedDto(msg, mySummaryDto))
+                .toList();
+    }
+
     private DirectMessageDto convertToDto(Long myId, Long conversationId, DirectMessage message, UserSummaryDto mySummaryDto, UserSummaryDto withUserDto) {
         Long messageId = message.getId();
         LocalDateTime createdAt = message.getCreatedAt();
@@ -93,5 +110,28 @@ public class DirectMessageService {
                 sender,
                 receiver,
                 message.getContent());
+    }
+
+    // 받는 사람이 무조건 본인
+    private DirectMessageDto convertToMissedDto(DirectMessage message, UserSummaryDto mySummaryDto) {
+        User author = message.getAuthor();
+
+        String presignedUrl = s3Manager.generatePresignedUrl(author.getProfileImageUrl());
+
+        // 보낸 사람 (상대방)
+        UserSummaryDto senderDto = new UserSummaryDto(
+                author.getId(),
+                author.getName(),
+                presignedUrl
+        );
+
+        return new DirectMessageDto(
+                message.getId(),
+                message.getConversation().getId(),
+                message.getCreatedAt(),
+                senderDto,   // 보낸 사람 (상대방)
+                mySummaryDto, // 받는 사람 (나)
+                message.getContent()
+        );
     }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/notification/consumer/NotificationConsumer.java
+++ b/mopl-api/src/main/java/com/mopl/domain/notification/consumer/NotificationConsumer.java
@@ -1,0 +1,27 @@
+package com.mopl.domain.notification.consumer;
+
+import com.mopl.domain.notification.event.DmNotificationEvent;
+import com.mopl.global.sse.SseManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationConsumer {
+
+    private final SseManager sseManager;
+
+    @KafkaListener(topics = "dm-notification", groupId = "api-server-group")
+    public void consumeDmNotification(DmNotificationEvent event) {
+        log.info("유저 {}의 DM 알림 소비", event.receiverId());
+
+        sseManager.sendToUser(
+                event.receiverId(),
+                "direct-messages",
+                event.directMessageDto()
+        );
+    }
+}

--- a/mopl-api/src/main/java/com/mopl/domain/notification/controller/SseController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/notification/controller/SseController.java
@@ -1,8 +1,13 @@
 package com.mopl.domain.notification.controller;
 
 import com.mopl.domain.auth.dto.UserPrincipal;
+import com.mopl.domain.conversation.dto.response.DirectMessageDto;
+import com.mopl.domain.conversation.service.DirectMessageService;
+import com.mopl.domain.notification.dto.NotificationDto;
+import com.mopl.domain.notification.service.NotificationService;
 import com.mopl.global.sse.SseManager;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,21 +16,78 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.util.List;
+
+@Slf4j
 @RestController
 @RequestMapping("/api/sse")
 @RequiredArgsConstructor
 public class SseController {
 
     private final SseManager sseManager;
+    private final DirectMessageService directMessageService;
+    private final NotificationService notificationService;
 
     @GetMapping(produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter subscribe(
-            @AuthenticationPrincipal UserPrincipal userPrincipal,
-            @RequestParam(value = "LastEventId", required = false, defaultValue = "")
-            String lastEventId
-    ) {
-        Long userId = userPrincipal.getUserId();
+    public SseEmitter subscribe(@AuthenticationPrincipal UserPrincipal userPrincipal,
+                                @RequestParam(value = "LastEventId", required = false) String lastEventId) {
 
-        return sseManager.subscribe(userId);
+        SseEmitter emitter = sseManager.subscribe(userPrincipal.getUserId());
+
+        // 재연결 요청시 유실 데이터 전송
+        if (lastEventId != null && !lastEventId.isBlank()) {
+            resendMissedEvents(userPrincipal.getUserId(), lastEventId);
+        }
+
+        return emitter;
+    }
+
+    private void resendMissedEvents(Long userId, String lastEventId) {
+        try {
+            // ID 형식: {timestamp}_TYPE_{dataId}
+            String[] parts = lastEventId.split("_");
+
+            if (parts.length < 3) {
+                log.warn("잘못된 형식의 LastEventId: {}", lastEventId);
+                return;
+            }
+
+            long lastTimestamp = Long.parseLong(parts[0]);
+            String type = parts[1];
+            long lastId = Long.parseLong(parts[2]);
+
+            // 유실된 DM 조회 및 재전송
+            if ("DM".equals(type)) {
+                // 마지막이 DM이었음 -> DM은 ID까지 정밀 조회
+                List<DirectMessageDto> missedDms = directMessageService.findMissedMessages(userId, lastTimestamp, lastId);
+                sendDms(userId, missedDms);
+
+                // 알림은 시간으로만 조회 (ID 비교 불가하므로)
+                List<NotificationDto> missedNotis = notificationService.findMissedNotifications(userId, lastTimestamp, 0L);
+                sendNotifications(userId, missedNotis);
+            } else if ("NOTI".equals(type)) {
+                // 마지막이 알림이었음 -> 알림은 ID까지 정밀 조회
+                List<NotificationDto> missedNotis = notificationService.findMissedNotifications(userId, lastTimestamp, lastId);
+                sendNotifications(userId, missedNotis);
+
+                // DM은 시간으로만 조회
+                List<DirectMessageDto> missedDms = directMessageService.findMissedMessages(userId, lastTimestamp, 0L);
+                sendDms(userId, missedDms);
+            }
+        } catch (Exception e) {
+            log.error("유실 데이터 전송 중 오류: {}", e.getMessage());
+        }
+    }
+
+    private void sendDms(Long userId, List<DirectMessageDto> dms) {
+        for (DirectMessageDto dm : dms) {
+            sseManager.sendToUser(userId, "direct-messages", dm);
+        }
+    }
+
+    private void sendNotifications(Long userId, List<NotificationDto> notis) {
+        for (NotificationDto noti : notis) {
+            sseManager.sendToUser(userId, "notifications", noti);
+        }
     }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/notification/service/NotificationService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/notification/service/NotificationService.java
@@ -18,7 +18,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.List;
@@ -43,7 +45,7 @@ public class NotificationService {
         NotificationDto notificationDto = toDto(notification);
         sseManager.sendToUser(
                 receiverId,
-                "notification",
+                "notifications",
                 notificationDto
         );
     }
@@ -111,6 +113,15 @@ public class NotificationService {
                 .sortBy(sortBy)
                 .sortDirection(sortDirection)
                 .build();
+    }
+
+    public List<NotificationDto> findMissedNotifications(Long userId, long lastTimestamp, Long lastId) {
+        LocalDateTime lastTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(lastTimestamp), ZoneId.of("Asia/Seoul"));
+        List<Notification> notifications = notificationRepository.findMissedNotifications(userId, lastTime, lastId);
+
+        return notifications.stream()
+                .map(this::toDto)
+                .toList();
     }
 
     private StartId parseStartId(String cursorRaw, String idAfterRaw) {

--- a/mopl-api/src/main/java/com/mopl/global/sse/SseManager.java
+++ b/mopl-api/src/main/java/com/mopl/global/sse/SseManager.java
@@ -1,5 +1,7 @@
 package com.mopl.global.sse;
 
+import com.mopl.domain.conversation.dto.response.DirectMessageDto;
+import com.mopl.domain.notification.dto.NotificationDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -13,6 +15,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class SseManager {
 
     private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private static final Long DEFAULT_TIMEOUT = 60_000L; // 프론트의 재연결 주기 기준
 
     /**
      * 클라이언트와 서버 간의 SSE 파이프라인을 생성하고 관리합니다.
@@ -22,20 +25,15 @@ public class SseManager {
      * @return 실시간 통신을 위한 SseEmitter 객체
      */
     public SseEmitter subscribe(Long userId) {
-        SseEmitter emitter = new SseEmitter(60_000L); // 프론트엔 재연결 주기 기준
+        SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
         emitters.put(userId, emitter);
 
         emitter.onCompletion(() -> emitters.remove(userId));
         emitter.onTimeout(() -> emitters.remove(userId));
         emitter.onError((e) -> emitters.remove(userId));
 
-        try {
-            assert emitter.getTimeout() != null;
-            Map<String, Long> timeoutData = Map.of("timeout", emitter.getTimeout());
-            emitter.send(SseEmitter.event().name("timeout").data(timeoutData));
-        } catch (IOException e) {
-            emitters.remove(userId);
-        }
+        // 더미 이벤트 전송 (503 에러 방지용)
+        sendToClient(emitter, "connect", "connected!");
 
         return emitter;
     }
@@ -45,18 +43,49 @@ public class SseManager {
      * 전송 실패 시 해당 사용자의 연결을 관리 목록에서 제거합니다.
      *
      * @param userId 이벤트를 수신할 사용자 ID
-     * @param eventName 이벤트 종류 (예: "chat", "notification")
+     * @param eventName 이벤트 종류 (예: "direct-messages", "notifications")
      * @param data 전송할 데이터 객체
      */
     public void sendToUser(Long userId, String eventName, Object data) {
         SseEmitter emitter = emitters.get(userId);
         if (emitter != null) {
-            try {
-                emitter.send(SseEmitter.event().name(eventName).data(data));
-            } catch (IOException e) {
-                log.error("SSE 전송 실패, userId: {}", userId);
-                emitters.remove(userId);
-            }
+            String eventId = generateEventId(data);
+            sendToClient(emitter, eventId, eventName, data);
         }
+    }
+
+    private void sendToClient(SseEmitter emitter, String id, String name, Object data) {
+        try {
+            emitter.send(SseEmitter.event()
+                    .id(id) // 재연결시 LastEventId 파라미터로 사용됨
+                    .name(name)
+                    .data(data));
+
+        } catch (IOException e) {
+            log.warn("SSE 전송 실패 (User disconnected): {}", e.getMessage());
+            emitter.complete();
+        }
+    }
+
+    private void sendToClient(SseEmitter emitter, String name, Object data) {
+        try {
+            emitter.send(SseEmitter.event().name(name).data(data));
+        } catch (IOException e) {
+            emitter.complete();
+        }
+    }
+
+    private String generateEventId(Object data) {
+        long timestamp = System.currentTimeMillis();
+
+        if (data instanceof NotificationDto notificationDto) {
+            return timestamp + "_NOTI_" + notificationDto.id();
+        }
+
+        if (data instanceof DirectMessageDto directMessageDto) {
+            return timestamp + "_DM_" + directMessageDto.id();
+        }
+
+        return timestamp + "_UNKNOWN_" + 0;
     }
 }

--- a/mopl-api/src/main/resources/application.yml
+++ b/mopl-api/src/main/resources/application.yml
@@ -10,6 +10,7 @@ spring:
     group:
       dev: core-dev
       prod: core-prod
+      local: core-local
   servlet:
     multipart:
       max-file-size: 10MB
@@ -27,6 +28,10 @@ spring:
          auth: true
          starttls:
           enable: true
+
+  kafka:
+    consumer:
+      group-id: api-server-group # API 서버용 그룹 id
 
 # swagger
 springdoc:

--- a/mopl-chat/src/main/java/com/mopl/domain/directmessage/event/WebSocketEventLister.java
+++ b/mopl-chat/src/main/java/com/mopl/domain/directmessage/event/WebSocketEventLister.java
@@ -1,0 +1,111 @@
+package com.mopl.domain.directmessage.event;
+
+import com.mopl.domain.auth.dto.UserPrincipal;
+import com.mopl.global.redis.RedisManager;
+import com.mopl.global.redis.RedisNameSpace;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketEventLister {
+
+    private final String CONVERSATION_PREFIX = "/conversations/";
+    private final String CURRENT_ROOM_ID = "currentRoomId";
+
+    private final RedisManager redisManager;
+
+    // 사용자가 채팅방에 들어올 때
+    @EventListener
+    public void handleSubscribeEvent(SessionSubscribeEvent event) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+
+        String destination = headerAccessor.getDestination();
+        String userId = extractUserId(headerAccessor);
+
+        // destination = /sub/conversations/{conversationId}/direct-messages
+        if (userId != null && destination != null && destination.contains(CONVERSATION_PREFIX)) {
+            String conversationId = extractConversationId(destination);
+            if (conversationId == null) {
+                return;
+            }
+
+            redisManager.addSetElement(RedisNameSpace.DM_VIEWERS, conversationId, userId);
+
+            // Disconnect 시 사용하기 위해 세션에 방 id 저장
+            if (headerAccessor.getSessionAttributes() != null) {
+                headerAccessor.getSessionAttributes().put(CURRENT_ROOM_ID, conversationId);
+            }
+
+            log.info("사용자 {}가 대화방 {}에 입장", userId, conversationId);
+        }
+    }
+
+    // 사용자가 채팅방을 나감
+    @EventListener
+    public void handleUnsubscribeEvent(SessionUnsubscribeEvent event) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+        removeUserFromRoom(headerAccessor);
+    }
+
+    // 사용자가 앱을 나감
+    @EventListener
+    public void handleDisconnectEvent(SessionDisconnectEvent event) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+        removeUserFromRoom(headerAccessor);
+    }
+
+    private void removeUserFromRoom(StompHeaderAccessor headerAccessor) {
+        String userId = extractUserId(headerAccessor);
+        String conversationId = headerAccessor.getSessionAttributes() != null ?
+                (String) headerAccessor.getSessionAttributes().get(CURRENT_ROOM_ID)
+                : null;
+
+        if (userId != null && conversationId != null) {
+            redisManager.removeSetElement(RedisNameSpace.DM_VIEWERS, conversationId, userId);
+            log.info("사용자 {}가 대화방 {}에서 퇴장.", userId, conversationId);
+        }
+    }
+
+    private String extractUserId(StompHeaderAccessor headerAccessor) {
+        try {
+            if (headerAccessor.getUser() instanceof Authentication authentication) {
+                Object principal = authentication.getPrincipal();
+                if (principal instanceof UserPrincipal userPrincipal) {
+                    return String.valueOf(userPrincipal.userId());
+                }
+            }
+        } catch (Exception e) {
+            log.error("WebSocket userId 추출 실패", e);
+        }
+        return null;
+    }
+
+    private String extractConversationId(String destination) {
+        // "/sub/conversations/10/direct-messages" -> "10"
+        try {
+            int start = destination.indexOf(CONVERSATION_PREFIX);
+            if (start == -1) {
+                return null;
+            }
+
+            start += CONVERSATION_PREFIX.length();
+            int end = destination.indexOf("/direct-messages", start);
+            if (end == -1) {
+                return null;
+            }
+
+            return destination.substring(start, end);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/mopl-chat/src/main/java/com/mopl/domain/directmessage/service/DMChatService.java
+++ b/mopl-chat/src/main/java/com/mopl/domain/directmessage/service/DMChatService.java
@@ -6,9 +6,13 @@ import com.mopl.domain.conversation.entity.DirectMessage;
 import com.mopl.domain.conversation.entity.ReadStatus;
 import com.mopl.domain.conversation.repository.DirectMessageRepository;
 import com.mopl.domain.conversation.repository.ReadStatusRepository;
+import com.mopl.domain.notification.event.DmNotificationEvent;
 import com.mopl.domain.user.dto.response.UserSummaryDto;
 import com.mopl.domain.user.entity.User;
+import com.mopl.global.redis.RedisManager;
+import com.mopl.global.redis.RedisNameSpace;
 import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +25,8 @@ public class DMChatService {
 
     private final DirectMessageRepository directMessageRepository;
     private final ReadStatusRepository readStatusRepository;
+    private final RedisManager redisManager;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
 
     @Transactional
     public DirectMessageDto saveMessage(Long senderId, Long conversationId, String content) {
@@ -51,6 +57,21 @@ public class DMChatService {
         DirectMessage message = new DirectMessage(conversation, sender, content);
         directMessageRepository.save(message);
 
+        DirectMessageDto directMessageDto = toDto(senderId, conversationId, content, message, sender, receiver);
+
+        // 상대방 대화창 활성화 여부 확인 후 알림 전송
+        boolean isWatching = redisManager.isMember(RedisNameSpace.DM_VIEWERS, String.valueOf(conversationId), String.valueOf(receiver.getId()));
+        if (!isWatching) {
+            kafkaTemplate.send("dm-notification", new DmNotificationEvent(
+                    receiver.getId(),
+                    directMessageDto
+            ));
+        }
+
+        return directMessageDto;
+    }
+
+    private static DirectMessageDto toDto(Long senderId, Long conversationId, String content, DirectMessage message, User sender, User receiver) {
         return new DirectMessageDto(
                 message.getId(),
                 conversationId,

--- a/mopl-chat/src/main/java/com/mopl/global/config/KafkaConfig.java
+++ b/mopl-chat/src/main/java/com/mopl/global/config/KafkaConfig.java
@@ -1,4 +1,0 @@
-package com.mopl.global.config;
-
-public class KafkaConfig {
-}

--- a/mopl-chat/src/main/resources/application.yml
+++ b/mopl-chat/src/main/resources/application.yml
@@ -13,6 +13,10 @@ spring:
       test: core-test
       local: core-local
 
+  kafka:
+    consumer:
+      group-id: chat-server-group # 채팅 서버용 그룹 id
+
 #jwt
 jwt:
   access-secret: ${JWT_ACCESS_SECRET}

--- a/mopl-core/build.gradle
+++ b/mopl-core/build.gradle
@@ -42,4 +42,8 @@ dependencies {
     implementation platform("software.amazon.awssdk:bom:2.26.21")
     implementation "software.amazon.awssdk:s3"
     implementation "software.amazon.awssdk:sts"
+
+    // Kafka
+    api 'org.springframework.boot:spring-boot-starter-kafka'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 }

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/repository/DirectMessageRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/repository/DirectMessageRepository.java
@@ -2,7 +2,11 @@ package com.mopl.domain.conversation.repository;
 
 import com.mopl.domain.conversation.entity.DirectMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface DirectMessageRepository extends JpaRepository<DirectMessage, Long>, DirectMessageRepositoryCustom {
@@ -11,4 +15,15 @@ public interface DirectMessageRepository extends JpaRepository<DirectMessage, Lo
     Optional<DirectMessage> findTopByConversationIdOrderByCreatedAtDescIdDesc(Long conversationId);
 
     Optional<DirectMessage> findByIdAndConversationId(Long directMessageId, Long conversationId);
+
+    @Query("""
+        SELECT dm FROM DirectMessage dm
+        JOIN FETCH dm.author u
+        JOIN ReadStatus rs ON rs.conversation = dm.conversation
+        WHERE rs.user.id = :userId
+            AND dm.author.id != :userId
+            AND (dm.createdAt > :lastTime OR (dm.createdAt = :lastTime AND dm.id > :lastId))
+        ORDER BY dm.createdAt ASC, dm.id ASC
+    """)
+    List<DirectMessage> findMissedMessages(@Param("userId") Long userId, @Param("lastTime") LocalDateTime lastTime, @Param("lastId") Long lastId);
 }

--- a/mopl-core/src/main/java/com/mopl/domain/notification/event/DmNotificationEvent.java
+++ b/mopl-core/src/main/java/com/mopl/domain/notification/event/DmNotificationEvent.java
@@ -1,0 +1,9 @@
+package com.mopl.domain.notification.event;
+
+import com.mopl.domain.conversation.dto.response.DirectMessageDto;
+
+public record DmNotificationEvent(
+        Long receiverId,
+        DirectMessageDto directMessageDto
+) {
+}

--- a/mopl-core/src/main/java/com/mopl/domain/notification/repository/NotificationRepository.java
+++ b/mopl-core/src/main/java/com/mopl/domain/notification/repository/NotificationRepository.java
@@ -33,4 +33,14 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
         """)
     Long countByReceiverId(@Param("userId")Long userId);
     Optional<Notification> findByIdAndReceiverId(Long notificationId, Long userId);
+
+    @Query("""
+        SELECT n FROM Notification n
+        WHERE n.receiverId = :userId
+            AND (n.createdAt > :lastTime OR (n.createdAt = :lastTime AND n.id > :lastId))
+        ORDER BY n.createdAt ASC, n.id ASC
+    """)
+    List<Notification> findMissedNotifications(@Param("userId") Long userId,
+                                               @Param("lastTime") LocalDateTime lastTime,
+                                               @Param("lastId") Long lastId);
 }

--- a/mopl-core/src/main/java/com/mopl/global/redis/RedisManager.java
+++ b/mopl-core/src/main/java/com/mopl/global/redis/RedisManager.java
@@ -46,4 +46,20 @@ public class RedisManager {
         String key = namespace.createKey(identifier);
         return Boolean.TRUE.equals(redisTemplate.hasKey(key));
     }
+
+    public void addSetElement(RedisNameSpace nameSpace, String identifier, Object value) {
+        String key = nameSpace.createKey(identifier);
+        redisTemplate.opsForSet().add(key, value);
+        redisTemplate.expire(key, nameSpace.getTtl());
+    }
+
+    public void removeSetElement(RedisNameSpace nameSpace, String identifier, Object value) {
+        String key = nameSpace.createKey(identifier);
+        redisTemplate.opsForSet().remove(key, value);
+    }
+
+    public boolean isMember(RedisNameSpace nameSpace, String identifier, Object value) {
+        String key = nameSpace.createKey(identifier);
+        return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(key, value));
+    }
 }

--- a/mopl-core/src/main/java/com/mopl/global/redis/RedisNameSpace.java
+++ b/mopl-core/src/main/java/com/mopl/global/redis/RedisNameSpace.java
@@ -9,19 +9,22 @@ import java.time.Duration;
 @RequiredArgsConstructor
 public enum RedisNameSpace {
     // 인증 토큰
-    AUTH_TOKEN("token", Duration.ofDays(7), false),
+    AUTH_TOKEN("token:", Duration.ofDays(7), false),
 
     // 임시 비밀번호
-    TEMP_PASSWORD("temp-password", Duration.ofMinutes(3), true),
+    TEMP_PASSWORD("temp-password:", Duration.ofMinutes(3), true),
 
     // 실시간 시청자 수
-    WATCHER_COUNT("watcher", Duration.ofHours(1), false);
+    WATCHER_COUNT("watcher:", Duration.ofHours(1), false),
+
+    // DM 채팅방 접속자 명단 Set
+    DM_VIEWERS("dm-chat:viewer:", Duration.ofHours(2), true),;
 
     private final String prefix;
     private final Duration ttl;
     private final boolean evictable;
 
     public String createKey(String identifier) {
-        return String.format("%s:%s", this.prefix, identifier);
+        return this.prefix + identifier;
     }
 }

--- a/mopl-core/src/main/resources/application-core-dev.yml
+++ b/mopl-core/src/main/resources/application-core-dev.yml
@@ -15,8 +15,11 @@ spring:
 
   data:
     redis:
-      host: localhost
-      port: 6379
+      host: ${REDIS_HOST_DEV}
+      port: ${REDIS_PORT}
+
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS_DEV}
 
 cloud:
   aws:

--- a/mopl-core/src/main/resources/application-core-prod.yml
+++ b/mopl-core/src/main/resources/application-core-prod.yml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ${DB_URL}
+    url: ${DB_URL} # 추후 변경 필요
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
   jpa:
@@ -13,8 +13,11 @@ spring:
         format_sql: false
   data:
     redis:
-      host: ${REDIS_HOST}
-      port: 6379
+      host: ${REDIS_HOST_PROD}
+      port: ${REDIS_PORT}
+
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS_DEV}
 
 logging:
   level:

--- a/mopl-core/src/main/resources/application-core.yml
+++ b/mopl-core/src/main/resources/application-core.yml
@@ -1,15 +1,30 @@
 spring:
+
   config:
     import: optional:file:.env[.properties], optional:file:../.env[.properties]
+
   jpa:
     open-in-view: false
     properties:
       hibernate:
         default_batch_fetch_size: 100
+
   data:
     redis:
       repositories:
         enabled: true
+
+  kafka:
+    consumer:
+      auto-offset-reset: latest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: "*" # 모든 패키지의 DTO 수신 허용
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+
 cloud:
   aws:
     s3:


### PR DESCRIPTION
## 연관 이슈
close #141 

## 🔄 변경 사항
예: 도서 리뷰 API의 응답 형식 수정

## 🧩 작업 사항
**1. 인프라 및 아키텍처**
- **Kafka**: `chat` 모듈과 `api` 모듈 간의 느슨한 결합을 위해 비동기 이벤트 통신 적용 (Docker Compose 구성)
- **Redis**: 실시간 채팅방 참여자 관리를 위해 Set 자료구조 활용
- 사용하지 않는 `KafkaConfig` 삭제

**2. 주요 기능 구현**
- **실시간 참여자 추적**: `WebSocketEventListener`를 통해 사용자가 채팅방에 입장/퇴장하는 이벤트를 감지하여 Redis에 상태(DM_VIEWERS)를 동기화
- 사용자가 보고있지 않은 DM 방에 메시지가 오면 SSE 전송

- SSE 메시지 복구 (Reliability):
  - `Last-Event-ID` 헤더를 활용하여 클라이언트 재연결 시 유실된 DM 및 알림을 조회하여 재전송하는 로직 구현.
  - 동일 타임스탬프 중복 방지를 위해 `(Time, ID)` 복합 커서 기반 쿼리 적용.

## TO-DO
- 알림