### PR TITLE
[fix] 웹소켓 설정의 allowOrigins에 mopl.shop 도메인 추가

### DIFF
--- a/mopl-chat/src/main/java/com/mopl/global/config/WebSocketConfig.java
+++ b/mopl-chat/src/main/java/com/mopl/global/config/WebSocketConfig.java
@@ -23,7 +23,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
             .setAllowedOrigins(
                     "http://localhost:3000",
                     "http://localhost:8080",
-                    "https://d1oe57b4vms6oj.cloudfront.net") // TODO application.yml에 옮기기
+                    "https://d1oe57b4vms6oj.cloudfront.net",
+                    "https://mopl.shop") // TODO application.yml에 옮기기
             .withSockJS(); // SockJS 지원 (웹소켓 미지원 브라우저 대응)
     }
 


### PR DESCRIPTION
## 🧩 작업 사항
- 웹소켓 설정의 allowOrigins에 mopl.shop 도메인 추가