### PR TITLE
[FIX] mopl-batch 컨테이너 실행 방식 개선

### DIFF
--- a/mopl-batch/Dockerfile
+++ b/mopl-batch/Dockerfile
@@ -37,4 +37,4 @@ COPY --from=builder /build/mopl-batch/build/libs/*-SNAPSHOT.jar app.jar
 
 EXPOSE 8081
 
-ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION


## 🔄 변경 사항
- mopl-batch Dockerfile의 ENTRYPOINT 실행 방식을 수정

## 🧩 작업 사항

- sh -c 기반 ENTRYPOINT 제거

- Java 프로세스를 직접 실행하도록 변경하여

- 불필요한 쉘 프로세스 제거

- 컨테이너 종료 및 시그널 처리 방식 단순화

## 🎯 변경 의도

- 배치 컨테이너는 작업 수행 후 종료되는 구조이므로
- 단순하고 명확한 실행 방식이 적합하다고 판단

- ECS / Fargate 환경에서 프로세스 관리 안정성 개선

