### PR TITLE
[FIX] DM 기능에서 상대방 프로필이 뜨지 않던 버그 & SSE Timeout 주기 변경 - 45초

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/conversation/service/ConversationService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/conversation/service/ConversationService.java
@@ -19,6 +19,7 @@ import com.mopl.domain.user.exception.UserErrorCode;
 import com.mopl.domain.user.exception.UserException;
 import com.mopl.domain.user.repository.UserRepository;
 import com.mopl.global.dto.PageResponse;
+import com.mopl.global.s3.S3Manager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -39,6 +40,7 @@ public class ConversationService {
     private final UserRepository userRepository;
     private final ReadStatusRepository readStatusRepository;
     private final DirectMessageRepository directMessageRepository;
+    private final S3Manager s3Manager;
 
     @Transactional
     public ConversationDto createConversation(Long myId, ConversationCreateRequest createRequest) {
@@ -53,36 +55,6 @@ public class ConversationService {
         return conversationRepository.findByParticipants(myId, withUserId)
                 .map(conversation -> fetchDetailsAndConvertToDto(conversation, me.getId(), targetUser))
                 .orElseGet(() -> createNewConversation(me, targetUser));
-    }
-
-    // 기존 대화방이 없을 때 새로 생성
-    private ConversationDto createNewConversation(User me, User target) {
-
-        Conversation newConversation = conversationRepository.save(new Conversation());
-
-        ReadStatus myReadStatus = ReadStatus.create(newConversation, me);
-        ReadStatus targetReadStatus = ReadStatus.create(newConversation, target);
-        readStatusRepository.saveAll(List.of(myReadStatus, targetReadStatus));
-
-        return convertToDto(newConversation, me.getId(), target, myReadStatus, null);
-    }
-
-    /**
-     * 추가 정보(채팅방의 마지막 메시지, 나의 읽음 상태) DB 조회 후 DTO로 컨버팅
-     */
-    private ConversationDto fetchDetailsAndConvertToDto(Conversation conversation, Long myId, User target) {
-        DirectMessage lastMessage = directMessageRepository.findTopByConversationIdOrderByCreatedAtDescIdDesc(conversation.getId())
-                .orElse(null);
-
-        ReadStatus myReadStatus = readStatusRepository.findByConversationIdAndUserId(conversation.getId(), myId)
-                .orElseThrow(() -> new ConversationException(CONVERSATION_NOT_FOUND));
-
-        return convertToDto(conversation, myId, target, myReadStatus, lastMessage);
-    }
-
-    private User getUserOrThrow(Long userId) {
-        return userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_EXIST));
     }
 
     // 대화 목록 전체 조회 (커서 페이지네이션)
@@ -133,15 +105,6 @@ public class ConversationService {
                 .build();
     }
 
-    private ConversationDto queryResultToDto(ConversationQueryResult queryResult, Long myId) {
-        Conversation conversation = queryResult.conversation();
-        User targetUser = queryResult.targetUser();
-        DirectMessage message = queryResult.lastMessage();
-        ReadStatus myStatus = queryResult.myReadStatus();
-
-        return convertToDto(conversation, myId, targetUser, myStatus, message);
-    }
-
     // 대화방의 메시지 읽음 처리
     @Transactional
     public void updateAsRead(Long myId, Long conversationId, Long directMessageId) {
@@ -170,11 +133,52 @@ public class ConversationService {
         return queryResultToDto(queryResult, myId);
     }
 
+    // 기존 대화방이 없을 때 새로 생성
+    private ConversationDto createNewConversation(User me, User target) {
+
+        Conversation newConversation = conversationRepository.save(new Conversation());
+
+        ReadStatus myReadStatus = ReadStatus.create(newConversation, me);
+        ReadStatus targetReadStatus = ReadStatus.create(newConversation, target);
+        readStatusRepository.saveAll(List.of(myReadStatus, targetReadStatus));
+
+        return convertToDto(newConversation, me.getId(), target, myReadStatus, null);
+    }
+
+    /**
+     * 추가 정보(채팅방의 마지막 메시지, 나의 읽음 상태) DB 조회 후 DTO로 컨버팅
+     */
+    private ConversationDto fetchDetailsAndConvertToDto(Conversation conversation, Long myId, User target) {
+        DirectMessage lastMessage = directMessageRepository.findTopByConversationIdOrderByCreatedAtDescIdDesc(conversation.getId())
+                .orElse(null);
+
+        ReadStatus myReadStatus = readStatusRepository.findByConversationIdAndUserId(conversation.getId(), myId)
+                .orElseThrow(() -> new ConversationException(CONVERSATION_NOT_FOUND));
+
+        return convertToDto(conversation, myId, target, myReadStatus, lastMessage);
+    }
+
+    private User getUserOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_EXIST));
+    }
+
+    private ConversationDto queryResultToDto(ConversationQueryResult queryResult, Long myId) {
+        Conversation conversation = queryResult.conversation();
+        User targetUser = queryResult.targetUser();
+        DirectMessage message = queryResult.lastMessage();
+        ReadStatus myStatus = queryResult.myReadStatus();
+
+        return convertToDto(conversation, myId, targetUser, myStatus, message);
+    }
+
     private ConversationDto convertToDto(Conversation conversation, Long myId, User targetUser,
                                          ReadStatus myReadStatus, DirectMessage lastMessage) {
 
         Long conversationId = conversation.getId();
-        UserSummaryDto with = new UserSummaryDto(targetUser.getId(), targetUser.getName(), targetUser.getProfileImageUrl());
+
+        String targetProfileUrl = s3Manager.generatePresignedUrl(targetUser.getProfileImageUrl());
+        UserSummaryDto with = new UserSummaryDto(targetUser.getId(), targetUser.getName(), targetProfileUrl);
 
         if (lastMessage == null) {
             return new ConversationDto(conversationId, with, null, false);

--- a/mopl-api/src/main/java/com/mopl/global/sse/SseManager.java
+++ b/mopl-api/src/main/java/com/mopl/global/sse/SseManager.java
@@ -15,7 +15,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class SseManager {
 
     private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
-    private static final Long DEFAULT_TIMEOUT = 60_000L; // 프론트의 재연결 주기 기준
+    private static final Long DEFAULT_TIMEOUT = 45_000L; // 프론트의 재연결 주기 기준
 
     /**
      * 클라이언트와 서버 간의 SSE 파이프라인을 생성하고 관리합니다.

--- a/mopl-chat/src/main/java/com/mopl/domain/directmessage/service/DMChatService.java
+++ b/mopl-chat/src/main/java/com/mopl/domain/directmessage/service/DMChatService.java
@@ -4,7 +4,7 @@ import com.mopl.domain.conversation.dto.response.DirectMessageDto;
 import com.mopl.domain.conversation.entity.Conversation;
 import com.mopl.domain.conversation.entity.DirectMessage;
 import com.mopl.domain.conversation.entity.ReadStatus;
-import com.mopl.domain.conversation.event.DmSendEvent;
+import com.mopl.domain.conversation.producer.DmEventProducer;
 import com.mopl.domain.conversation.repository.DirectMessageRepository;
 import com.mopl.domain.conversation.repository.ReadStatusRepository;
 import com.mopl.domain.notification.enums.NotificationType;
@@ -15,8 +15,6 @@ import com.mopl.global.redis.RedisManager;
 import com.mopl.global.redis.RedisNameSpace;
 import com.mopl.global.s3.S3Manager;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,11 +29,8 @@ public class DMChatService {
     private final ReadStatusRepository readStatusRepository;
     private final RedisManager redisManager;
     private final NotificationEventProducer notificationEventProducer;
+    private final DmEventProducer dmEventProducer;
     private final S3Manager s3Manager;
-    private final KafkaTemplate<String, Object> kafkaTemplate;
-
-    @Value("${mopl.kafka.topics.dm}")
-    private String dmTopic;
 
     @Transactional
     public DirectMessageDto saveMessage(Long senderId, Long conversationId, String content) {
@@ -71,10 +66,7 @@ public class DMChatService {
         // 상대방 대화창 활성화 여부 확인 후 DM 전송
         boolean isWatching = redisManager.isMember(RedisNameSpace.DM_VIEWERS, String.valueOf(conversationId), String.valueOf(receiver.getId()));
         if (!isWatching) {
-            kafkaTemplate.send(dmTopic, new DmSendEvent(
-                    receiver.getId(),
-                    directMessageDto
-            ));
+            dmEventProducer.send(receiver.getId(), directMessageDto);
 
             notificationEventProducer.send(
                     receiver.getId(),

--- a/mopl-chat/src/main/java/com/mopl/domain/directmessage/service/DMChatService.java
+++ b/mopl-chat/src/main/java/com/mopl/domain/directmessage/service/DMChatService.java
@@ -13,6 +13,7 @@ import com.mopl.domain.user.dto.response.UserSummaryDto;
 import com.mopl.domain.user.entity.User;
 import com.mopl.global.redis.RedisManager;
 import com.mopl.global.redis.RedisNameSpace;
+import com.mopl.global.s3.S3Manager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -30,6 +31,7 @@ public class DMChatService {
     private final ReadStatusRepository readStatusRepository;
     private final RedisManager redisManager;
     private final NotificationEventProducer notificationEventProducer;
+    private final S3Manager s3Manager;
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
     @Value("${mopl.kafka.topics.dm}")
@@ -52,7 +54,7 @@ public class DMChatService {
         }
 
         if (myStatus == null) {
-            throw new IllegalArgumentException("대화방에 참여하고 있지 않습니다.");
+            throw new IllegalArgumentException("대화방에 참여하고 있지 않습니다."); // TODO 예외 및 핸들러를 core 모듈로 옮긴 후 도메인 예외로 변경
         }
         if (receiver == null) {
             throw new IllegalArgumentException("상대방을 찾을 수 없습니다.");
@@ -84,13 +86,16 @@ public class DMChatService {
         return directMessageDto;
     }
 
-    private static DirectMessageDto toDto(Long senderId, Long conversationId, String content, DirectMessage message, User sender, User receiver) {
+    private DirectMessageDto toDto(Long senderId, Long conversationId, String content, DirectMessage message, User sender, User receiver) {
+        String senderProfileUrl = s3Manager.generatePresignedUrl(sender.getProfileImageUrl());
+        String receiverProfileUrl = s3Manager.generatePresignedUrl(receiver.getProfileImageUrl());
+
         return new DirectMessageDto(
                 message.getId(),
                 conversationId,
                 message.getCreatedAt(),
-                new UserSummaryDto(senderId, sender.getName(), sender.getProfileImageUrl()),
-                new UserSummaryDto(receiver.getId(), receiver.getName(), receiver.getProfileImageUrl()),
+                new UserSummaryDto(senderId, sender.getName(), senderProfileUrl),
+                new UserSummaryDto(receiver.getId(), receiver.getName(), receiverProfileUrl),
                 content
         );
     }

--- a/mopl-core/src/main/java/com/mopl/domain/conversation/producer/DmEventProducer.java
+++ b/mopl-core/src/main/java/com/mopl/domain/conversation/producer/DmEventProducer.java
@@ -1,0 +1,27 @@
+package com.mopl.domain.conversation.producer;
+
+import com.mopl.domain.conversation.dto.response.DirectMessageDto;
+import com.mopl.domain.conversation.event.DmSendEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DmEventProducer {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Value("${mopl.kafka.topics.dm}")
+    private String dmTopic;
+
+    public void send(Long receiverId, DirectMessageDto directMessageDto) {
+        kafkaTemplate.send(dmTopic, new DmSendEvent(
+                receiverId,
+                directMessageDto
+        ));
+    }
+}


### PR DESCRIPTION
## 연관 이슈
#141, #205

## 🔄 변경 사항
[fix]
- 사용자 프로필 url을 presigned url로 변경
  - `ConversationService` 내부의 메서드 위치 변경 (private을 하단으로)
- SSE 타임아웃 주기 변경 (45초)

[refactor]
- 비활성화된 DM 수신 코드 - `DmEventProducer`를 추가해 `DMChatService`에서 `KafkaTemplate`을 의존하지 않도록 리팩토링


## 📸 스크린샷
.