### PR TITLE
[Refactor] WatchingSession API 구현 및 성능 최적화

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/watching/controller/WatchingSessionController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/watching/controller/WatchingSessionController.java
@@ -15,14 +15,18 @@ public class WatchingSessionController implements WatchingSessionControllerDocs 
 
     private final WatchingSessionService watchingSessionService;
 
-    // 특정 사용자의 시청 세션 단건 조회
     @Override
     public ResponseEntity<WatchingSessionUserResponse> getWatchingSession(Long watcherId) {
         WatchingSessionUserResponse response = watchingSessionService.getWatchingSession(watcherId);
+
+        // 시청 중인 세션이 없을 경우 204 No Content 반환
+        if (response == null) {
+            return ResponseEntity.noContent().build();
+        }
+
         return ResponseEntity.ok(response);
     }
 
-    // 특정 콘텐츠의 시청 세션 목록 조회 (커서 페이지네이션)
     @Override
     public ResponseEntity<WatchingSessionContentListResponse> getWatchingSessionsByContent(
             Long contentId,
@@ -33,15 +37,21 @@ public class WatchingSessionController implements WatchingSessionControllerDocs 
             String sortBy,
             SortDirection sortDirection
     ) {
+        // null 방어 및 기본값 설정 (Docs 인터페이스의 defaultValue와 일치)
+        int finalLimit = (limit != null) ? limit : 10;
+        String finalSortBy = (sortBy != null) ? sortBy : "createdAt";
+        SortDirection finalSortDirection = (sortDirection != null) ? sortDirection : SortDirection.DESCENDING;
+
         WatchingSessionContentListResponse response = watchingSessionService.getWatchingSessionsByContent(
                 contentId,
                 watcherNameLike,
                 cursor,
                 idAfter,
-                limit,
-                sortBy,
-                sortDirection
+                finalLimit,
+                finalSortBy,
+                finalSortDirection
         );
+
         return ResponseEntity.ok(response);
     }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/watching/controller/docs/WatchingSessionControllerDocs.java
+++ b/mopl-api/src/main/java/com/mopl/domain/watching/controller/docs/WatchingSessionControllerDocs.java
@@ -20,39 +20,51 @@ public interface WatchingSessionControllerDocs {
 
     @Operation(
             summary = "특정 사용자의 시청 세션 조회",
-            description = "특정 사용자가 현재 실시간으로 시청 중인 콘텐츠 정보를 조회합니다. 시청 중인 정보가 없을 경우 null을 반환합니다."
+            description = "특정 사용자가 현재 실시간으로 시청 중인 콘텐츠 정보를 조회합니다. 시청 중이지 않을 경우 응답 바디가 비어있을 수 있습니다."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공 (시청 중이지 않을 경우 응답 바디가 비어있을 수 있음)"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터 (ID 형식 오류 등)"),
-            @ApiResponse(responseCode = "401", description = "인증 오류 (로그인 필요)"),
-            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음"),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "204", description = "시청 중인 세션 없음"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터"),
+            @ApiResponse(responseCode = "401", description = "인증 오류"),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
     })
     @GetMapping("/users/{watcherId}/watching-sessions")
     ResponseEntity<WatchingSessionUserResponse> getWatchingSession(
-            @Parameter(description = "조회할 사용자 ID", required = true)
+            @Parameter(description = "조회할 사용자 ID (Long)", required = true, example = "123")
             @PathVariable Long watcherId
     );
 
     @Operation(
             summary = "특정 콘텐츠의 시청 세션 목록 조회",
-            description = "특정 콘텐츠를 현재 시청 중인 사용자들의 목록을 커서 기반 페이지네이션으로 조회합니다."
+            description = "특정 콘텐츠를 현재 시청 중인 사용자 목록을 커서 기반 페이지네이션으로 조회합니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터 (ID 형식 오류 등)"),
-            @ApiResponse(responseCode = "401", description = "인증 오류 (로그인 필요)"),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터"),
+            @ApiResponse(responseCode = "401", description = "인증 오류")
     })
     @GetMapping("/contents/{contentId}/watching-sessions")
     ResponseEntity<WatchingSessionContentListResponse> getWatchingSessionsByContent(
-            @Parameter(description = "콘텐츠 ID", required = true) @PathVariable Long contentId,
-            @Parameter(description = "시청자 이름 검색 (부분 일치)") @RequestParam(required = false) String watcherNameLike,
-            @Parameter(description = "페이지네이션 커서 (전페이지 마지막 데이터의 createdAt)") @RequestParam(required = false) String cursor,
-            @Parameter(description = "보조 커서 (전페이지 마지막 데이터의 watcherId)") @RequestParam(required = false) Long idAfter,
-            @Parameter(description = "조회 개수", required = true) @RequestParam(defaultValue = "10") Integer limit,
-            @Parameter(description = "정렬 기준", required = true) @RequestParam(defaultValue = "createdAt") String sortBy,
-            @Parameter(description = "정렬 방향", required = true) @RequestParam(defaultValue = "DESCENDING") SortDirection sortDirection
+            @Parameter(description = "콘텐츠 ID (Long)", required = true, example = "456")
+            @PathVariable Long contentId,
+
+            @Parameter(description = "시청자 이름 검색 (부분 일치)")
+            @RequestParam(required = false) String watcherNameLike,
+
+            @Parameter(description = "페이지네이션 커서 (전페이지 마지막 데이터의 createdAt, ISO-8601 형식)", example = "2026-01-19T06:46:27.803")
+            @RequestParam(required = false) String cursor,
+
+            @Parameter(description = "보조 커서 (전페이지 마지막 데이터의 watcherId)", example = "123")
+            @RequestParam(required = false) Long idAfter,
+
+            @Parameter(description = "조회 개수", required = true, example = "10")
+            @RequestParam(defaultValue = "10") Integer limit,
+
+            @Parameter(description = "정렬 기준 (현재 createdAt만 지원)")
+            @RequestParam(defaultValue = "createdAt") String sortBy,
+
+            @Parameter(description = "정렬 방향", required = true)
+            @RequestParam(defaultValue = "DESCENDING") SortDirection sortDirection
     );
 }

--- a/mopl-api/src/main/java/com/mopl/domain/watching/dto/response/WatchingSessionContentListResponse.java
+++ b/mopl-api/src/main/java/com/mopl/domain/watching/dto/response/WatchingSessionContentListResponse.java
@@ -1,9 +1,12 @@
 package com.mopl.domain.watching.dto.response;
 
 import com.mopl.global.enums.SortDirection;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
+import java.util.Collections;
 import java.util.List;
 
 @Builder
@@ -15,8 +18,9 @@ public record WatchingSessionContentListResponse(
         @Schema(description = "다음 페이지 조회를 위한 커서 (createdAt 기반)")
         String nextCursor,
 
+        @JsonSerialize(using = ToStringSerializer.class) // JS 정밀도 문제 방지 추가
         @Schema(description = "다음 페이지 조회를 위한 보조 커서 (watcherId 기반)")
-        String nextIdAfter,
+        Long nextIdAfter,
 
         @Schema(description = "다음 페이지 존재 여부")
         boolean hasNext,
@@ -28,6 +32,17 @@ public record WatchingSessionContentListResponse(
         String sortBy,
 
         @Schema(description = "정렬 방향 (ASCENDING, DESCENDING)")
-        SortDirection sortDirection // Enum 타입 적용
+        SortDirection sortDirection
 ) {
+    public static WatchingSessionContentListResponse empty(String sortBy, SortDirection sortDirection) {
+        return WatchingSessionContentListResponse.builder()
+                .data(Collections.emptyList())
+                .nextCursor(null)
+                .nextIdAfter(null)
+                .hasNext(false)
+                .totalCount(0)
+                .sortBy(sortBy)
+                .sortDirection(sortDirection)
+                .build();
+    }
 }

--- a/mopl-api/src/main/java/com/mopl/domain/watching/dto/response/WatchingSessionUserResponse.java
+++ b/mopl-api/src/main/java/com/mopl/domain/watching/dto/response/WatchingSessionUserResponse.java
@@ -5,8 +5,8 @@ import com.mopl.domain.user.dto.response.UserSummaryDto;
 import com.mopl.domain.watching.entity.WatchingSession;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
-import tools.jackson.databind.annotation.JsonSerialize;
-import tools.jackson.databind.ser.std.ToStringSerializer;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 
 import java.time.LocalDateTime;
 
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 public record WatchingSessionUserResponse(
         @JsonSerialize(using = ToStringSerializer.class)
         @Schema(description = "세션 ID (watcherId와 동일)")
-        String id,
+        Long id,
 
         @Schema(description = "세션 생성 일시")
         LocalDateTime createdAt,
@@ -27,8 +27,10 @@ public record WatchingSessionUserResponse(
         ContentDto content
 ) {
     public static WatchingSessionUserResponse of(WatchingSession session, UserSummaryDto watcher, ContentDto content) {
+        if (session == null) return null;
+
         return WatchingSessionUserResponse.builder()
-                .id(String.valueOf(session.getId()))
+                .id(session.getId()) // 타입 변경에 따른 수정
                 .createdAt(session.getCreatedAt())
                 .watcher(watcher)
                 .content(content)

--- a/mopl-api/src/main/java/com/mopl/domain/watching/exception/WatchingErrorCode.java
+++ b/mopl-api/src/main/java/com/mopl/domain/watching/exception/WatchingErrorCode.java
@@ -10,14 +10,16 @@ import org.springframework.http.HttpStatus;
 public enum WatchingErrorCode implements DomainErrorCode {
 
     // 특정 사용자의 시청 세션 단건 조회 예외 코드
-    INVALID_WATCHING_REQUEST("W001", "잘못된 시청 세션 요청입니다.", HttpStatus.BAD_REQUEST), // 400
-    WATCHING_SESSION_NOT_FOUND("W002", "시청 세션이 존재하지 않거나 이미 종료되었습니다.", HttpStatus.NOT_FOUND), // 404
-    USER_NOT_FOUND("W003", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND), // 404
-    CONTENT_NOT_FOUND("W004", "시청 중인 콘텐츠 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND), // 404
+    INVALID_WATCHING_REQUEST("W001", "잘못된 시청 세션 조회 요청입니다.", HttpStatus.BAD_REQUEST),
+    USER_NOT_FOUND("W002", "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
+    CONTENT_NOT_FOUND("W003", "콘텐츠 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
     // 특정 콘텐츠의 시청 세션 목록 조회 예외 코드
-    INVALID_CURSOR("W005", "유효하지 않은 커서 값입니다.", HttpStatus.BAD_REQUEST), // 400
-    INVALID_PAGINATION_LIMIT("W006", "페이지 요청 개수는 1개 이상 100개 이하이어야 합니다.", HttpStatus.BAD_REQUEST) // 400
+    INVALID_CURSOR("W004", "유효하지 않은 커서 값입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_PAGINATION_LIMIT("W005", "페이지 요청 개수가 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+
+    // 세션 강제 조작 방지 등 추후 확장용
+    WATCHING_SESSION_EXPIRED("W006", "시청 세션이 만료되었습니다.", HttpStatus.GONE) // 410 or 404
     ;
 
     private final String errorCode;

--- a/mopl-api/src/main/java/com/mopl/domain/watching/service/WatchingSessionService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/watching/service/WatchingSessionService.java
@@ -30,124 +30,71 @@ public class WatchingSessionService {
     private final UserRepository userRepository;
     private final ContentRepository contentRepository;
 
-    // 특정 사용자의 시청 세션 단건 조회
+    /**
+     * 특정 사용자의 시청 세션 단건 조회
+     * @return 시청 중인 세션 정보 (없을 경우 null)
+     */
     public WatchingSessionUserResponse getWatchingSession(Long watcherId) {
         if (watcherId == null || watcherId < 0) {
             throw new WatchingException(WatchingErrorCode.INVALID_WATCHING_REQUEST);
         }
 
-        if (!userRepository.existsById(watcherId)) {
-            throw new WatchingException(WatchingErrorCode.USER_NOT_FOUND);
-        }
-
+        // 1. Redis에서 세션 존재 여부 확인
         return watchingSessionRepository.findById(watcherId)
-                .map(this::convertToResponse)
-                .orElse(null);
+                .map(session -> {
+                    // 2. [최적화] 유저 정보 조회
+                    User user = userRepository.findById(watcherId)
+                            .orElseThrow(() -> new WatchingException(WatchingErrorCode.USER_NOT_FOUND));
+
+                    // 3. [최적화] Fetch Join을 사용하여 태그 정보까지 한 번에 조회 (N+1 방지)
+                    Content content = contentRepository.findByIdWithTags(session.getContentId())
+                            .orElseThrow(() -> new WatchingException(WatchingErrorCode.CONTENT_NOT_FOUND));
+
+                    return convertToResponse(session, user, content);
+                })
+                .orElse(null); // 시청 중이지 않으면 null 반환 (Controller에서 204 대응)
     }
 
-    // 시청 세션 단건 변환 (개별 조회용)
-    private WatchingSessionUserResponse convertToResponse(WatchingSession session) {
-        User user = userRepository.findById(session.getId())
-                .orElseThrow(() -> new WatchingException(WatchingErrorCode.USER_NOT_FOUND));
-
-        Content content = contentRepository.findById(session.getContentId())
-                .orElseThrow(() -> new WatchingException(WatchingErrorCode.CONTENT_NOT_FOUND));
-
-        return convertToResponse(session, user, content);
-    }
-
-    // 시청 세션 엔티티와 RDB 데이터를 결합하여 응답 DTO로 변환
-    private WatchingSessionUserResponse convertToResponse(WatchingSession session, User user, Content content) {
-        UserSummaryDto watcherDto = new UserSummaryDto(
-                user.getId(),
-                user.getName(),
-                user.getProfileImageUrl()
-        );
-
-        List<String> tags = content.getContentTags().stream()
-                .map(contentTag -> contentTag.getTag().getTag())
-                .toList();
-
-        ContentDto contentDto = new ContentDto(
-                String.valueOf(content.getId()),
-                content.getContentType(),
-                content.getTitle(),
-                content.getDescription(),
-                content.getThumbnailUrl(),
-                tags,
-                content.getAverageRating(),
-                content.getReviewCount(),
-                0
-        );
-
-        return WatchingSessionUserResponse.of(session, watcherDto, contentDto);
-    }
-
-    // 특정 콘텐츠의 시청 세션 목록 조회 (커서 페이지네이션 적용)
+    /**
+     * 특정 콘텐츠의 시청 세션 목록 조회 (커서 페이지네이션 적용)
+     */
     public WatchingSessionContentListResponse getWatchingSessionsByContent(
             Long contentId, String watcherNameLike, String cursor,
             Long idAfter, Integer limit, String sortBy, SortDirection sortDirection
     ) {
-        // 1. 페이지 크기 유효성 검사
-        if (limit == null || limit <= 0) {
-            throw new WatchingException(WatchingErrorCode.INVALID_PAGINATION_LIMIT);
-        }
-
-        // 2. Redis에서 해당 콘텐츠를 시청 중인 모든 세션 조회 (Secondary Index 활용)
+        // 1. Redis에서 해당 콘텐츠의 시청 세션 모두 조회
         List<WatchingSession> allSessions = watchingSessionRepository.findAllByContentId(contentId);
         if (allSessions.isEmpty()) {
             return createEmptyResponse(sortBy, sortDirection);
         }
 
-        // 3. 세션에 포함된 유저 및 콘텐츠 ID를 추출하여 DB 쿼리 최소화
-        List<Long> watcherIds = allSessions.stream().map(WatchingSession::getId).toList();
-        List<Long> contentIds = allSessions.stream().map(WatchingSession::getContentId).distinct().toList();
+        // 2. [최적화] 콘텐츠 정보는 단 1회만 조회 (Fetch Join 적용)
+        Content content = contentRepository.findByIdWithTags(contentId)
+                .orElseThrow(() -> new WatchingException(WatchingErrorCode.CONTENT_NOT_FOUND));
 
-        // 4. 조회된 엔티티를 Map으로 변환
+        // 3. [최적화] N+1 방지를 위해 시청자 정보를 In-clause로 일괄 조회
+        List<Long> watcherIds = allSessions.stream().map(WatchingSession::getId).toList();
         Map<Long, User> userMap = userRepository.findAllById(watcherIds).stream()
                 .collect(Collectors.toMap(User::getId, user -> user));
-        Map<Long, Content> contentMap = contentRepository.findAllById(contentIds).stream()
-                .collect(Collectors.toMap(Content::getId, content -> content));
 
-        // 5. 엔티티 결합, 필터링 및 전체 정렬 수행
+        // 4. 필터링 및 정렬 (Memory Level)
         List<WatchingSessionUserResponse> allResponses = allSessions.stream()
-                .map(session -> {
-                    User user = userMap.get(session.getId());
-                    Content content = contentMap.get(session.getContentId());
-                    if (user == null || content == null) return null; // 데이터 불일치 시 제외
-                    return convertToResponse(session, user, content);
-                })
-                .filter(Objects::nonNull)
-                // 이름 부분 일치 검색 필터링
+                .filter(session -> userMap.containsKey(session.getId()))
+                .map(session -> convertToResponse(session, userMap.get(session.getId()), content))
                 .filter(res -> watcherNameLike == null || res.watcher().name().contains(watcherNameLike))
-                // 커서 기반 정렬 (createdAt 우선, 동일 시간일 경우 id 기준 정렬)
-                .sorted((o1, o2) -> {
-                    int compare = sortDirection == SortDirection.ASCENDING
-                            ? o1.createdAt().compareTo(o2.createdAt())
-                            : o2.createdAt().compareTo(o1.createdAt());
-                    return (compare != 0) ? compare : o1.id().compareTo(o2.id());
-                })
+                .sorted(getComparator(sortDirection))
                 .toList();
 
-        // 6. 커서 위치 탐색 및 페이지 슬라이싱
-        int startIndex = 0;
-        if (cursor != null && idAfter != null) {
-            try {
-                LocalDateTime cursorTime = LocalDateTime.parse(cursor);
-                startIndex = findStartIndex(allResponses, cursorTime, idAfter, sortDirection);
-            } catch (Exception e) {
-                throw new WatchingException(WatchingErrorCode.INVALID_CURSOR);
-            }
-        }
-
+        // 5. 커서 기반 슬라이싱 연산
+        int startIndex = findStartIndex(allResponses, cursor, idAfter, sortDirection);
         int totalSize = allResponses.size();
         int endIndex = Math.min(startIndex + limit, totalSize);
         List<WatchingSessionUserResponse> pagedData = allResponses.subList(startIndex, endIndex);
 
-        // 7. 다음 페이지 존재 여부 확인 및 다음 커서 정보 생성
+        // 6. 다음 페이지 정보 생성
         boolean hasNext = endIndex < totalSize;
         String nextCursor = null;
-        String nextIdAfter = null;
+        Long nextIdAfter = null;
 
         if (hasNext && !pagedData.isEmpty()) {
             WatchingSessionUserResponse lastItem = pagedData.get(pagedData.size() - 1);
@@ -166,34 +113,67 @@ public class WatchingSessionService {
                 .build();
     }
 
-    // 커서(시간, ID) 값을 기준으로 다음 페이지가 시작될 인덱스를 검색
-    private int findStartIndex(List<WatchingSessionUserResponse> list, LocalDateTime cursorTime, Long idAfter, SortDirection direction) {
-        for (int i = 0; i < list.size(); i++) {
-            WatchingSessionUserResponse item = list.get(i);
-            boolean isAfter;
+    /** 커서(시간, ID) 값을 기준으로 슬라이싱 시작 인덱스 탐색 */
+    private int findStartIndex(List<WatchingSessionUserResponse> list, String cursor, Long idAfter, SortDirection direction) {
+        if (cursor == null || idAfter == null) return 0;
 
-            // 정렬 방향에 따라 커서보다 '뒤'에 있는 데이터인지 판단
-            if (direction == SortDirection.ASCENDING) {
-                isAfter = item.createdAt().isAfter(cursorTime) ||
-                        (item.createdAt().isEqual(cursorTime) && Long.parseLong(item.id()) > idAfter);
-            } else {
-                isAfter = item.createdAt().isBefore(cursorTime) ||
-                        (item.createdAt().isEqual(cursorTime) && Long.parseLong(item.id()) < idAfter);
+        try {
+            LocalDateTime cursorTime = LocalDateTime.parse(cursor);
+            for (int i = 0; i < list.size(); i++) {
+                WatchingSessionUserResponse item = list.get(i);
+                if (direction == SortDirection.ASCENDING) {
+                    if (item.createdAt().isAfter(cursorTime) ||
+                            (item.createdAt().isEqual(cursorTime) && item.id() > idAfter)) return i;
+                } else {
+                    if (item.createdAt().isBefore(cursorTime) ||
+                            (item.createdAt().isEqual(cursorTime) && item.id() < idAfter)) return i;
+                }
             }
-
-            if (isAfter) return i;
+        } catch (Exception e) {
+            throw new WatchingException(WatchingErrorCode.INVALID_CURSOR);
         }
         return list.size();
     }
 
-    // 데이터가 없는 경우를 위한 빈 응답 객체 생성
+    /** 정렬 Comparator (createdAt -> id 순) */
+    private Comparator<WatchingSessionUserResponse> getComparator(SortDirection direction) {
+        return (o1, o2) -> {
+            int compare = (direction == SortDirection.ASCENDING)
+                    ? o1.createdAt().compareTo(o2.createdAt())
+                    : o2.createdAt().compareTo(o1.createdAt());
+            return (compare != 0) ? compare : o1.id().compareTo(o2.id());
+        };
+    }
+
+    /** 엔티티 결합 및 DTO 변환 (패키지 구조 및 필드명 준수) */
+    private WatchingSessionUserResponse convertToResponse(WatchingSession session, User user, Content content) {
+        UserSummaryDto watcherDto = new UserSummaryDto(
+                user.getId(),
+                user.getName(),
+                user.getProfileImageUrl()
+        );
+
+        // Fetch Join 덕분에 추가 쿼리 없이 태그 리스트 생성 가능
+        List<String> tags = content.getContentTags().stream()
+                .map(ct -> ct.getTag().getTag())
+                .toList();
+
+        ContentDto contentDto = new ContentDto(
+                String.valueOf(content.getId()),
+                content.getContentType(),
+                content.getTitle(),
+                content.getDescription(),
+                content.getThumbnailUrl(),
+                tags,
+                content.getAverageRating(),
+                content.getReviewCount(),
+                0
+        );
+
+        return WatchingSessionUserResponse.of(session, watcherDto, contentDto);
+    }
+
     private WatchingSessionContentListResponse createEmptyResponse(String sortBy, SortDirection direction) {
-        return WatchingSessionContentListResponse.builder()
-                .data(Collections.emptyList())
-                .hasNext(false)
-                .totalCount(0)
-                .sortBy(sortBy)
-                .sortDirection(direction)
-                .build();
+        return WatchingSessionContentListResponse.empty(sortBy, direction);
     }
 }

--- a/mopl-core/src/main/java/com/mopl/global/redis/RedisNameSpace.java
+++ b/mopl-core/src/main/java/com/mopl/global/redis/RedisNameSpace.java
@@ -18,7 +18,11 @@ public enum RedisNameSpace {
     WATCHER_COUNT("watcher:", Duration.ofHours(1), false),
 
     // DM 채팅방 접속자 명단 Set
-    DM_VIEWERS("dm-chat:viewer:", Duration.ofHours(2), true),;
+    DM_VIEWERS("dm-chat:viewer:", Duration.ofHours(2), true),
+
+    // 세션용
+    CONTENT_SESSIONS("content:sessions:", Duration.ofHours(1), true),
+    WATCHING_SESSION("watching_session:", Duration.ofHours(1), true);
 
     private final String prefix;
     private final Duration ttl;


### PR DESCRIPTION
## 연관 이슈

* close #172 
* close #174 
* close #204 
* close #223 

## 🔄 변경 사항

* 특정 사용자 및 콘텐츠별 실시간 시청 정보(세션) 조회 API 추가
* Redis 기반의 실시간 데이터 관리 및 RDB 영속 데이터 결합 로직 구현

## 🧩 작업 사항

* **실시간 데이터 관리 (Redis)**:
* `RedisNameSpace`에 시청 세션 전용 네임스페이스 추가 및 TTL 설정
* Redis 데이터를 기반으로 한 실시간 시청 상태 추적 및 조회 로직 구현


* **비즈니스 로직 및 최적화**:
* `getWatchingSession`: 특정 사용자의 시청 정보 단건 조회 기능 구현
* `getWatchingSessionsByContent`: 특정 콘텐츠 시청자 목록 조회 및 **커서 기반 페이지네이션** 적용
* **성능 최적화**: N+1 문제 방지를 위해 `Fetch Join`(태그 정보) 및 `In-clause`(시청자 유저 정보)를 활용한 데이터 일괄 조회 적용


* **데이터 모델링 (DTO)**:
* JSON 직렬화 시 `Long` 타입 ID의 정밀도 손실 방지를 위한 `ToStringSerializer` 적용
* Swagger(@Schema)를 통한 API 응답 규격 상세 문서화

## 📸 스크린샷