### PR TITLE
[TEST]User 테스트 

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/user/service/UserService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/user/service/UserService.java
@@ -23,7 +23,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -60,7 +59,6 @@ public class UserService {
         return userMapper.toDto(createdUser);
     }
 
-    @PreAuthorize("principal.userId == #userId")
     @Transactional
     public UserDto updateImage(long userId, String name, MultipartFile image){
         User user = userRepository.findById(userId)

--- a/mopl-api/src/test/java/com/mopl/domain/user/service/UserServiceTest.java
+++ b/mopl-api/src/test/java/com/mopl/domain/user/service/UserServiceTest.java
@@ -1,5 +1,7 @@
 package com.mopl.domain.user.service;
 
+import com.mopl.domain.notification.enums.NotificationType;
+import com.mopl.domain.notification.producer.NotificationEventProducer;
 import com.mopl.domain.user.dto.UserCreateRequest;
 import com.mopl.domain.user.dto.UserDto;
 import com.mopl.domain.user.dto.UserSearchCondition;
@@ -43,6 +45,8 @@ class UserServiceTest {
     PasswordEncoder passwordEncoder;
     @MockitoBean
     private S3Manager s3Manager;
+    @MockitoBean
+    private NotificationEventProducer notificationEventProducer;
 
     // 테스트 데이터 생성 헬퍼
     private void createTestUsers() {
@@ -111,6 +115,7 @@ class UserServiceTest {
     void updateRole_Success() {
         //given
         User me = userRepository.save(new User("me", "me@test.com", "pw"));
+        Role oldRole = me.getRole();  // 기존 role 저장(USER 권한)
 
         //when
         userService.updateRole(me.getId(), Role.ADMIN);
@@ -118,6 +123,15 @@ class UserServiceTest {
         //then
         User updated = userRepository.findById(me.getId()).orElseThrow();
         assertThat(updated.getRole()).isEqualTo(Role.ADMIN);
+
+        // Kafka 이벤트 발행 검증 - 정확한 파라미터 확인
+        verify(notificationEventProducer, times(1))
+                .send(
+                        eq(me.getId()),
+                        eq(NotificationType.ROLE_UPDATED),
+                        eq(oldRole.name()),      // 이전 role
+                        eq(Role.ADMIN.name())    // 새 role
+                );
     }
 
     @Test

--- a/mopl-api/src/test/java/com/mopl/domain/user/service/UserServiceTest.java
+++ b/mopl-api/src/test/java/com/mopl/domain/user/service/UserServiceTest.java
@@ -35,10 +35,14 @@ import static org.mockito.Mockito.*;
 @ActiveProfiles("test")
 class UserServiceTest {
 
-    @Autowired UserService userService;
-    @Autowired UserRepository userRepository;
-    @Autowired PasswordEncoder passwordEncoder;
-    @MockitoBean private S3Manager s3Manager;
+    @Autowired
+    UserService userService;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    PasswordEncoder passwordEncoder;
+    @MockitoBean
+    private S3Manager s3Manager;
 
     // 테스트 데이터 생성 헬퍼
     private void createTestUsers() {
@@ -57,9 +61,9 @@ class UserServiceTest {
 
     @Test
     @DisplayName("성공: 사용자 생성 시 DB에 저장되고 암호화된 비밀번호를 가진다")
-    void createUser_Success () {
+    void createUser_Success() {
         // given
-        UserCreateRequest request = new UserCreateRequest("사용자1","email@com.com", "password1234");
+        UserCreateRequest request = new UserCreateRequest("사용자1", "email@com.com", "password1234");
 
         // when
         UserDto result = userService.createUser(request);
@@ -104,7 +108,7 @@ class UserServiceTest {
 
     @Test
     @DisplayName("성공: 사용자의 권한을 변경 한다(admin 계정 확인은 컨트롤러)")
-    void updateRole_Success () {
+    void updateRole_Success() {
         //given
         User me = userRepository.save(new User("me", "me@test.com", "pw"));
 
@@ -129,7 +133,7 @@ class UserServiceTest {
 
     @Test
     @DisplayName("locked 상태 변경 전후 확인")
-    void updateLocked_Success () {
+    void updateLocked_Success() {
         //given
         User me = userRepository.save(new User("me", "me@test.com", "pw"));
         assertThat(me.getLocked()).isFalse();
@@ -155,7 +159,7 @@ class UserServiceTest {
 
     @Test
     @DisplayName("성공: 사용자의 비밀번호를 변경한다")
-    void updatePassword_Success () {
+    void updatePassword_Success() {
         //given
         User user = userRepository.save(new User("me", "me@test.com", "oldpw"));
         String newPassword = "newPassword123";
@@ -236,6 +240,7 @@ class UserServiceTest {
         // S3 호출 안됨
         verify(s3Manager, never()).upload(any(), any());
     }
+
     @Test
     @DisplayName("성공: 검색 조건 없이 전체 사용자 조회(다음 페이지 있음)")
     void findAllUsers_NoCondition() {
@@ -268,8 +273,6 @@ class UserServiceTest {
         assertThat(result.data().get(1).name()).isEqualTo("Iris");
         assertThat(result.data().get(2).name()).isEqualTo("Henry");
     }
-
-
 
 
 }

--- a/mopl-api/src/test/java/com/mopl/domain/user/service/UserServiceTest.java
+++ b/mopl-api/src/test/java/com/mopl/domain/user/service/UserServiceTest.java
@@ -2,21 +2,33 @@ package com.mopl.domain.user.service;
 
 import com.mopl.domain.user.dto.UserCreateRequest;
 import com.mopl.domain.user.dto.UserDto;
+import com.mopl.domain.user.dto.UserSearchCondition;
 import com.mopl.domain.user.entity.User;
+import com.mopl.domain.user.enums.Role;
 import com.mopl.domain.user.exception.UserException;
 import com.mopl.domain.user.repository.UserRepository;
-import com.mopl.global.redis.RedisManager;
+import com.mopl.global.dto.PageResponse;
+import com.mopl.global.dto.UploadFileRequest;
+import com.mopl.global.enums.SortBy;
+import com.mopl.global.enums.SortDirection;
+import com.mopl.global.s3.FileCategory;
 import com.mopl.global.s3.S3Manager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 @SpringBootTest
 @Transactional
@@ -26,8 +38,21 @@ class UserServiceTest {
     @Autowired UserService userService;
     @Autowired UserRepository userRepository;
     @Autowired PasswordEncoder passwordEncoder;
-    @Autowired S3Manager s3Manager;      // 실제 빈 사용 - 수정 예정
-    @Autowired RedisManager redisManager;  // 실제 빈 사용
+    @MockitoBean private S3Manager s3Manager;
+
+    // 테스트 데이터 생성 헬퍼
+    private void createTestUsers() {
+        userRepository.save(new User("Alice", "alice@test.com", "pw"));
+        userRepository.save(new User("Bob", "bob@test.com", "pw"));
+        userRepository.save(new User("Charlie", "charlie@test.com", "pw"));
+        userRepository.save(new User("David", "david@test.com", "pw"));
+        userRepository.save(new User("Eve", "eve@test.com", "pw"));
+        userRepository.save(new User("Frank", "frank@test.com", "pw"));
+        userRepository.save(new User("Grace", "grace@test.com", "pw"));
+        userRepository.save(new User("Henry", "henry@test.com", "pw"));
+        userRepository.save(new User("Iris", "iris@test.com", "pw"));
+        userRepository.save(new User("Jack", "jack@test.com", "pw"));
+    }
 
 
     @Test
@@ -76,6 +101,174 @@ class UserServiceTest {
                 userService.createUser(duplicateRequest)
         ).isInstanceOf(UserException.class);
     }
+
+    @Test
+    @DisplayName("성공: 사용자의 권한을 변경 한다(admin 계정 확인은 컨트롤러)")
+    void updateRole_Success () {
+        //given
+        User me = userRepository.save(new User("me", "me@test.com", "pw"));
+
+        //when
+        userService.updateRole(me.getId(), Role.ADMIN);
+
+        //then
+        User updated = userRepository.findById(me.getId()).orElseThrow();
+        assertThat(updated.getRole()).isEqualTo(Role.ADMIN);
+    }
+
+    @Test
+    @DisplayName("실패: 권한을 변경할 사용자의 존재하지 않는 ID")
+    void updateRole_Fail() {
+        //given
+        Long nonExistentId = 999L;  // ← DB에 없는 ID
+
+        //when & then
+        assertThrows(UserException.class,
+                () -> userService.updateRole(nonExistentId, Role.ADMIN));
+    }
+
+    @Test
+    @DisplayName("locked 상태 변경 전후 확인")
+    void updateLocked_Success () {
+        //given
+        User me = userRepository.save(new User("me", "me@test.com", "pw"));
+        assertThat(me.getLocked()).isFalse();
+
+        //when
+        userService.updateLocked(me.getId(), true);
+
+        //then
+        User updated = userRepository.findById(me.getId()).orElseThrow();
+        assertThat(updated.getLocked()).isTrue();
+    }
+
+    @Test
+    @DisplayName("실패: 존재하지 않는 사용자 ID")
+    void updateLocked_Fail() {
+        //given
+        Long nonExistentId = 999L;  // ← DB에 없는 ID
+
+        //when & then
+        assertThrows(UserException.class,
+                () -> userService.updateLocked(nonExistentId, true));
+    }
+
+    @Test
+    @DisplayName("성공: 사용자의 비밀번호를 변경한다")
+    void updatePassword_Success () {
+        //given
+        User user = userRepository.save(new User("me", "me@test.com", "oldpw"));
+        String newPassword = "newPassword123";
+
+        //when
+        userService.updatePassword(user.getId(), newPassword);
+
+        //then
+        User updated = userRepository.findById(user.getId()).orElseThrow();
+        assertThat(updated.getPassword()).isNotEqualTo(newPassword);
+        assertThat(passwordEncoder.matches(newPassword, updated.getPassword())).isTrue();
+    }
+
+    @Test
+    @DisplayName("성공: 이름과 이미지를 모두 업데이트한다")
+    void updateImage_NameAndImage() throws Exception {
+        //given
+        User user = userRepository.save(new User("oldName", "test@test.com", "pw"));
+        Long userId = user.getId();
+
+        // Mock 이미지 파일 생성
+        MockMultipartFile mockImage = new MockMultipartFile(
+                "image",                          // 파라미터 이름
+                "profile.jpg",                    // 원본 파일명
+                "image/jpeg",                     // Content-Type
+                "test image content".getBytes()   // 파일 내용
+        );
+
+        // S3 Mock 동작 설정
+        String newImageUrl = "https://s3.amazonaws.com/bucket/new-profile.jpg";
+        when(s3Manager.upload(any(UploadFileRequest.class), eq(FileCategory.PROFILE_IMAGE)))
+                .thenReturn(newImageUrl);
+
+        String presignedUrl = "https://s3.amazonaws.com/bucket/new-profile.jpg?presigned=xyz";
+        when(s3Manager.generatePresignedUrl(newImageUrl))
+                .thenReturn(presignedUrl);
+
+        //when
+        UserDto result = userService.updateImage(userId, "newName", mockImage);
+
+        //then
+        // 1. DB 확인
+        User updated = userRepository.findById(userId).orElseThrow();
+        assertThat(updated.getName()).isEqualTo("newName");
+        assertThat(updated.getProfileImageUrl()).isEqualTo(newImageUrl);
+
+        // 2. S3 호출 확인
+        verify(s3Manager).upload(any(UploadFileRequest.class), eq(FileCategory.PROFILE_IMAGE));
+        verify(s3Manager).generatePresignedUrl(newImageUrl);
+
+        // 3. 반환값 확인
+        assertThat(result).isNotNull();
+        assertThat(result.name()).isEqualTo("newName");
+        assertThat(result.profileImageUrl()).isEqualTo(presignedUrl);
+    }
+
+    @Test
+    @DisplayName("실패: 빈 이미지 파일은 무시됨")
+    void updateImage_EmptyImage() {
+        //given
+        User user = userRepository.save(new User("oldName", "test@test.com", "pw"));
+
+        MockMultipartFile emptyImage = new MockMultipartFile(
+                "image",
+                "empty.jpg",
+                "image/jpeg",
+                new byte[0]  // 빈 파일
+        );
+
+        //when
+        UserDto result = userService.updateImage(user.getId(), "newName", emptyImage);
+
+        //then
+        User updated = userRepository.findById(user.getId()).orElseThrow();
+        assertThat(updated.getName()).isEqualTo("newName");  // 이름만 변경
+        assertThat(updated.getProfileImageUrl()).isNull();  // 이미지 변경 안됨
+
+        // S3 호출 안됨
+        verify(s3Manager, never()).upload(any(), any());
+    }
+    @Test
+    @DisplayName("성공: 검색 조건 없이 전체 사용자 조회(다음 페이지 있음)")
+    void findAllUsers_NoCondition() {
+        //given
+        createTestUsers();  // 10명 생성
+
+        UserSearchCondition condition = new UserSearchCondition(
+                null,  // emailLike
+                null,  // roleEqual
+                null,  // isLocked
+                null,  // cursor
+                null,  // idAfter
+                5,    // limit
+                SortDirection.DESCENDING, //default
+                SortBy.name //default
+        );
+
+        //when
+        PageResponse<UserDto> result = userService.findAllUsers(condition);
+
+        //then
+        assertThat(result.data()).hasSize(5);
+        assertThat(result.hasNext()).isTrue();  // limit(5) < 데이터(10)
+        assertThat(result.nextCursor()).isNotNull();
+        assertThat(result.nextIdAfter()).isNotNull();
+        assertThat(result.totalCount()).isEqualTo(6);
+
+        // ✅ 추가: 정렬 순서 확인
+        assertThat(result.data().get(0).name()).isEqualTo("Jack");  // DESC: C > B > A
+        assertThat(result.data().get(1).name()).isEqualTo("Iris");
+        assertThat(result.data().get(2).name()).isEqualTo("Henry");
+    }
+
 
 
 

--- a/mopl-api/src/test/java/com/mopl/domain/user/service/UserServiceTest.java
+++ b/mopl-api/src/test/java/com/mopl/domain/user/service/UserServiceTest.java
@@ -1,0 +1,82 @@
+package com.mopl.domain.user.service;
+
+import com.mopl.domain.user.dto.UserCreateRequest;
+import com.mopl.domain.user.dto.UserDto;
+import com.mopl.domain.user.entity.User;
+import com.mopl.domain.user.exception.UserException;
+import com.mopl.domain.user.repository.UserRepository;
+import com.mopl.global.redis.RedisManager;
+import com.mopl.global.s3.S3Manager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class UserServiceTest {
+
+    @Autowired UserService userService;
+    @Autowired UserRepository userRepository;
+    @Autowired PasswordEncoder passwordEncoder;
+    @Autowired S3Manager s3Manager;      // 실제 빈 사용 - 수정 예정
+    @Autowired RedisManager redisManager;  // 실제 빈 사용
+
+
+    @Test
+    @DisplayName("성공: 사용자 생성 시 DB에 저장되고 암호화된 비밀번호를 가진다")
+    void createUser_Success () {
+        // given
+        UserCreateRequest request = new UserCreateRequest("사용자1","email@com.com", "password1234");
+
+        // when
+        UserDto result = userService.createUser(request);
+
+        // then
+        // 반환값 검증
+        assertThat(result).isNotNull();
+        assertThat(result.id()).isNotNull();  // ID가 생성되었는지
+        assertThat(result.name()).isEqualTo("사용자1");
+        assertThat(result.email()).isEqualTo("email@com.com");
+
+        // 실제 DB 저장 확인
+        User savedUser = userRepository.findById(result.id()).orElseThrow();
+        assertThat(savedUser.getName()).isEqualTo("사용자1");
+        assertThat(savedUser.getEmail()).isEqualTo("email@com.com");
+
+        //비밀번호 암호화 확인
+        assertThat(savedUser.getPassword()).isNotEqualTo("password1234");  // 암호화됨
+        assertThat(savedUser.getPassword()).startsWith("$2a$");  // bcrypt 형식
+
+    }
+
+    @Test
+    @DisplayName("실패: 중복 이메일로 가입 시 예외 발생")
+    void createUser_Fail_DuplicateEmail() {
+        // given
+        userService.createUser(
+                new UserCreateRequest("사용자1", "dup@test.com", "pw1234")
+        );
+
+        // when & then
+        UserCreateRequest duplicateRequest = new UserCreateRequest(
+                "사용자2",
+                "dup@test.com",  // 같은 이메일
+                "pw5678"
+        );
+
+        assertThatThrownBy(() ->
+                userService.createUser(duplicateRequest)
+        ).isInstanceOf(UserException.class);
+    }
+
+
+
+}


### PR DESCRIPTION
## 연관 이슈
close #215 

## 🔄 변경 사항
성공 : 유저 생성
실패 : 유저 생성 - 중복이메일
성공 : 사용자 권한 변경
실패 : 사용자 권한 변경 - 존재 X
성공 : 사용자 잠금 상태 변경
실패 : 사용자 잠금 상태 변경 - 존재 X
성공 : 비밀번호 변경
성공 : 사용자 프로필 사진 변경
실패 : 사용자 프로필 사진 변경 - 빈 이미지
성공 : 사용자 목록 조회 커서 0

## 🧩 작업 사항
작업한 내용을 간략하게 설명해주세요.
- UserService 테스트 코드 추가 
- s3, NotificationEventProducer는 @MockitoBean으로 선언으로 가볍게 돌아가도록 함 

## 📸 스크린샷
<img width="1261" height="451" alt="image" src="https://github.com/user-attachments/assets/008fb8df-75d4-496b-afb4-b3ee6177b51f" />
