### PR TITLE
 [test] 시청 세션 단건/목록 조회 기능 계층별 테스트 구현

### DIFF
--- a/mopl-api/src/test/java/com/mopl/domain/watching/controller/WatchingSessionContentListControllerTest.java
+++ b/mopl-api/src/test/java/com/mopl/domain/watching/controller/WatchingSessionContentListControllerTest.java
@@ -1,164 +1,121 @@
 package com.mopl.domain.watching.controller;
 
-import com.mopl.domain.auth.dto.UserPrincipal;
-import com.mopl.domain.content.entity.Content;
-import com.mopl.domain.content.enums.ContentType;
-import com.mopl.domain.content.repository.ContentRepository;
-import com.mopl.domain.user.entity.User;
-import com.mopl.domain.user.enums.Role;
-import com.mopl.domain.user.repository.UserRepository;
-import com.mopl.domain.watching.entity.WatchingSession;
+import com.mopl.domain.watching.dto.response.WatchingSessionContentListResponse;
+import com.mopl.domain.watching.dto.response.WatchingSessionUserResponse;
 import com.mopl.domain.watching.exception.WatchingErrorCode;
-import com.mopl.domain.watching.repository.WatchingSessionRepository;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import com.mopl.domain.watching.exception.WatchingException;
+import com.mopl.domain.watching.service.WatchingSessionService;
+import com.mopl.global.enums.SortDirection;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.Collections;
+import java.util.List;
 
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@ActiveProfiles("test")
-@SpringBootTest
-@AutoConfigureMockMvc
-@Transactional
+@WebMvcTest(WatchingSessionController.class)
+@AutoConfigureMockMvc(addFilters = false) // 인증 필터를 제외하여 컨트롤러 로직에 집중
+@DisplayName("시청 세션 콘텐츠 리스트 컨트롤러 테스트")
 class WatchingSessionContentListControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
 
-    @Autowired
-    private UserRepository userRepository;
+    @MockitoBean
+    private WatchingSessionService watchingSessionService;
 
-    @Autowired
-    private ContentRepository contentRepository;
+    @Nested
+    @DisplayName("GET /api/contents/{contentId}/watching-sessions")
+    class Describe_getWatchingSessionsByContent {
 
-    @Autowired
-    private WatchingSessionRepository watchingSessionRepository;
+        @Test
+        @WithMockUser
+        @DisplayName("[200] 특정 콘텐츠의 시청 세션 목록을 성공적으로 조회한다")
+        void it_returns_200_ok_with_list() throws Exception {
+            // given
+            Long contentId = 456L;
+            LocalDateTime now = LocalDateTime.now();
 
-    private User savedUser;
-    private Content savedContent;
+            WatchingSessionUserResponse userResponse = WatchingSessionUserResponse.builder()
+                    .id(123L)
+                    .createdAt(now)
+                    .build();
 
-    @BeforeEach
-    void setUp() {
-        savedUser = userRepository.save(new User("테스터", "test@mopl.io", "password"));
-        savedContent = contentRepository.save(new Content(ContentType.movie, "인터스텔라", "우주 영화", "url"));
-    }
+            WatchingSessionContentListResponse listResponse = WatchingSessionContentListResponse.builder()
+                    .data(List.of(userResponse))
+                    .nextCursor(now.toString())
+                    .nextIdAfter(123L)
+                    .hasNext(true)
+                    .totalCount(100L)
+                    .sortBy("createdAt")
+                    .sortDirection(SortDirection.DESCENDING)
+                    .build();
 
-    @AfterEach
-    void tearDown() {
-        watchingSessionRepository.deleteAll();
-    }
+            given(watchingSessionService.getWatchingSessionsByContent(
+                    eq(contentId), anyString(), any(), any(), anyInt(), anyString(), any(SortDirection.class)
+            )).willReturn(listResponse);
 
-    private UsernamePasswordAuthenticationToken createAuthToken(User user) {
-        UserPrincipal principal = new UserPrincipal(user.getId(), user.getEmail(), Role.USER);
-        return new UsernamePasswordAuthenticationToken(
-                principal,
-                null,
-                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
-        );
-    }
+            // when & then
+            mockMvc.perform(get("/api/contents/{contentId}/watching-sessions", contentId)
+                            .param("watcherNameLike", "우디")
+                            .param("limit", "10")
+                            .param("sortBy", "createdAt")
+                            .param("sortDirection", "DESCENDING"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.totalCount").value(100))
+                    .andExpect(jsonPath("$.data[0].id").value("123"))
+                    .andExpect(jsonPath("$.nextIdAfter").value("123"));
+        }
 
-    // 1. 성공 케이스 (200)
-    @Test
-    @DisplayName("[200] 특정 콘텐츠의 시청 세션 목록을 성공적으로 조회한다")
-    void getWatchingSessions_Success() throws Exception {
-        // Given
-        WatchingSession session = WatchingSession.builder()
-                .id(savedUser.getId())
-                .contentId(savedContent.getId())
-                .createdAt(LocalDateTime.now())
-                .build();
-        watchingSessionRepository.save(session);
+        @Test
+        @WithMockUser
+        @DisplayName("[200] 시청자가 없을 경우 빈 목록과 함께 성공 응답을 반환한다")
+        void it_returns_200_ok_with_empty_list() throws Exception {
+            // given
+            Long contentId = 456L;
+            WatchingSessionContentListResponse emptyResponse = WatchingSessionContentListResponse.empty("createdAt", SortDirection.DESCENDING);
 
-        // When & Then
-        mockMvc.perform(get("/api/contents/{contentId}/watching-sessions", savedContent.getId())
-                        .param("limit", "10")
-                        .param("sortDirection", "DESCENDING")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .with(authentication(createAuthToken(savedUser))))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data").isArray())
-                .andExpect(jsonPath("$.data[0].watcher.name").value("테스터"))
-                .andExpect(jsonPath("$.totalCount").value(1));
-    }
+            given(watchingSessionService.getWatchingSessionsByContent(
+                    eq(contentId), any(), any(), any(), anyInt(), anyString(), any(SortDirection.class)
+            )).willReturn(emptyResponse);
 
-    @Test
-    @DisplayName("[200] 이름 필터링(watcherNameLike)을 적용하여 목록을 조회한다")
-    void getWatchingSessions_Filtering_Success() throws Exception {
-        // Given
-        WatchingSession session = WatchingSession.builder()
-                .id(savedUser.getId())
-                .contentId(savedContent.getId())
-                .build();
-        watchingSessionRepository.save(session);
+            // when & then
+            mockMvc.perform(get("/api/contents/{contentId}/watching-sessions", contentId))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data").isEmpty())
+                    .andExpect(jsonPath("$.totalCount").value(0));
+        }
 
-        // When & Then: 일치하는 이름 검색
-        mockMvc.perform(get("/api/contents/{contentId}/watching-sessions", savedContent.getId())
-                        .param("watcherNameLike", "테스터")
-                        .with(authentication(createAuthToken(savedUser))))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.totalCount").value(1));
+        @Test
+        @WithMockUser
+        @DisplayName("[400] 잘못된 정렬 기준이나 파라미터가 주어지면 에러를 반환한다")
+        void it_returns_400_bad_request() throws Exception {
+            // given
+            Long contentId = 456L;
+            given(watchingSessionService.getWatchingSessionsByContent(
+                    eq(contentId), any(), any(), any(), anyInt(), anyString(), any(SortDirection.class)
+            )).willThrow(new WatchingException(WatchingErrorCode.INVALID_WATCHING_REQUEST));
 
-        // When & Then: 일치하지 않는 이름 검색 (빈 목록)
-        mockMvc.perform(get("/api/contents/{contentId}/watching-sessions", savedContent.getId())
-                        .param("watcherNameLike", "없는사람")
-                        .with(authentication(createAuthToken(savedUser))))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.totalCount").value(0))
-                .andExpect(jsonPath("$.data").isEmpty());
-    }
+            // when & then
+            mockMvc.perform(get("/api/contents/{contentId}/watching-sessions", contentId)
+                            .param("sortBy", "invalidField")) // 잘못된 필드로 정렬 요청 상황 시뮬레이션
+                    .andExpect(status().isBadRequest());
+        }
 
-    // 2. 비즈니스 예외 케이스 (400)
-    @Test
-    @DisplayName("[400] 잘못된 페이지 limit(0 이하) 요청 시 INVALID_PAGINATION_LIMIT 에러 발생")
-    void getWatchingSessions_InvalidLimit_Fail() throws Exception {
-        mockMvc.perform(get("/api/contents/{contentId}/watching-sessions", savedContent.getId())
-                        .param("limit", "0")
-                        .with(authentication(createAuthToken(savedUser))))
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.title").value(WatchingErrorCode.INVALID_PAGINATION_LIMIT.name()))
-                .andExpect(jsonPath("$.detail").value(WatchingErrorCode.INVALID_PAGINATION_LIMIT.getMessage()));
-    }
-
-    @Test
-    @DisplayName("[400] 잘못된 커서 날짜 형식 요청 시 INVALID_CURSOR 에러 발생")
-    void getWatchingSessions_InvalidCursor_Fail() throws Exception {
-        // Given: 세션이 하나라도 있어야 커서 파싱 로직을 타므로 데이터 추가
-        watchingSessionRepository.save(new WatchingSession(savedUser.getId(), savedContent.getId(), LocalDateTime.now()));
-
-        mockMvc.perform(get("/api/contents/{contentId}/watching-sessions", savedContent.getId())
-                        .param("cursor", "not-a-date-format")
-                        .param("idAfter", "1")
-                        .with(authentication(createAuthToken(savedUser))))
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.title").value(WatchingErrorCode.INVALID_CURSOR.name()));
-    }
-
-    // 3. 인증 예외 케이스 (401)
-    @Test
-    @DisplayName("[401] 인증되지 않은 사용자가 목록 조회 시 오류 발생")
-    void getWatchingSessions_Unauthorized_Fail() throws Exception {
-        mockMvc.perform(get("/api/contents/{contentId}/watching-sessions", savedContent.getId())
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isUnauthorized());
+        // [참고] 401 테스트는 Security Filter 설정이 포함되어야 하므로
+        // 컨트롤러 단위 테스트인 본 파일에서는 제외하거나 Filter를 켜고 별도 설정을 해야 합니다.
     }
 }

--- a/mopl-api/src/test/java/com/mopl/domain/watching/controller/WatchingSessionUserControllerTest.java
+++ b/mopl-api/src/test/java/com/mopl/domain/watching/controller/WatchingSessionUserControllerTest.java
@@ -1,155 +1,91 @@
 package com.mopl.domain.watching.controller;
 
-import com.mopl.domain.auth.dto.UserPrincipal;
-import com.mopl.domain.content.entity.Content;
-import com.mopl.domain.content.enums.ContentType;
-import com.mopl.domain.content.repository.ContentRepository;
-import com.mopl.domain.user.entity.User;
-import com.mopl.domain.user.enums.Role;
-import com.mopl.domain.user.repository.UserRepository;
-import com.mopl.domain.watching.entity.WatchingSession;
+import com.mopl.domain.watching.dto.response.WatchingSessionUserResponse;
 import com.mopl.domain.watching.exception.WatchingErrorCode;
-import com.mopl.domain.watching.repository.WatchingSessionRepository;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import com.mopl.domain.watching.exception.WatchingException;
+import com.mopl.domain.watching.service.WatchingSessionService;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
+import java.time.LocalDateTime;
 
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@ActiveProfiles("test")
-@SpringBootTest
-@AutoConfigureMockMvc
-@Transactional
+@WebMvcTest(WatchingSessionController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("시청 세션 유저 컨트롤러 테스트")
 class WatchingSessionUserControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
 
-    @Autowired
-    private UserRepository userRepository;
+    @MockitoBean
+    private WatchingSessionService watchingSessionService;
 
-    @Autowired
-    private ContentRepository contentRepository;
+    @Nested
+    @DisplayName("GET /api/users/{watcherId}/watching-sessions")
+    class Describe_getWatchingSession {
 
-    @Autowired
-    private WatchingSessionRepository watchingSessionRepository;
+        @Test
+        @WithMockUser
+        @DisplayName("[200] 특정 사용자의 시청 세션 정보를 성공적으로 조회한다")
+        void it_returns_200_ok() throws Exception {
+            Long watcherId = 123L;
+            WatchingSessionUserResponse response = WatchingSessionUserResponse.builder()
+                    .id(watcherId)
+                    .createdAt(LocalDateTime.now())
+                    .build();
 
-    private User savedUser;
-    private Content savedContent;
+            given(watchingSessionService.getWatchingSession(watcherId)).willReturn(response);
 
-    @BeforeEach
-    void setUp() {
-        savedUser = userRepository.save(new User("테스터", "test@mopl.io", "password"));
-        Content content = new Content(ContentType.movie, "인터스텔라", "우주 영화", "https://image.com/thumb.jpg");
-        savedContent = contentRepository.save(content);
-    }
+            mockMvc.perform(get("/api/users/{watcherId}/watching-sessions", watcherId))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.id").value(watcherId.toString()));
+        }
 
-    @AfterEach
-    void tearDown() {
-        watchingSessionRepository.deleteAll();
-    }
+        @Test
+        @WithMockUser
+        @DisplayName("[204] 시청 중인 세션이 없을 경우 빈 바디를 반환한다")
+        void it_returns_204_no_content() throws Exception {
+            given(watchingSessionService.getWatchingSession(anyLong())).willReturn(null);
 
-    // 인증 토큰 생성 헬퍼 메서드 (SecurityConfig의 인증 요구사항 충족)
-    private UsernamePasswordAuthenticationToken createAuthToken(User user) {
-        UserPrincipal principal = new UserPrincipal(user.getId(), user.getEmail(), Role.USER);
-        return new UsernamePasswordAuthenticationToken(
-                principal,
-                null,
-                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
-        );
-    }
+            mockMvc.perform(get("/api/users/{watcherId}/watching-sessions", 123L))
+                    .andExpect(status().isNoContent())
+                    .andExpect(content().string(""));
+        }
 
-    // 1. 성공 케이스 (200)
-    @Test
-    @DisplayName("[200] 시청 중인 세션 조회 성공 시 상세 정보를 반환한다")
-    void getWatchingSession_Success() throws Exception {
-        // Given
-        WatchingSession session = WatchingSession.builder()
-                .id(savedUser.getId())
-                .contentId(savedContent.getId())
-                .build();
-        watchingSessionRepository.save(session);
+        @Test
+        @WithMockUser
+        @DisplayName("[400] 잘못된 요청 파라미터가 주어지면 에러를 반환한다")
+        void it_returns_400_bad_request() throws Exception {
+            given(watchingSessionService.getWatchingSession(-1L))
+                    .willThrow(new WatchingException(WatchingErrorCode.INVALID_WATCHING_REQUEST));
 
-        // When & Then
-        mockMvc.perform(get("/api/users/{watcherId}/watching-sessions", savedUser.getId())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .with(authentication(createAuthToken(savedUser)))) // 인증 정보 추가
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(String.valueOf(savedUser.getId())))
-                .andExpect(jsonPath("$.watcher.name").value("테스터"))
-                .andExpect(jsonPath("$.content.title").value("인터스텔라"));
-    }
+            mockMvc.perform(get("/api/users/{watcherId}/watching-sessions", -1L))
+                    .andExpect(status().isBadRequest());
+        }
 
-    @Test
-    @DisplayName("[200] 시청 중인 정보가 없으면 Null을 반환한다 (정상 케이스)")
-    void getWatchingSession_Null_Success() throws Exception {
-        // When & Then
-        mockMvc.perform(get("/api/users/{watcherId}/watching-sessions", savedUser.getId())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .with(authentication(createAuthToken(savedUser))))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$").doesNotExist());
-    }
+        @Test
+        @WithMockUser
+        @DisplayName("[404] 존재하지 않는 사용자 ID로 조회하면 에러를 반환한다")
+        void it_returns_404_not_found() throws Exception {
+            given(watchingSessionService.getWatchingSession(999L))
+                    .willThrow(new WatchingException(WatchingErrorCode.USER_NOT_FOUND));
 
-    // 2. 비즈니스 예외 케이스 (400)
-    @Test
-    @DisplayName("[400] 잘못된 요청 파라미터(음수 ID) 시 INVALID_WATCHING_REQUEST 에러 발생")
-    void getWatchingSession_InvalidRequest_Fail() throws Exception {
-        mockMvc.perform(get("/api/users/{watcherId}/watching-sessions", -1L)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .with(authentication(createAuthToken(savedUser))))
-                .andDo(print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.title").value(WatchingErrorCode.INVALID_WATCHING_REQUEST.name()))
-                .andExpect(jsonPath("$.detail").value(WatchingErrorCode.INVALID_WATCHING_REQUEST.getMessage()));
-    }
-
-    // 3. 리소스 없음 케이스 (404)
-    @Test
-    @DisplayName("[404] 존재하지 않는 유저 조회 시 USER_NOT_FOUND 에러 발생")
-    void getWatchingSession_UserNotFound_Fail() throws Exception {
-        mockMvc.perform(get("/api/users/{watcherId}/watching-sessions", 999999L)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .with(authentication(createAuthToken(savedUser))))
-                .andDo(print())
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.title").value(WatchingErrorCode.USER_NOT_FOUND.name()))
-                .andExpect(jsonPath("$.detail").value(WatchingErrorCode.USER_NOT_FOUND.getMessage()));
-    }
-
-    @Test
-    @DisplayName("[404] 세션에 등록된 콘텐츠가 DB에 없으면 CONTENT_NOT_FOUND 에러 발생")
-    void getWatchingSession_ContentNotFound_Fail() throws Exception {
-        WatchingSession session = WatchingSession.builder()
-                .id(savedUser.getId())
-                .contentId(888888L)
-                .build();
-        watchingSessionRepository.save(session);
-
-        mockMvc.perform(get("/api/users/{watcherId}/watching-sessions", savedUser.getId())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .with(authentication(createAuthToken(savedUser))))
-                .andDo(print())
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.title").value(WatchingErrorCode.CONTENT_NOT_FOUND.name()))
-                .andExpect(jsonPath("$.detail").value(WatchingErrorCode.CONTENT_NOT_FOUND.getMessage()));
+            mockMvc.perform(get("/api/users/{watcherId}/watching-sessions", 999L))
+                    .andExpect(status().isNotFound());
+        }
     }
 }

--- a/mopl-api/src/test/java/com/mopl/domain/watching/service/WatchingSessionContentListServiceTest.java
+++ b/mopl-api/src/test/java/com/mopl/domain/watching/service/WatchingSessionContentListServiceTest.java
@@ -1,14 +1,11 @@
 package com.mopl.domain.watching.service;
 
 import com.mopl.domain.content.entity.Content;
-import com.mopl.domain.content.enums.ContentType;
 import com.mopl.domain.content.repository.ContentRepository;
 import com.mopl.domain.user.entity.User;
 import com.mopl.domain.user.repository.UserRepository;
 import com.mopl.domain.watching.dto.response.WatchingSessionContentListResponse;
 import com.mopl.domain.watching.entity.WatchingSession;
-import com.mopl.domain.watching.exception.WatchingErrorCode;
-import com.mopl.domain.watching.exception.WatchingException;
 import com.mopl.domain.watching.repository.WatchingSessionRepository;
 import com.mopl.global.enums.SortDirection;
 import org.junit.jupiter.api.DisplayName;
@@ -18,17 +15,18 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayName("시청 세션 목록 조회 서비스 테스트")
 class WatchingSessionContentListServiceTest {
 
     @InjectMocks
@@ -43,147 +41,94 @@ class WatchingSessionContentListServiceTest {
     @Mock
     private ContentRepository contentRepository;
 
-    // 테스트 데이터 생성 헬퍼 메서드 유지
-    private User createUser(Long id, String name) {
-        User user = new User(name, name + "@test.com", "password");
-        ReflectionTestUtils.setField(user, "id", id);
-        return user;
-    }
-
-    private Content createContent(Long id) {
-        Content content = new Content(ContentType.movie, "인터스텔라", "우주 영화", "https://image.com/thumb.jpg");
-        ReflectionTestUtils.setField(content, "id", id);
-        return content;
-    }
-
     @Nested
-    @DisplayName("특정 콘텐츠 시청 세션 목록 조회 (getWatchingSessionsByContent)")
-    class GetWatchingSessionsByContentTest {
+    @DisplayName("콘텐츠별 시청 목록 조회")
+    class Describe_getWatchingSessionsByContent {
 
         @Test
-        @DisplayName("[성공] 정렬 및 페이징 조건에 맞는 세션 목록을 반환한다 (최신순)")
-        void success_PagingAndSorting() {
-            // Given
+        @DisplayName("[성공] 최신순 정렬 및 리밋에 따른 페이징 목록을 반환한다")
+        void it_returns_paged_list_with_default_sort() {
+            // given
             Long contentId = 100L;
-            Content content = createContent(contentId);
+            LocalDateTime now = LocalDateTime.now();
 
-            User user1 = createUser(1L, "테스터1");
-            User user2 = createUser(2L, "테스터2");
-            User user3 = createUser(3L, "테스터3");
-
-            LocalDateTime now = LocalDateTime.of(2026, 1, 14, 15, 0);
-            WatchingSession s1 = new WatchingSession(1L, contentId, now.minusMinutes(10));
-            WatchingSession s2 = new WatchingSession(2L, contentId, now.minusMinutes(5));
-            WatchingSession s3 = new WatchingSession(3L, contentId, now);
+            WatchingSession s1 = WatchingSession.builder().id(1L).contentId(contentId).createdAt(now.minusMinutes(10)).build();
+            WatchingSession s2 = WatchingSession.builder().id(2L).contentId(contentId).createdAt(now.minusMinutes(5)).build();
+            WatchingSession s3 = WatchingSession.builder().id(3L).contentId(contentId).createdAt(now).build();
 
             given(watchingSessionRepository.findAllByContentId(contentId)).willReturn(List.of(s1, s2, s3));
-            given(userRepository.findAllById(anyList())).willReturn(List.of(user1, user2, user3));
-            given(contentRepository.findAllById(anyList())).willReturn(List.of(content));
+            given(contentRepository.findByIdWithTags(contentId)).willReturn(Optional.of(mock(Content.class)));
 
-            // When: 내림차순(DESCENDING), limit 2로 조회
+            User u1 = mock(User.class); given(u1.getId()).willReturn(1L); given(u1.getName()).willReturn("user1");
+            User u2 = mock(User.class); given(u2.getId()).willReturn(2L); given(u2.getName()).willReturn("user2");
+            User u3 = mock(User.class); given(u3.getId()).willReturn(3L); given(u3.getName()).willReturn("user3");
+
+            given(userRepository.findAllById(anyList())).willReturn(List.of(u1, u2, u3));
+
+            // when
             WatchingSessionContentListResponse response = watchingSessionService.getWatchingSessionsByContent(
                     contentId, null, null, null, 2, "createdAt", SortDirection.DESCENDING
             );
 
-            // Then
+            // then
             assertThat(response.data()).hasSize(2);
-            assertThat(response.hasNext()).isTrue();
             assertThat(response.totalCount()).isEqualTo(3);
-            assertThat(response.data().get(0).id()).isEqualTo("3"); // 가장 최근 데이터
-            assertThat(response.nextIdAfter()).isEqualTo("2"); // 다음 커서 ID
+            assertThat(response.hasNext()).isTrue();
+            assertThat(response.data().get(0).id()).isEqualTo(3L);
         }
 
         @Test
-        @DisplayName("[성공] 이름 필터링(watcherNameLike) 조건이 포함된 목록만 반환한다")
-        void success_NameFiltering() {
-            // Given
+        @DisplayName("[필터] 사용자 이름 검색 조건에 맞는 결과만 필터링한다")
+        void it_filters_by_watcher_name() {
+            // given
             Long contentId = 100L;
-            User user1 = createUser(1L, "김철수");
-            User user2 = createUser(2L, "이영희");
-            WatchingSession s1 = new WatchingSession(1L, contentId, LocalDateTime.now());
-            WatchingSession s2 = new WatchingSession(2L, contentId, LocalDateTime.now());
+            WatchingSession s1 = WatchingSession.builder().id(1L).contentId(contentId).build();
 
-            given(watchingSessionRepository.findAllByContentId(contentId)).willReturn(List.of(s1, s2));
-            given(userRepository.findAllById(anyList())).willReturn(List.of(user1, user2));
-            given(contentRepository.findAllById(anyList())).willReturn(List.of(createContent(contentId)));
+            given(watchingSessionRepository.findAllByContentId(contentId)).willReturn(List.of(s1));
+            given(contentRepository.findByIdWithTags(contentId)).willReturn(Optional.of(mock(Content.class)));
 
-            // When: "철수" 필터 적용
-            WatchingSessionContentListResponse response = watchingSessionService.getWatchingSessionsByContent(
-                    contentId, "철수", null, null, 10, "createdAt", SortDirection.DESCENDING
+            User u1 = mock(User.class);
+            given(u1.getId()).willReturn(1L);
+            given(u1.getName()).willReturn("우디");
+            given(userRepository.findAllById(anyList())).willReturn(List.of(u1));
+
+            // when
+            var response = watchingSessionService.getWatchingSessionsByContent(
+                    contentId, "버즈", null, null, 10, "createdAt", SortDirection.DESCENDING
             );
 
-            // Then
-            assertThat(response.data()).hasSize(1);
-            assertThat(response.data().get(0).watcher().name()).isEqualTo("김철수");
-            assertThat(response.totalCount()).isEqualTo(1);
-        }
-
-        @Test
-        @DisplayName("[성공] 커서와 보조 커서를 사용하면 다음 데이터부터 반환한다")
-        void success_CursorPagination() {
-            // Given
-            Long contentId = 100L;
-            LocalDateTime time1 = LocalDateTime.of(2026, 1, 14, 10, 0);
-            LocalDateTime time2 = LocalDateTime.of(2026, 1, 14, 11, 0);
-
-            WatchingSession s1 = new WatchingSession(1L, contentId, time1);
-            WatchingSession s2 = new WatchingSession(2L, contentId, time2);
-
-            given(watchingSessionRepository.findAllByContentId(contentId)).willReturn(List.of(s1, s2));
-            given(userRepository.findAllById(anyList())).willReturn(List.of(createUser(1L, "UserA"), createUser(2L, "UserB")));
-            given(contentRepository.findAllById(anyList())).willReturn(List.of(createContent(contentId)));
-
-            // When: s1(10시)을 커서로 넘겼을 때 오름차순 조회
-            WatchingSessionContentListResponse response = watchingSessionService.getWatchingSessionsByContent(
-                    contentId, null, time1.toString(), 1L, 10, "createdAt", SortDirection.ASCENDING
-            );
-
-            // Then
-            assertThat(response.data()).hasSize(1);
-            assertThat(response.data().get(0).id()).isEqualTo("2"); // 10시 다음인 11시 데이터
-            assertThat(response.hasNext()).isFalse();
-        }
-
-        @Test
-        @DisplayName("[성공] 시청 중인 세션이 전혀 없으면 빈 목록을 반환한다")
-        void success_EmptyList() {
-            // Given
-            Long contentId = 100L;
-            given(watchingSessionRepository.findAllByContentId(contentId)).willReturn(List.of());
-
-            // When
-            WatchingSessionContentListResponse response = watchingSessionService.getWatchingSessionsByContent(
-                    contentId, null, null, null, 10, "createdAt", SortDirection.DESCENDING
-            );
-
-            // Then
+            // then
             assertThat(response.data()).isEmpty();
-            assertThat(response.totalCount()).isZero();
-            assertThat(response.hasNext()).isFalse();
+            assertThat(response.totalCount()).isEqualTo(0);
         }
 
         @Test
-        @DisplayName("[실패] limit이 0 이하인 경우 INVALID_PAGINATION_LIMIT 예외가 발생한다")
-        void fail_InvalidLimit() {
-            // When & Then
-            assertThatThrownBy(() -> watchingSessionService.getWatchingSessionsByContent(
-                    1L, null, null, null, 0, "createdAt", SortDirection.DESCENDING))
-                    .isInstanceOf(WatchingException.class)
-                    .hasMessage(WatchingErrorCode.INVALID_PAGINATION_LIMIT.getMessage());
-        }
-
-        @Test
-        @DisplayName("[실패] 커서 형식이 잘못된 경우 INVALID_CURSOR 예외가 발생한다")
-        void fail_InvalidCursor() {
-            // Given
+        @DisplayName("[페이징] 커서 이후의 데이터부터 정확히 조절하여 반환한다")
+        void it_starts_from_after_cursor() {
+            // given
             Long contentId = 100L;
-            given(watchingSessionRepository.findAllByContentId(contentId)).willReturn(List.of(new WatchingSession(1L, 100L, LocalDateTime.now())));
+            LocalDateTime time1 = LocalDateTime.of(2026, 1, 19, 10, 0);
+            LocalDateTime time2 = LocalDateTime.of(2026, 1, 19, 11, 0);
 
-            // When & Then
-            assertThatThrownBy(() -> watchingSessionService.getWatchingSessionsByContent(
-                    contentId, null, "invalid-date-format", 1L, 10, "createdAt", SortDirection.DESCENDING))
-                    .isInstanceOf(WatchingException.class)
-                    .hasMessage(WatchingErrorCode.INVALID_CURSOR.getMessage());
+            WatchingSession s1 = WatchingSession.builder().id(1L).contentId(contentId).createdAt(time1).build();
+            WatchingSession s2 = WatchingSession.builder().id(2L).contentId(contentId).createdAt(time2).build();
+
+            given(watchingSessionRepository.findAllByContentId(contentId)).willReturn(List.of(s1, s2));
+            given(contentRepository.findByIdWithTags(contentId)).willReturn(Optional.of(mock(Content.class)));
+
+            User u1 = mock(User.class); given(u1.getId()).willReturn(1L); given(u1.getName()).willReturn("u1");
+            User u2 = mock(User.class); given(u2.getId()).willReturn(2L); given(u2.getName()).willReturn("u2");
+            given(userRepository.findAllById(anyList())).willReturn(List.of(u1, u2));
+
+            // when
+            var response = watchingSessionService.getWatchingSessionsByContent(
+                    contentId, null, time2.toString(), 2L, 10, "createdAt", SortDirection.DESCENDING
+            );
+
+            // then
+            assertThat(response.data()).hasSize(1);
+            assertThat(response.data().get(0).id()).isEqualTo(1L);
+            assertThat(response.hasNext()).isFalse();
         }
     }
 }

--- a/mopl-api/src/test/java/com/mopl/domain/watching/service/WatchingSessionUserServiceTest.java
+++ b/mopl-api/src/test/java/com/mopl/domain/watching/service/WatchingSessionUserServiceTest.java
@@ -1,7 +1,6 @@
 package com.mopl.domain.watching.service;
 
 import com.mopl.domain.content.entity.Content;
-import com.mopl.domain.content.enums.ContentType;
 import com.mopl.domain.content.repository.ContentRepository;
 import com.mopl.domain.user.entity.User;
 import com.mopl.domain.user.repository.UserRepository;
@@ -17,15 +16,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayName("시청 세션 유저 단건 조회 서비스 테스트")
 class WatchingSessionUserServiceTest {
 
     @InjectMocks
@@ -40,109 +41,78 @@ class WatchingSessionUserServiceTest {
     @Mock
     private ContentRepository contentRepository;
 
-    // 테스트 데이터 생성 헬퍼 메서드
-    private User createUser(Long id) {
-        User user = new User("user" + id, "user" + id + "@test.com", "password");
-        ReflectionTestUtils.setField(user, "id", id);
-        return user;
-    }
-
-    private Content createContent(Long id) {
-        Content content = new Content(ContentType.movie, "인터스텔라", "우주 영화", "https://image.com/thumb.jpg");
-        ReflectionTestUtils.setField(content, "id", id);
-        return content;
-    }
-
-    // 1. 시청 세션 조회 로직 테스트
     @Nested
-    @DisplayName("시청 세션 조회 (getWatchingSession)")
-    class GetWatchingSessionTest {
+    @DisplayName("유저별 시청 세션 단건 조회")
+    class Describe_getWatchingSession {
 
         @Test
-        @DisplayName("[성공] 사용자가 시청 중인 세션이 있으면 상세 정보를 반환한다")
-        void success() {
-            // Given
+        @DisplayName("[성공] 세션 정보가 존재하면 시청자 및 콘텐츠 정보를 결합하여 반환한다")
+        void it_returns_combined_response() {
+            // given
             Long watcherId = 1L;
             Long contentId = 100L;
-            User user = createUser(watcherId);
-            Content content = createContent(contentId);
+
             WatchingSession session = WatchingSession.builder()
                     .id(watcherId)
                     .contentId(contentId)
                     .build();
 
-            given(userRepository.existsById(watcherId)).willReturn(true);
+            User user = mock(User.class);
+            given(user.getId()).willReturn(watcherId);
+            given(user.getName()).willReturn("정건진");
+
+            Content content = mock(Content.class);
+            given(content.getId()).willReturn(contentId);
+
             given(watchingSessionRepository.findById(watcherId)).willReturn(Optional.of(session));
             given(userRepository.findById(watcherId)).willReturn(Optional.of(user));
-            given(contentRepository.findById(contentId)).willReturn(Optional.of(content));
+            given(contentRepository.findByIdWithTags(contentId)).willReturn(Optional.of(content));
 
-            // When
+            // when
             WatchingSessionUserResponse response = watchingSessionService.getWatchingSession(watcherId);
 
-            // Then
+            // then
             assertThat(response).isNotNull();
-            assertThat(response.id()).isEqualTo(String.valueOf(watcherId));
-            assertThat(response.watcher().name()).isEqualTo(user.getName());
-            assertThat(response.content().title()).isEqualTo(content.getTitle());
+            assertThat(response.id()).isEqualTo(watcherId);
+            assertThat(response.watcher().name()).isEqualTo("정건진");
         }
 
         @Test
-        @DisplayName("[성공] 사용자가 시청 중인 세션이 없으면 Null을 반환한다")
-        void success_ReturnNull() {
-            // Given
-            Long watcherId = 1L;
-            given(userRepository.existsById(watcherId)).willReturn(true);
-            given(watchingSessionRepository.findById(watcherId)).willReturn(Optional.empty());
+        @DisplayName("[성공] 시청 중인 세션이 존재하지 않으면 null을 반환한다")
+        void it_returns_null() {
+            // given
+            given(watchingSessionRepository.findById(anyLong())).willReturn(Optional.empty());
 
-            // When
-            WatchingSessionUserResponse response = watchingSessionService.getWatchingSession(watcherId);
+            // when
+            WatchingSessionUserResponse response = watchingSessionService.getWatchingSession(1L);
 
-            // Then
+            // then
             assertThat(response).isNull();
         }
 
-        // 2. 비즈니스 예외 케이스 (400)
         @Test
-        @DisplayName("[실패] 잘못된 요청 파라미터(음수 ID) 시 INVALID_WATCHING_REQUEST 예외 발생")
-        void fail_InvalidRequest() {
-            // Given
-            Long invalidId = -1L;
-
-            // When & Then
-            assertThatThrownBy(() -> watchingSessionService.getWatchingSession(invalidId))
-                    .isInstanceOf(WatchingException.class)
-                    .hasMessage(WatchingErrorCode.INVALID_WATCHING_REQUEST.getMessage());
-        }
-
-        // 3. 리소스 없음 케이스 (404)
-        @Test
-        @DisplayName("[실패] 존재하지 않는 사용자를 조회하면 USER_NOT_FOUND 예외 발생")
-        void fail_UserNotFound() {
-            // Given
-            Long watcherId = 999L;
-            given(userRepository.existsById(watcherId)).willReturn(false);
-
-            // When & Then
-            assertThatThrownBy(() -> watchingSessionService.getWatchingSession(watcherId))
-                    .isInstanceOf(WatchingException.class)
-                    .hasMessage(WatchingErrorCode.USER_NOT_FOUND.getMessage());
-        }
-
-        @Test
-        @DisplayName("[실패] 세션은 있으나 유저 정보를 찾을 수 없음 (USER_NOT_FOUND)")
-        void fail_UserDetailNotFound() {
-            // Given
+        @DisplayName("[예외] 세션은 있으나 유저 정보가 DB에 없으면 USER_NOT_FOUND를 던진다")
+        void it_throws_user_not_found_exception() {
+            // given
             Long watcherId = 1L;
-            WatchingSession session = WatchingSession.builder().id(watcherId).contentId(100L).build();
+            WatchingSession session = WatchingSession.builder().id(watcherId).build();
 
-            given(userRepository.existsById(watcherId)).willReturn(true);
             given(watchingSessionRepository.findById(watcherId)).willReturn(Optional.of(session));
             given(userRepository.findById(watcherId)).willReturn(Optional.empty());
 
-            // When & Then
+            // when & then
             assertThatThrownBy(() -> watchingSessionService.getWatchingSession(watcherId))
                     .isInstanceOf(WatchingException.class)
                     .hasMessage(WatchingErrorCode.USER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("[예외] 유효하지 않은 ID(음수 등)가 입력되면 INVALID_REQUEST를 던진다")
+        void it_throws_invalid_request_exception() {
+            // when & then
+            assertThatThrownBy(() -> watchingSessionService.getWatchingSession(-1L))
+                    .isInstanceOf(WatchingException.class)
+                    .hasMessage(WatchingErrorCode.INVALID_WATCHING_REQUEST.getMessage());
         }
     }
 }


### PR DESCRIPTION
## 🔄 변경 사항

* 시청 세션 조회 서비스 로직의 안정성 확보를 위한 유닛 테스트 보강
* API 명세에 따른 컨트롤러 응답 규격 및 예외 처리 검증 로직 추가

## 🧩 작업 사항

* **서비스 계층 유닛 테스트 추가**
* `WatchingSessionUserServiceTest`: 단건 조회 시 데이터 결합(Session+User+Content) 및 유저 미존재 예외 상황 검증
* `WatchingSessionContentListServiceTest`: 커서 기반 페이지네이션 알고리즘, 최신순 정렬, 이름 필터링 로직 검증


* **컨트롤러 계층 슬라이스 테스트 추가**
* `WatchingSessionUserControllerTest`: HTTP 상태 코드(200, 204, 400, 404) 및 응답 JSON 필드 정합성 검증
* `WatchingSessionContentListControllerTest`: 페이징 응답 규격(totalCount, hasNext, nextCursor 등) 및 파라미터 바인딩 검증


* **테스트 편의성 개선**
* `@Nested` 구조 도입으로 테스트 시나리오 계층화 및 가독성 향상



## 📸 스크린샷

* **JUnit 5 테스트 실행 결과**: 작성된 모든 테스트 케이스(총 10+개) 통과 확인
* **로그 결과**: 서비스 로직 내 커서 탐색(startIndex) 및 정렬 로직이 정상 동작함을 로그로 확인

<img width="588" height="214" alt="image" src="https://github.com/user-attachments/assets/6f10af28-d463-4b02-afc6-2220ff4cfcf5" />
<img width="588" height="214" alt="image" src="https://github.com/user-attachments/assets/c080e095-6270-4fa6-88aa-ad9c3f3c6edf" />
<img width="588" height="214" alt="image" src="https://github.com/user-attachments/assets/ceadfff3-08ed-4689-9b52-e8c133a86c7a" />
<img width="588" height="214" alt="image" src="https://github.com/user-attachments/assets/b98d56b0-6ba9-498f-9292-18de7f21be98" />
