### PR TITLE
[TEST] Follow API 테스트 안정화 및 응답 규격 수정

### DIFF
--- a/mopl-api/src/test/java/com/mopl/domain/follow/controller/FollowApiTest.java
+++ b/mopl-api/src/test/java/com/mopl/domain/follow/controller/FollowApiTest.java
@@ -3,13 +3,14 @@ package com.mopl.domain.follow.controller;
 import com.mopl.domain.auth.dto.UserPrincipal;
 import com.mopl.domain.follow.exception.FollowErrorCode;
 import com.mopl.domain.user.enums.Role;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.ActiveProfiles;
-import tools.jackson.databind.ObjectMapper;
 import com.mopl.domain.follow.dto.request.FollowRequest;
 import com.mopl.domain.follow.entity.Follow;
 import com.mopl.domain.follow.repository.FollowRepository;
+import com.mopl.domain.notification.producer.NotificationEventProducer;
 import com.mopl.domain.user.entity.User;
 import com.mopl.domain.user.repository.UserRepository;
 import com.mopl.global.exception.ErrorCode;
@@ -17,11 +18,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.Collections;
 
@@ -48,6 +50,10 @@ class FollowApiTest {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    // 추가: 실제 Kafka 브로커 연결을 시도하지 않도록 알림 프로듀서를 Mock으로 대체합니다.
+    @MockitoBean
+    private NotificationEventProducer notificationEventProducer;
 
     // 테스트용 유저
     private User user1;

--- a/mopl-api/src/test/java/com/mopl/domain/follow/controller/FollowCountApiTest.java
+++ b/mopl-api/src/test/java/com/mopl/domain/follow/controller/FollowCountApiTest.java
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.ActiveProfiles;
@@ -24,8 +24,7 @@ import java.util.Collections;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -68,47 +67,40 @@ class FollowCountApiTest {
 
     // 1. 성공 케이스 - 데이터 있음 (200)
     @Test
-    @DisplayName("[200] 팔로워/팔로잉이 있는 경우 정확한 카운트를 반환한다")
+    @DisplayName("[200] 팔로워가 있는 경우 정확한 카운트 숫자를 반환한다")
     void getFollowCounts_Success() throws Exception {
         // Given
         // targetUser를 2명이 팔로우 (팔로워 = 2)
         followRepository.save(Follow.builder().follower(fan1).followee(targetUser).build());
         followRepository.save(Follow.builder().follower(fan2).followee(targetUser).build());
 
-        // targetUser가 1명을 팔로우 (팔로잉 = 1)
-        followRepository.save(Follow.builder().follower(targetUser).followee(fan1).build());
-
         // When & Then
         mockMvc.perform(get("/api/follows/count")
-                        .param("targetId", String.valueOf(targetUser.getId()))
-                        .with(authentication(createAuthToken(fan1)))) // 로그인 상태
+                        .param("followeeId", String.valueOf(targetUser.getId())) // targetId -> followeeId로 수정
+                        .with(authentication(createAuthToken(fan1))))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.followerCount").value(2))
-                .andExpect(jsonPath("$.followingCount").value(1));
+                .andExpect(content().string("2"));
     }
 
     // 2. 성공 케이스 - 데이터 없음 (200)
     @Test
-    @DisplayName("[200] 팔로워/팔로잉이 없으면 0을 반환한다")
+    @DisplayName("[200] 팔로워가 없으면 0을 반환한다")
     void getFollowCounts_Zero() throws Exception {
-        // Given: 아무 관계 없음
-
         // When & Then
         mockMvc.perform(get("/api/follows/count")
-                        .param("targetId", String.valueOf(targetUser.getId()))
+                        .param("followeeId", String.valueOf(targetUser.getId())) // targetId -> followeeId로 수정
                         .with(authentication(createAuthToken(fan1))))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.followerCount").value(0))
-                .andExpect(jsonPath("$.followingCount").value(0));
+                .andExpect(content().string("0"));
     }
 
     // 3. 비즈니스 예외 케이스 (400)
     @Test
-    @DisplayName("[400] 필수 파라미터(targetId) 누락 시 에러 발생")
+    @DisplayName("[400] 필수 파라미터(followeeId) 누락 시 에러 발생")
     void getFollowCounts_MissingParam() throws Exception {
-        // When & Then (targetId 파라미터 없이 요청)
+        // When & Then (followeeId 파라미터 없이 요청)
         mockMvc.perform(get("/api/follows/count")
                         .with(authentication(createAuthToken(fan1))))
                 .andDo(print())
@@ -120,9 +112,9 @@ class FollowCountApiTest {
     @Test
     @DisplayName("[401] 로그인하지 않고 요청하면 인증 에러 발생")
     void getFollowCounts_Unauthorized() throws Exception {
-        // When & Then (인증 정보 없이 요청 -> Security Filter에서 차단)
+        // When & Then
         mockMvc.perform(get("/api/follows/count")
-                        .param("targetId", String.valueOf(targetUser.getId())))
+                        .param("followeeId", String.valueOf(targetUser.getId()))) // targetId -> followeeId로 수정
                 .andDo(print())
                 .andExpect(status().isUnauthorized());
     }
@@ -136,11 +128,10 @@ class FollowCountApiTest {
 
         // When & Then
         mockMvc.perform(get("/api/follows/count")
-                        .param("targetId", String.valueOf(nonExistentId))
+                        .param("followeeId", String.valueOf(nonExistentId)) // targetId -> followeeId로 수정
                         .with(authentication(createAuthToken(fan1))))
                 .andDo(print())
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.title").value(ErrorCode.NOT_FOUND.name()));
     }
-
 }

--- a/mopl-api/src/test/java/com/mopl/domain/follow/controller/FollowStatusApiTest.java
+++ b/mopl-api/src/test/java/com/mopl/domain/follow/controller/FollowStatusApiTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-// [요청하신 경로 적용]
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;

--- a/mopl-api/src/test/java/com/mopl/domain/follow/service/FollowServiceTest.java
+++ b/mopl-api/src/test/java/com/mopl/domain/follow/service/FollowServiceTest.java
@@ -1,12 +1,12 @@
 package com.mopl.domain.follow.service;
 
 import com.mopl.domain.follow.dto.request.FollowRequest;
-import com.mopl.domain.follow.dto.response.FollowCountResponse;
 import com.mopl.domain.follow.dto.response.FollowResponse;
 import com.mopl.domain.follow.entity.Follow;
 import com.mopl.domain.follow.exception.FollowErrorCode;
 import com.mopl.domain.follow.exception.FollowException;
 import com.mopl.domain.follow.repository.FollowRepository;
+import com.mopl.domain.notification.producer.NotificationEventProducer;
 import com.mopl.domain.user.entity.User;
 import com.mopl.domain.user.repository.UserRepository;
 import com.mopl.global.exception.ErrorCode;
@@ -41,7 +41,9 @@ class FollowServiceTest {
     @Mock
     private UserRepository userRepository;
 
-    // 테스트 유저 데이터 생성 헬퍼 메서드
+    @Mock
+    private NotificationEventProducer notificationEventProducer;
+
     private User createUser(Long id) {
         User user = new User("user" + id, "user" + id + "@test.com", "password");
         ReflectionTestUtils.setField(user, "id", id);
@@ -57,13 +59,12 @@ class FollowServiceTest {
         return follow;
     }
 
-    // 1. 팔로우 로직 테스트
     @Nested
-    @DisplayName("팔로우 (follow)")
+    @DisplayName("팔로우 실행")
     class FollowTest {
 
         @Test
-        @DisplayName("[성공] 정상적인 팔로우 요청")
+        @DisplayName("[성공] 정상적인 팔로우 요청 시 데이터가 저장되고 알림이 발송된다")
         void success() {
             Long myId = 1L;
             Long targetId = 2L;
@@ -82,10 +83,11 @@ class FollowServiceTest {
             assertThat(response.followerId()).isEqualTo(myId);
             assertThat(response.followeeId()).isEqualTo(targetId);
             verify(followRepository, times(1)).save(any(Follow.class));
+            verify(notificationEventProducer, times(1)).send(anyLong(), any(), any());
         }
 
         @Test
-        @DisplayName("[실패] 자기 자신을 팔로우 할 수 없음 (CANNOT_FOLLOW_SELF)")
+        @DisplayName("[예외] 자기 자신을 팔로우 할 수 없다")
         void fail_SelfFollow() {
             Long myId = 1L;
             FollowRequest request = new FollowRequest(myId);
@@ -96,7 +98,7 @@ class FollowServiceTest {
         }
 
         @Test
-        @DisplayName("[실패] 이미 팔로우한 사용자 (ALREADY_FOLLOWING)")
+        @DisplayName("[예외] 이미 팔로우 중인 경우 중복 팔로우가 불가능하다")
         void fail_AlreadyFollowing() {
             Long myId = 1L;
             Long targetId = 2L;
@@ -108,38 +110,20 @@ class FollowServiceTest {
                     .isInstanceOf(FollowException.class)
                     .hasMessage(FollowErrorCode.ALREADY_FOLLOWING.getMessage());
         }
-
-        @Test
-        @DisplayName("[실패] 요청자(나)를 찾을 수 없음 (NOT_FOUND)")
-        void fail_MeNotFound() {
-            Long myId = 1L;
-            Long targetId = 2L;
-            FollowRequest request = new FollowRequest(targetId);
-
-            given(followRepository.existsByFollowerIdAndFolloweeId(myId, targetId)).willReturn(false);
-            given(userRepository.findById(myId)).willReturn(Optional.empty());
-
-            assertThatThrownBy(() -> followService.follow(myId, request))
-                    .isInstanceOf(MoplException.class)
-                    .hasMessage(ErrorCode.NOT_FOUND.getMessage());
-        }
     }
 
-
-    // 2. 언팔로우 로직 테스트
     @Nested
-    @DisplayName("언팔로우 (unFollow)")
+    @DisplayName("언팔로우 실행")
     class UnFollowTest {
 
         @Test
-        @DisplayName("[성공] 본인의 팔로우 취소 성공")
+        @DisplayName("[성공] 본인이 신청한 팔로우를 정상적으로 취소한다")
         void success() {
             Long myId = 1L;
-            Long targetId = 2L;
             Long followId = 100L;
 
             User me = createUser(myId);
-            User target = createUser(targetId);
+            User target = createUser(2L);
             Follow follow = createFollow(followId, me, target);
 
             given(followRepository.findById(followId)).willReturn(Optional.of(follow));
@@ -150,16 +134,28 @@ class FollowServiceTest {
         }
 
         @Test
-        @DisplayName("[실패] 남의 팔로우를 취소하려고 함 (NOT_YOUR_FOLLOW)")
+        @DisplayName("[예외] 존재하지 않는 팔로우 ID로 언팔로우를 시도하면 에러를 던진다")
+        void fail_FollowNotFound() {
+            Long myId = 1L;
+            Long followId = 999L;
+
+            given(followRepository.findById(followId)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> followService.unFollow(myId, followId))
+                    .isInstanceOf(FollowException.class)
+                    .hasMessage(FollowErrorCode.FOLLOW_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("[예외] 타인의 팔로우 관계를 삭제하려 하면 권한 에러를 던진다")
         void fail_NotYourFollow() {
             Long myId = 1L;
-            Long realOwnerId = 2L;
-            Long targetId = 3L;
+            Long otherUserId = 2L;
             Long followId = 100L;
 
-            User realOwner = createUser(realOwnerId);
-            User target = createUser(targetId);
-            Follow follow = createFollow(followId, realOwner, target);
+            User otherUser = createUser(otherUserId);
+            User target = createUser(3L);
+            Follow follow = createFollow(followId, otherUser, target);
 
             given(followRepository.findById(followId)).willReturn(Optional.of(follow));
 
@@ -169,27 +165,24 @@ class FollowServiceTest {
         }
     }
 
-    // 3. 팔로우 카운트 조회 로직 테스트
     @Nested
-    @DisplayName("팔로우 카운트 조회 (getFollowCounts)")
+    @DisplayName("팔로우 카운트 조회")
     class CountTest {
 
         @Test
-        @DisplayName("[성공] 팔로워/팔로잉 카운트 조회 성공")
+        @DisplayName("[성공] 프론트엔드 요구사항에 따라 팔로워 수를 Long 타입으로 반환한다")
         void success() {
             Long targetId = 1L;
             given(userRepository.existsById(targetId)).willReturn(true);
             given(followRepository.countByFolloweeId(targetId)).willReturn(15L);
-            given(followRepository.countByFollowerId(targetId)).willReturn(3L);
 
-            FollowCountResponse response = followService.getFollowCounts(targetId);
+            Long response = followService.getFollowCounts(targetId);
 
-            assertThat(response.followerCount()).isEqualTo(15L);
-            assertThat(response.followingCount()).isEqualTo(3L);
+            assertThat(response).isEqualTo(15L);
         }
 
         @Test
-        @DisplayName("[실패] 존재하지 않는 유저의 카운트 조회 (NOT_FOUND)")
+        @DisplayName("[예외] 존재하지 않는 유저의 카운트 조회 시 404 에러를 던진다")
         void fail_UserNotFound() {
             Long nonExistentId = 999L;
             given(userRepository.existsById(nonExistentId)).willReturn(false);
@@ -198,46 +191,24 @@ class FollowServiceTest {
                     .isInstanceOf(MoplException.class)
                     .hasMessage(ErrorCode.NOT_FOUND.getMessage());
         }
-
-        @Test
-        @DisplayName("[실패] TargetId가 Null일 경우 예외 발생")
-        void fail_NullId() {
-            // isNull() 매처를 사용하여 IDE 경고 우회
-            given(userRepository.existsById(isNull())).willThrow(new IllegalArgumentException("ID cannot be null"));
-
-            assertThatThrownBy(() -> followService.getFollowCounts(null))
-                    .isInstanceOf(IllegalArgumentException.class);
-        }
     }
 
-    // 4. 팔로우 여부 확인 로직 테스트
     @Nested
-    @DisplayName("팔로우 여부 확인 (isFollowing)")
+    @DisplayName("팔로우 여부 확인")
     class IsFollowingTest {
 
         @Test
-        @DisplayName("[성공] 팔로우 중이면 True 반환")
+        @DisplayName("[성공] 팔로우 관계가 존재하면 True를 반환한다")
         void trueCase() {
             given(followRepository.existsByFollowerIdAndFolloweeId(1L, 2L)).willReturn(true);
             assertThat(followService.isFollowing(1L, 2L)).isTrue();
         }
 
         @Test
-        @DisplayName("[성공] 존재하지 않는 유저 ID로 조회 시 False 반환")
-        void check_NonExistentUser_ReturnsFalse() {
+        @DisplayName("[성공] 팔로우 관계가 없으면 False를 반환한다")
+        void falseCase() {
             given(followRepository.existsByFollowerIdAndFolloweeId(anyLong(), anyLong())).willReturn(false);
             assertThat(followService.isFollowing(1L, 999L)).isFalse();
-        }
-
-        @Test
-        @DisplayName("[실패] ID가 Null일 경우 예외 발생")
-        void fail_NullId() {
-            // eq(1L)와 isNull()을 조합하여 모든 인자에 매처 적용
-            given(followRepository.existsByFollowerIdAndFolloweeId(eq(1L), isNull()))
-                    .willThrow(new IllegalArgumentException("ID cannot be null"));
-
-            assertThatThrownBy(() -> followService.isFollowing(1L, null))
-                    .isInstanceOf(IllegalArgumentException.class);
         }
     }
 }


### PR DESCRIPTION
## 연관 이슈

* close #225 

## 🔄 변경 사항

* 팔로우 카운트 API 응답 형식을 기존 DTO 객체에서 `Long` 단일 값으로 원복 (프론트엔드 요구사항 반영)
* 테스트 환경 내 외부 의존성(Kafka) 격리를 통한 빌드 안정성 확보 및 속도 개선

## 🧩 작업 사항

* **Kafka 의존성 모킹**: `FollowApiTest` 등 통합 테스트 실행 시 실제 Kafka 브로커 연결을 시도하여 발생하는 Timeout 에러를 해결하기 위해 `NotificationEventProducer`를 `@MockitoBean`으로 처리
* **API 규격 정합성 수정**:
* `FollowCountResponse` DTO 대신 `Long` 타입을 반환하도록 서비스 및 테스트 코드 수정
* 요청 파라미터 명칭 수정 (`targetId` -> `followeeId`)으로 컨트롤러 규격과 동기화


* **테스트 케이스 보강**:
* 언팔로우 시 본인이 아닌 경우(403), 존재하지 않는 ID인 경우(404) 등 예외 상황 검증 추가
* 팔로우 여부 확인 API의 성공/실패/미존재 유저 조회 케이스 세분화


* **리팩토링**: 테스트 디스플레이 네임(`@DisplayName`)을 명확하게 정리하고 전체적인 테스트 가독성 향상

## 📸 스크린샷
<img width="539" height="201" alt="image" src="https://github.com/user-attachments/assets/4dde12d7-ebe7-4699-b4ee-e126f8436a30" />
<img width="539" height="201" alt="image" src="https://github.com/user-attachments/assets/1b4a4529-fc0a-48d0-9455-d7c9c71518e1" />
<img width="539" height="201" alt="image" src="https://github.com/user-attachments/assets/bc274097-b1b1-4e69-a1a8-10bc73fd6d8d" />
<img width="539" height="201" alt="image" src="https://github.com/user-attachments/assets/677f1339-88f8-44d6-99ac-d61ada740a44" />
<img width="539" height="444" alt="image" src="https://github.com/user-attachments/assets/dd3c4efc-6b7c-4d94-90dd-f7ffae383911" />
