### PR TITLE
[FIX] SSE 연결 타임아웃 시 500 에러 발생 및 JWT 인증 실패 로그 과다 적재 수정

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/auth/exception/JwtAuthenticationEntryPoint.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/exception/JwtAuthenticationEntryPoint.java
@@ -6,7 +6,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
@@ -26,19 +25,30 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-        ErrorCode errorCode = ErrorCode.UNAUTHORIZED;
-        log.error("인증 실패: {} - {}", errorCode.getStatus(), errorCode.getMessage(), authException);
+        // 응답이 이미 클라이언트로 전송 시작했는지 확인
+        if (response.isCommitted()) {
+            // 이미 커밋된 상태에서 다시 예외를 처리하려고 하면 'Response Committed' 에러가 발생
+            log.warn("응답이 이미 커밋되어 예외를 처리할 수 없습니다.");
+            return;
+        }
+
+        ErrorCode errorCode = (ErrorCode) request.getAttribute("exception"); // JwtFilter에서 담아둔 예외 확인
+        if (errorCode == null) {
+            errorCode = ErrorCode.UNAUTHORIZED;
+        }
+
+        log.warn("인증 실패: {} - {}", errorCode.getStatus(), errorCode.getMessage());
+
         ProblemDetail pd = ProblemDetail.forStatusAndDetail(
                 HttpStatusCode.valueOf(errorCode.getStatus()),
                 errorCode.getMessage()
         );
-        pd.setTitle(errorCode.name());
-        pd.setDetail(errorCode.getMessage());
-        pd.setStatus(errorCode.getStatus());
 
-        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        pd.setTitle(errorCode.name());
+
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
+        response.setStatus(errorCode.getStatus());
 
         String json = objectMapper.writeValueAsString(pd);
         response.getWriter().write(json);

--- a/mopl-api/src/main/java/com/mopl/domain/auth/jwt/JwtFilter.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/jwt/JwtFilter.java
@@ -1,5 +1,8 @@
 package com.mopl.domain.auth.jwt;
 
+import com.mopl.global.exception.ErrorCode;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -30,30 +33,27 @@ public class JwtFilter extends OncePerRequestFilter {
             String token = jwtTokenProvider.resolveToken(request);
 
             // 토큰 유효성 검증 및 인증 정보(Authentication) 설정
-            if (token != null && jwtTokenProvider.validateAccessToken(token)) {
+            if (token != null) {
+                jwtTokenProvider.validateAccessToken(token);
+
                 Authentication authentication = jwtTokenProvider.getAuthentication(token);
 
                 // SecurityContext에 인증 객체 저장 (요청 처리 동안 유지)
                 SecurityContextHolder.getContext().setAuthentication(authentication);
                 log.debug("JWT 인증 성공: {}", authentication.getName());
             }
-
-            // 다음 필터로 요청 전달
-            filterChain.doFilter(request, response);
-
+        } catch (ExpiredJwtException e) {
+            request.setAttribute("exception", ErrorCode.EXPIRED_TOKEN);
+        } catch (JwtException | IllegalArgumentException e) {
+            // 위조되거나 잘못된 토큰
+            request.setAttribute("exception", ErrorCode.INVALID_TOKEN);
         } catch (Exception e) {
-            // 응답이 이미 클라이언트로 전송 시작했는지 확인
-            if (response.isCommitted()) {
-                // 이미 커밋된 상태에서 다시 예외를 처리하려고 하면 'Response Committed' 에러가 발생
-                log.warn("응답이 이미 커밋되어 예외를 처리할 수 없습니다: {}", e.getMessage());
-                return;
-            }
-
+            log.error("JWT 필터 내부 오류", e);
             // 발생한 예외를 Request 속성에 저장하여 EntryPoint 등에서 활용할 수 있게 함
-            request.setAttribute("exception", e);
-
-            // 예외 발생 시에도 필터 체인을 계속 진행하여 AuthenticationEntryPoint에서 처리하도록 유도
-            filterChain.doFilter(request, response);
+            request.setAttribute("exception", ErrorCode.INVALID_TOKEN);
         }
+
+        // 예외 발생 시에도 필터 체인을 계속 진행하여 AuthenticationEntryPoint에서 처리하도록 유도
+        filterChain.doFilter(request, response);
     }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/auth/jwt/JwtFilter.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/jwt/JwtFilter.java
@@ -43,12 +43,15 @@ public class JwtFilter extends OncePerRequestFilter {
                 log.debug("JWT 인증 성공: {}", authentication.getName());
             }
         } catch (ExpiredJwtException e) {
+            SecurityContextHolder.clearContext();
             request.setAttribute("exception", ErrorCode.EXPIRED_TOKEN);
         } catch (JwtException | IllegalArgumentException e) {
             // 위조되거나 잘못된 토큰
+            SecurityContextHolder.clearContext();
             request.setAttribute("exception", ErrorCode.INVALID_TOKEN);
         } catch (Exception e) {
             log.error("JWT 필터 내부 오류", e);
+            SecurityContextHolder.clearContext();
             // 발생한 예외를 Request 속성에 저장하여 EntryPoint 등에서 활용할 수 있게 함
             request.setAttribute("exception", ErrorCode.INVALID_TOKEN);
         }

--- a/mopl-api/src/main/java/com/mopl/domain/auth/jwt/JwtTokenProvider.java
+++ b/mopl-api/src/main/java/com/mopl/domain/auth/jwt/JwtTokenProvider.java
@@ -4,6 +4,7 @@ import com.mopl.domain.auth.dto.UserPrincipal;
 import com.mopl.domain.user.entity.User;
 import com.mopl.domain.user.enums.Role;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -115,9 +116,13 @@ public class JwtTokenProvider {
                     .build()
                     .parseClaimsJws(token);
             return true;
+        } catch (ExpiredJwtException e) {
+            // 만료된 토큰은 info 로그만 찍고 예외를 던져 필터에게 알림
+            log.info("만료된 JWT 토큰입니다.");
+            throw e;
         } catch (JwtException | IllegalArgumentException e) {
-            log.error(e.getMessage(), e);
-            return false;
+            log.error("유효하지 않은 JWT 토큰", e);
+            throw e;
         }
     }
 

--- a/mopl-api/src/main/java/com/mopl/global/config/SecurityConfig.java
+++ b/mopl-api/src/main/java/com/mopl/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.mopl.global.config;
 import com.mopl.domain.auth.exception.JwtAuthenticationEntryPoint;
 import com.mopl.domain.auth.jwt.JwtFilter;
 import com.mopl.domain.auth.jwt.JwtTokenProvider;
+import jakarta.servlet.DispatcherType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -55,6 +56,7 @@ public class SecurityConfig {
                                 .csrfTokenRequestHandler(requestHandler)
                 )
                 .authorizeHttpRequests(auth -> auth
+                        .dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()
                         .requestMatchers(
                                 "/api-docs/**",
                                 "/swagger-ui/**",

--- a/mopl-api/src/main/java/com/mopl/global/exception/GlobalExceptionHandler.java
+++ b/mopl-api/src/main/java/com/mopl/global/exception/GlobalExceptionHandler.java
@@ -2,13 +2,16 @@ package com.mopl.global.exception;
 
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.async.AsyncRequestTimeoutException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
@@ -58,6 +61,19 @@ public class GlobalExceptionHandler {
         log.error("권한 부족: {}", ErrorCode.INSUFFICIENT_PERMISSIONS.getMessage(), e);
 
         return createErrorResponse(ErrorCode.INSUFFICIENT_PERMISSIONS, ErrorCode.INSUFFICIENT_PERMISSIONS.getMessage());
+    }
+
+    /**
+     * SSE 타임아웃 예외 처리
+     * 이 예외는 클라이언트가 재연결하면 되므로
+     * 별도의 에러 바디(JSON)를 쓰지 않고 304(Not Modified)나 204(No Content) 등을 반환하거나
+     * 아무것도 반환하지 않아야 함.
+     */
+    @ExceptionHandler(AsyncRequestTimeoutException.class)
+    @ResponseStatus(HttpStatus.NOT_MODIFIED)
+    public void handleAsyncRequestTimeoutException(AsyncRequestTimeoutException e) {
+        // 로그만 남기고 아무것도 하지 않음 (JSON 변환 시도 방지)
+        log.debug("SSE Connection Timeout: {}", e.getMessage());
     }
 
     /** 공통 응답 생성 메서드 */

--- a/mopl-api/src/main/java/com/mopl/global/sse/SseManager.java
+++ b/mopl-api/src/main/java/com/mopl/global/sse/SseManager.java
@@ -29,8 +29,16 @@ public class SseManager {
         emitters.put(userId, emitter);
 
         emitter.onCompletion(() -> emitters.remove(userId));
-        emitter.onTimeout(() -> emitters.remove(userId));
-        emitter.onError((e) -> emitters.remove(userId));
+
+        emitter.onTimeout(() -> {
+            emitter.complete();
+            emitters.remove(userId);
+        });
+
+        emitter.onError((e) -> {
+            emitter.complete();
+            emitters.remove(userId);
+        });
 
         // 더미 이벤트 전송 (503 에러 방지용)
         sendToClient(emitter, "connect", "connected!");


### PR DESCRIPTION
## 연관 이슈
close #217 

## 🧩 작업 사항
### 1. SSE 연결 안정성 강화 (SSE Timeout Fix)
SSE 연결이 유지 시간(Timeout)을 초과할 때 서블릿 컨테이너 레벨에서 발생하는 예외를 정상적인 종료 흐름으로 변경함.
- `SecurityConfig`: 타임아웃 처리 시 발생하는 내부 비동기 요청(DispatcherType.ASYNC)이 인증 필터에 막히지 않도록 permitAll() 설정을 추가

- `SseManager`: `onTimeout` 이벤트 발생 시 `emitter.complete()`를 명시적으로 호출하여 서블릿이 이를 '처리되지 않은 예외'로 판단하지 않도록 수정

- `GlobalExceptionHandler`: 만약 `AsyncRequestTimeoutException`이 발생하더라도 이미 닫힌 스트림에 JSON 에러 응답을 쓰지 않도록 핸들러를 추가하고 `304 Not Modified`를 반환하도록 처리

### 2. JWT 인증 로직 및 에러 응답 개선 (Auth Refactor)
정상적인 비즈니스 흐름인 '토큰 만료'가 시스템 장애처럼 기록되는 문제를 해결하고, 클라이언트 응답을 구체화함.

- `JwtTokenProvider`: `ExpiredJwtException`(만료) 발생 시 출력되던 스택트레이스와 `ERROR` 로그를 제거하고, `INFO` 레벨 로그로 변경하여 노이즈 최소화

- JwtFilter: 인증 실패 시 무조건 '유효하지 않은 토큰'으로 처리하던 로직을 세분화하여 예외 종류(만료 vs 위조/오류)를 `request attribute`에 저장하도록 변경

- JwtAuthenticationEntryPoint:
  - 방어 코드 추가: `response.isCommitted()` 체크를 추가하여(기존 `jwtFilter`에서 하던 체크를 `EntryPoint`로 이동) SSE 타임아웃 등 이미 응답 헤더가 전송된 상태에서 에러 JSON을 쓰려다 발생하는 서버 에러 방지
  - 응답 표준화: 필터에서 넘겨받은 에러 코드를 확인하여 만료된 경우와 일반 인증 실패를 구분한 `ProblemDetail` 응답 반환

## 📸 테스트 결과
1. SSE 타임아웃 시
- **Before**: ERROR 로그 발생 (AuthorizationDeniedException / AsyncRequestTimeoutException)
- **After**: 에러 로그 없이 정상적으로 연결 종료

2. 토큰 만료 시
- **Before**: ERROR 로그와 긴 스택트레이스 출력
- **After**: `[INFO] JwtTokenProvider : 만료된 JWT 토큰입니다.`