### PR TITLE
[feat] 실시간 콘텐츠 채팅 참여자 세션 및 카운트 기능 구현

### DIFF
--- a/mopl-api/src/main/java/com/mopl/domain/content/dto/ContentDto.java
+++ b/mopl-api/src/main/java/com/mopl/domain/content/dto/ContentDto.java
@@ -13,6 +13,6 @@ public record ContentDto(
     List<String> tags,
     double averageRating,
     int reviewCount,
-    int watchCount
+    int watcherCount
 ) {
 }

--- a/mopl-api/src/main/java/com/mopl/domain/content/service/ContentService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/content/service/ContentService.java
@@ -176,9 +176,7 @@ public class ContentService {
     }
 
     private int getWatchCount(Long contentId) {
-        return redisManager
-                .findByKey(RedisNameSpace.WATCHER_COUNT, contentId.toString(), Integer.class)
-                .orElse(0);
+        return (int) redisManager.getSetSize(RedisNameSpace.CONTENT_SESSIONS, String.valueOf(contentId));
     }
 
     /** Dto 변환 */

--- a/mopl-api/src/main/java/com/mopl/domain/watching/controller/WatchingSessionController.java
+++ b/mopl-api/src/main/java/com/mopl/domain/watching/controller/WatchingSessionController.java
@@ -7,16 +7,21 @@ import com.mopl.domain.watching.service.WatchingSessionService;
 import com.mopl.global.enums.SortDirection;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class WatchingSessionController implements WatchingSessionControllerDocs {
 
     private final WatchingSessionService watchingSessionService;
 
     @Override
-    public ResponseEntity<WatchingSessionUserResponse> getWatchingSession(Long watcherId) {
+    @GetMapping("/users/{watcherId}/watching-sessions")
+    public ResponseEntity<WatchingSessionUserResponse> getWatchingSession(@PathVariable Long watcherId) {
         WatchingSessionUserResponse response = watchingSessionService.getWatchingSession(watcherId);
 
         // 시청 중인 세션이 없을 경우 204 No Content 반환
@@ -28,8 +33,9 @@ public class WatchingSessionController implements WatchingSessionControllerDocs 
     }
 
     @Override
+    @GetMapping("/contents/{contentId}/watching-sessions")
     public ResponseEntity<WatchingSessionContentListResponse> getWatchingSessionsByContent(
-            Long contentId,
+            @PathVariable Long contentId,
             String watcherNameLike,
             String cursor,
             Long idAfter,

--- a/mopl-api/src/main/java/com/mopl/domain/watching/service/WatchingSessionService.java
+++ b/mopl-api/src/main/java/com/mopl/domain/watching/service/WatchingSessionService.java
@@ -13,12 +13,15 @@ import com.mopl.domain.watching.exception.WatchingErrorCode;
 import com.mopl.domain.watching.exception.WatchingException;
 import com.mopl.domain.watching.repository.WatchingSessionRepository;
 import com.mopl.global.enums.SortDirection;
+import com.mopl.global.s3.S3Manager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.*;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -29,6 +32,7 @@ public class WatchingSessionService {
     private final WatchingSessionRepository watchingSessionRepository;
     private final UserRepository userRepository;
     private final ContentRepository contentRepository;
+    private final S3Manager s3Manager;
 
     /**
      * 특정 사용자의 시청 세션 단건 조회
@@ -150,7 +154,7 @@ public class WatchingSessionService {
         UserSummaryDto watcherDto = new UserSummaryDto(
                 user.getId(),
                 user.getName(),
-                user.getProfileImageUrl()
+                s3Manager.generatePresignedUrl(user.getProfileImageUrl())
         );
 
         // Fetch Join 덕분에 추가 쿼리 없이 태그 리스트 생성 가능

--- a/mopl-chat/src/main/java/com/mopl/domain/directmessage/event/DmWebSocketEventListener.java
+++ b/mopl-chat/src/main/java/com/mopl/domain/directmessage/event/DmWebSocketEventListener.java
@@ -16,7 +16,7 @@ import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class WebSocketEventLister {
+public class DmWebSocketEventListener {
 
     private final String CONVERSATION_PREFIX = "/conversations/";
     private final String CURRENT_ROOM_ID = "currentRoomId";

--- a/mopl-chat/src/main/java/com/mopl/domain/watching/event/WatchingWebSocketEventListener.java
+++ b/mopl-chat/src/main/java/com/mopl/domain/watching/event/WatchingWebSocketEventListener.java
@@ -1,0 +1,108 @@
+package com.mopl.domain.watching.event;
+
+import com.mopl.domain.auth.dto.UserPrincipal;
+import com.mopl.domain.watching.service.WatchingPresenceService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WatchingWebSocketEventListener {
+
+    private static final String WATCHING_PREFIX = "/contents/";
+    private static final String KEY_CURRENT_CONTENT_ID = "current_content_id";
+
+    private final WatchingPresenceService watchingPresenceService;
+
+    // 사용자가 콘텐츠에 입장할 때
+    @EventListener
+    public void handleSubscribeEvent(SessionSubscribeEvent event) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+        String destination = headerAccessor.getDestination(); // SUBSCRIBE /sub/contents/{contentId}/watch
+
+        if (destination == null || !destination.contains(WATCHING_PREFIX)) {
+            return;
+        }
+
+        String sessionId = headerAccessor.getSessionId();
+        Long userId = extractUserId(headerAccessor);
+        Long contentId = extractContentId(destination);
+
+        // 메모리에 세션 매핑 저장 - 콘텐츠 나갈 때 제거하기 위해
+        if (sessionId != null && contentId != null && headerAccessor.getSessionAttributes() != null) {
+            headerAccessor.getSessionAttributes().put(KEY_CURRENT_CONTENT_ID, contentId);
+
+            watchingPresenceService.joinContent(userId, contentId);
+        }
+    }
+
+    // 사용자가 콘텐츠를 나감
+    @EventListener
+    public void handleUnsubscribeEvent(SessionUnsubscribeEvent event) {
+        handleLeave(event.getMessage());
+    }
+
+    // 사용자가 앱을 나감
+    @EventListener
+    public void handleDisconnectEvent(SessionDisconnectEvent event) {
+        handleLeave(event.getMessage());
+    }
+
+    private void handleLeave(Message<byte[]> message) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(message);
+
+        Long contentId = null;
+        Map<String, Object> sessionAttributes = headerAccessor.getSessionAttributes();
+        if (sessionAttributes != null) {
+            contentId = (Long) sessionAttributes.get(KEY_CURRENT_CONTENT_ID);
+        }
+
+        Long userId = extractUserId(headerAccessor);
+
+        if (contentId != null && userId != null) {
+            watchingPresenceService.leaveContent(userId, contentId);
+
+            sessionAttributes.remove(KEY_CURRENT_CONTENT_ID);
+        }
+    }
+
+    private Long extractUserId(StompHeaderAccessor headerAccessor) {
+        try {
+            if (headerAccessor.getUser() instanceof Authentication authentication) {
+                Object principal = authentication.getPrincipal();
+                if (principal instanceof UserPrincipal userPrincipal) {
+                    return userPrincipal.userId();
+                }
+            }
+        } catch (Exception e) {
+            log.error("WebSocket userId 추출 실패", e);
+        }
+        return null;
+    }
+
+    private Long extractContentId(String destination) {
+        try {
+            String[] parts = destination.split("/");
+
+            for (int i = 0; i < parts.length; i++) {
+                if ("contents".equals(parts[i]) && i + 1 < parts.length) {
+                    return Long.parseLong(parts[i + 1]);
+                }
+            }
+        } catch (Exception e) {
+            log.error("WebSocket contentId 추출 실패: {}", destination);
+        }
+        return null;
+    }
+}

--- a/mopl-chat/src/main/java/com/mopl/domain/watching/service/WatchingPresenceService.java
+++ b/mopl-chat/src/main/java/com/mopl/domain/watching/service/WatchingPresenceService.java
@@ -1,0 +1,90 @@
+package com.mopl.domain.watching.service;
+
+import com.mopl.domain.user.dto.response.UserSummaryDto;
+import com.mopl.domain.user.entity.User;
+import com.mopl.domain.user.repository.UserRepository;
+import com.mopl.domain.watching.dto.WatchingSessionChange;
+import com.mopl.domain.watching.dto.response.ContentPayload;
+import com.mopl.domain.watching.dto.response.WatchingSessionEventPayload;
+import com.mopl.domain.watching.entity.WatchingSession;
+import com.mopl.domain.watching.enums.ChangeType;
+import com.mopl.domain.watching.repository.WatchingSessionRepository;
+import com.mopl.global.exception.ErrorCode;
+import com.mopl.global.exception.MoplException;
+import com.mopl.global.redis.RedisManager;
+import com.mopl.global.redis.RedisNameSpace;
+import com.mopl.global.s3.S3Manager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WatchingPresenceService {
+
+    private final UserRepository userRepository;
+    private final WatchingSessionRepository watchingSessionRepository;
+    private final RedisManager redisManager;
+    private final SimpMessagingTemplate messagingTemplate;
+    private final S3Manager s3Manager;
+
+    public void joinContent(Long userId, Long contentId) {
+        String userIdStr = String.valueOf(userId);
+        String contentIdStr = String.valueOf(contentId);
+
+        WatchingSession watchingSession = WatchingSession.builder()
+                .id(userId)
+                .contentId(contentId)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        watchingSessionRepository.save(watchingSession);
+
+        redisManager.addSetElement(RedisNameSpace.CONTENT_SESSIONS, contentIdStr, userIdStr);
+
+        broadcast(userId, contentId, ChangeType.JOIN);
+    }
+
+    public void leaveContent(Long userId, Long contentId) {
+        String userIdStr = String.valueOf(userId);
+        String contentIdStr = String.valueOf(contentId);
+
+        watchingSessionRepository.deleteById(userId);
+        redisManager.removeSetElement(RedisNameSpace.CONTENT_SESSIONS, contentIdStr, userIdStr);
+
+        broadcast(userId, contentId, ChangeType.LEAVE);
+    }
+
+    private void broadcast(Long userId, Long contentId, ChangeType changeType) {
+        long currentCount = redisManager.getSetSize(RedisNameSpace.CONTENT_SESSIONS, String.valueOf(contentId));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new MoplException(ErrorCode.NOT_FOUND));
+        String profileUrl = s3Manager.generatePresignedUrl(user.getProfileImageUrl());
+
+        WatchingSessionEventPayload payload = WatchingSessionEventPayload.builder()
+                .id(userId)
+                .createdAt(LocalDateTime.now())
+                .watcher(new UserSummaryDto(
+                        userId,
+                        user.getName(),
+                        profileUrl
+                ))
+                .content(ContentPayload.builder()
+                        .id(String.valueOf(contentId))
+                        .build())
+                .build();
+
+        WatchingSessionChange message = new WatchingSessionChange(changeType, payload, currentCount);
+
+        // 해당 콘텐츠 접속 중인 유저들에게 전송
+        String destination = "/sub/contents/" + contentId + "/watch";
+        messagingTemplate.convertAndSend(destination, message);
+
+        log.info("전송 {}: 유저 {}가 콘텐츠{}에 입장 (Total: {})", changeType, userId, contentId, currentCount);
+    }
+}

--- a/mopl-core/src/main/java/com/mopl/domain/watching/dto/WatchingSessionChange.java
+++ b/mopl-core/src/main/java/com/mopl/domain/watching/dto/WatchingSessionChange.java
@@ -1,0 +1,11 @@
+package com.mopl.domain.watching.dto;
+
+import com.mopl.domain.watching.dto.response.WatchingSessionEventPayload;
+import com.mopl.domain.watching.enums.ChangeType;
+
+public record WatchingSessionChange(
+        ChangeType type,
+        WatchingSessionEventPayload watchingSession,
+        long watcherCount
+) {
+}

--- a/mopl-core/src/main/java/com/mopl/domain/watching/dto/response/ContentPayload.java
+++ b/mopl-core/src/main/java/com/mopl/domain/watching/dto/response/ContentPayload.java
@@ -1,0 +1,31 @@
+package com.mopl.domain.watching.dto.response;
+
+import com.mopl.domain.content.enums.ContentType;
+import lombok.Builder;
+
+import java.util.Collections;
+import java.util.List;
+
+public record ContentPayload(
+        String id,
+        ContentType type,
+        String title,
+        String description,
+        String thumbnailUrl,
+        List<String> tags,
+        double averageRating,
+        int reviewCount,
+        int watcherCount
+) {
+    @Builder
+    public ContentPayload {
+        type = null;
+        title = "";
+        description = "";
+        thumbnailUrl = "";
+        tags = Collections.emptyList();
+        averageRating = 0.0;
+        reviewCount = 0;
+        watcherCount = 0;
+    }
+}

--- a/mopl-core/src/main/java/com/mopl/domain/watching/dto/response/WatchingSessionEventPayload.java
+++ b/mopl-core/src/main/java/com/mopl/domain/watching/dto/response/WatchingSessionEventPayload.java
@@ -1,0 +1,15 @@
+package com.mopl.domain.watching.dto.response;
+
+import com.mopl.domain.user.dto.response.UserSummaryDto;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record WatchingSessionEventPayload(
+        Long id, // userId
+        LocalDateTime createdAt,
+        UserSummaryDto watcher, // 전부 필요
+        ContentPayload content // id만
+){
+}

--- a/mopl-core/src/main/java/com/mopl/domain/watching/enums/ChangeType.java
+++ b/mopl-core/src/main/java/com/mopl/domain/watching/enums/ChangeType.java
@@ -1,0 +1,5 @@
+package com.mopl.domain.watching.enums;
+
+public enum ChangeType {
+    JOIN, LEAVE
+}

--- a/mopl-core/src/main/java/com/mopl/global/redis/RedisConfig.java
+++ b/mopl-core/src/main/java/com/mopl/global/redis/RedisConfig.java
@@ -6,11 +6,13 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.GenericJacksonJsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import tools.jackson.databind.ObjectMapper;
 
 @Configuration
+@EnableRedisRepositories(basePackages = "com.mopl.domain.watching.repository")
 public class RedisConfig {
 
     @Value("${spring.data.redis.host}")

--- a/mopl-core/src/main/java/com/mopl/global/redis/RedisManager.java
+++ b/mopl-core/src/main/java/com/mopl/global/redis/RedisManager.java
@@ -25,14 +25,15 @@ public class RedisManager {
         String key = namespace.createKey(identifier);
         Object value = redisTemplate.opsForValue().get(key);
 
-        if(value == null) return Optional.empty();
+        if (value == null) return Optional.empty();
 
         try {
             return Optional.of(clazz.cast(value));
         } catch (ClassCastException e) {
             log.error("Redis 타입 불일치 발생 - Key: {}, 예상 타입: {}, 실제 데이터 타입: {}",
                     key, clazz.getSimpleName(), value.getClass().getSimpleName());
-            return Optional.empty();}
+            return Optional.empty();
+        }
     }
 
     /** 데이터 삭제 */
@@ -61,5 +62,11 @@ public class RedisManager {
     public boolean isMember(RedisNameSpace nameSpace, String identifier, Object value) {
         String key = nameSpace.createKey(identifier);
         return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(key, value));
+    }
+
+    public long getSetSize(RedisNameSpace nameSpace, String identifier) {
+        String key = nameSpace.createKey(identifier);
+        Long size = redisTemplate.opsForSet().size(key);
+        return size != null ? size : 0;
     }
 }

--- a/mopl-core/src/main/java/com/mopl/global/redis/RedisNameSpace.java
+++ b/mopl-core/src/main/java/com/mopl/global/redis/RedisNameSpace.java
@@ -14,15 +14,11 @@ public enum RedisNameSpace {
     // 임시 비밀번호
     TEMP_PASSWORD("temp-password:", Duration.ofMinutes(3), true),
 
-    // 실시간 시청자 수
-    WATCHER_COUNT("watcher:", Duration.ofHours(1), false),
-
     // DM 채팅방 접속자 명단 Set
     DM_VIEWERS("dm-chat:viewer:", Duration.ofHours(2), true),
 
     // 세션용
-    CONTENT_SESSIONS("content:sessions:", Duration.ofHours(1), true),
-    WATCHING_SESSION("watching_session:", Duration.ofHours(1), true);
+    CONTENT_SESSIONS("content:sessions:", Duration.ofHours(1), true);
 
     private final String prefix;
     private final Duration ttl;


### PR DESCRIPTION
## 연관 이슈
close #206 

## 🔄 변경 사항
- 시청 세션 조회 API 엔드 포인트 매핑 추가
- 기존 웹소켓 이벤트 리스너를 Dm 전용으로 분리 
- `ContentDto` 필드명 수정 (`watchCount` -> `watcherCount`)
- `WatchingSessionService`: 프로필 이미지 Presigned URL 적용


## 🧩 작업 사항
### 1. Redis 구조 개선
- **Core 모듈:** `RedisManager`에 실시간 채팅 참여자 수 조회용 `getSetSize()` 메서드 추가
- `Redis Hash`: 유저가 현재 어떤 콘텐츠를 보고 있는지 객체로 저장 (`WatchingSession`)
- `Redis Set`: 특정 콘텐츠에 들어와 있는 유저 id 목록 및 실시간 참여자 카운트 관리

### 2. Chat 모듈 (WebSocket)
- **`WatchingWebSocketEventListener`**: 
  - 사용자가 `/sub/contents/{id}/watch`를 구독하면 입장
  - 입, 퇴장 감지해 서비스 로직 호출
- **`WatchingPresenceService`**: 
  - Redis로 시청 세션 정보 핸들링 및 `WatchingSessionChange`를 해당 콘텐츠의 모든 유저에게 전송

### 3. 리팩토링 및 최적화
- **DTO 수정:**
  - `ContentDto`의 `watchCount`를 프론트엔드 규격에 맞춰 `watcherCount`로 수정
  - 실시간 채팅 참여자 목록 조회 시 프로필 이미지를 S3 Presigned URL로 변환해 반환하도록 수정
- **Payload 최적화:** 실시간 메시지 전송 시 이미 클라이언트가 알고 있는 콘텐츠 상세 정보(제목, 설명 등)는 빈 값으로 보냄 (네트워크 트래픽 절약)